### PR TITLE
Fixed serilization issue of list() and deletion of folder in Android

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -131,6 +131,20 @@ public class CapacitorUpdater {
         return true;
     }
 
+    private void deleteDirectory(File file) throws IOException {
+        if (file.isDirectory()) {
+            File[] entries = file.listFiles();
+            if (entries != null) {
+                for (File entry : entries) {
+                    deleteDirectory(entry);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new IOException("Failed to delete " + file);
+        }
+    }
+
     public String download(String url) {
         Log.i("CapacitorUpdater", "URL: " + url);
         try {
@@ -147,7 +161,7 @@ public class CapacitorUpdater {
             this.flattenAssets(folderNameUnZip, folderName);
             return version;
         } catch (Exception e) {
-            Log.e("TAG", "updateApp error", e);
+            Log.e(TAG, "updateApp error", e);
             return null;
         }
     }
@@ -166,14 +180,14 @@ public class CapacitorUpdater {
         return res;
     }
 
-    public Boolean delete(String version) {
+    public Boolean delete(String version) throws IOException {
         File destHot = new File(this.context.getFilesDir()  + "/" + basePathHot + "/" + version);
         Log.i(TAG, "delete File : " + destHot.getPath());
         if (destHot.exists()) {
-            destHot.delete();
+            deleteDirectory(destHot);
             return true;
         }
-        Log.i(TAG, "File not removed.");
+        Log.i(TAG, "Directory not removed.");
         return false;
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -2,12 +2,14 @@ package ee.forgr.capacitor_updater;
 
 import android.util.Log;
 
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 @CapacitorPlugin(name = "CapacitorUpdater")
@@ -53,12 +55,17 @@ public class CapacitorUpdaterPlugin extends Plugin {
     @PluginMethod
     public void delete(PluginCall call) {
         String version = call.getString("version");
-        Boolean res = implementation.delete(version);
+        try {
+            Boolean res = implementation.delete(version);
 
-        if (res) {
-            call.resolve();
-        } else {
-            call.reject("Delete failed, version don't exist");
+            if (res) {
+                call.resolve();
+            } else {
+                call.reject("Delete failed, version don't exist");
+            }
+        } catch(IOException ex) {
+            Log.e("CapacitorUpdater", "An unexpected error occurred during deletion of folder. Message: " + ex.getMessage());
+            call.reject("An unexpected error occurred during deletion of folder.");
         }
     }
 
@@ -66,7 +73,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     public void list(PluginCall call) {
         ArrayList<String> res = implementation.list();
         JSObject ret = new JSObject();
-        ret.put("versions", res);
+        ret.put("versions", new JSArray(res));
         call.resolve(ret);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-updater",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "license": "AGPL-3.0-only",
   "description": "Download app update from url",
   "main": "dist/plugin.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-updater",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "AGPL-3.0-only",
   "description": "Download app update from url",
   "main": "dist/plugin.cjs.js",


### PR DESCRIPTION
This fixes the issue #5 and also an issue that the delete method did not delete the folders in Android. The original implementation of the delete would only delete the folder if the folder is empty. Now the folder gets recursivly deleted.