### PR TITLE
Fix: list() returning full filepath

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -182,7 +182,7 @@ public class CapacitorUpdater {
         Log.i(TAG, "list File : " + destHot.getPath());
         if (destHot.exists()) {
             for (File i : destHot.listFiles()) {
-                res.add(i.getPath());
+                res.add(i.getName());
             }
         } else {
             Log.i(TAG, "NO version available" + destHot);


### PR DESCRIPTION
`list()` incorrectly reutrning full file path instead of file name (version name)