### PR TITLE
iOS fails to update fix

### DIFF
--- a/ios/Plugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Plugin/CapacitorUpdaterPlugin.swift
@@ -480,11 +480,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                     }
                 }
             } else {
-                vc.setServerBasePath(path: dest.path)
-                // For setServerBasePath, we need to wait for the next page load
-                vc.webView?.navigationDelegate = navigationDelegate
-                // Trigger a reload to ensure the new path is loaded
                 DispatchQueue.main.async {
+                    vc.setServerBasePath(path: dest.path)
+                    // For setServerBasePath, we need to wait for the next page load
+                    vc.webView?.navigationDelegate = navigationDelegate
+                    // Trigger a reload to ensure the new path is loaded
                     vc.webView?.reload()
                 }
             }


### PR DESCRIPTION
In my use for this package we are doing a fully self manage update ecosystem using vue with capacitor 5. I just updated from v5 to v7 capacitor and with the newest version of capacitor-updater I found that suddenly all of our updates were failing with the error "Main Thread Checker: UI API called on a background thread: -[WKWebView setNavigationDelegate:]." Inspecting the code I found this portion of the _reload function that sets the navigation delegate without enforcing the thread to be the main thread. Moving the DispatchQueue.main.async up 4 lines to fully encapsulate the else block has resolved the issue in our case and the application now reloads properly every time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed occasional failures to refresh content on iOS after updates, reducing instances of stale or blank views and ensuring the correct content loads reliably.

* **Performance/Stability**
  * Improved reliability of content reloads on iOS by coordinating updates on the main thread, resulting in smoother transitions during updates and fewer intermittent glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->