### PR TITLE
fix: remove temporary zip file for Android

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdater.java
@@ -339,6 +339,9 @@ public class CapacitorUpdater {
             }
             // Remove the decryption for manifest downloads
         } catch (Exception e) {
+            if (downloaded != null && downloaded.exists()) {
+              downloaded.delete();
+            }
             final Boolean res = this.delete(id);
             if (!res) {
                 Log.i(CapacitorUpdater.TAG, "Double error, cannot cleanup: " + version);
@@ -362,8 +365,8 @@ public class CapacitorUpdater {
                 this.notifyDownload(id, 91);
                 final String idName = bundleDirectory + "/" + id;
                 this.flattenAssets(downloaded, idName);
-                downloaded.delete();
             }
+            downloaded.delete();
             this.notifyDownload(id, 100);
             this.saveBundleInfo(id, null);
             BundleInfo next = new BundleInfo(id, version, BundleStatus.PENDING, new Date(System.currentTimeMillis()), checksum);


### PR DESCRIPTION
We tested the latest v6, and the issue is resolved on iOS (thanks for that!) but it’s still not fixed on Android. I checked the diffs and noticed there were no related changes for Android regarding [this issue](https://github.com/Cap-go/capacitor-updater/issues/613).

So for your convenience I’ve submitted this Android part of the PR again. We’d really appreciate it if you could release a fix for Android as well. If you already have a fix from v7, like the one applied for iOS, we’re happy to close this PR instead.