### PR TITLE
fix: use DownloadService sharedClient in CapgoUpdater to set user-agent

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -61,8 +61,6 @@ public class CapgoUpdater {
     public SharedPreferences.Editor editor;
     public SharedPreferences prefs;
 
-    private OkHttpClient client;
-
     public File documentsDir;
     public Boolean directUpdate = false;
     public Activity activity;
@@ -85,8 +83,6 @@ public class CapgoUpdater {
 
     public CapgoUpdater(Logger logger) {
         this.logger = logger;
-        // Simple OkHttpClient - actual configuration happens in plugin
-        this.client = new OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS).readTimeout(30, TimeUnit.SECONDS).build();
     }
 
     private final FilenameFilter filter = (f, name) -> {
@@ -772,7 +768,7 @@ public class CapgoUpdater {
 
         Request request = new Request.Builder().url(url).post(body).build();
 
-        client
+        DownloadService.sharedClient
             .newCall(request)
             .enqueue(
                 new okhttp3.Callback() {
@@ -881,7 +877,7 @@ public class CapgoUpdater {
             .delete(RequestBody.create(json.toString(), MediaType.get("application/json")))
             .build();
 
-        client
+        DownloadService.sharedClient
             .newCall(request)
             .enqueue(
                 new okhttp3.Callback() {
@@ -992,7 +988,7 @@ public class CapgoUpdater {
             .put(RequestBody.create(json.toString(), MediaType.get("application/json")))
             .build();
 
-        client
+        DownloadService.sharedClient
             .newCall(request)
             .enqueue(
                 new okhttp3.Callback() {
@@ -1089,7 +1085,7 @@ public class CapgoUpdater {
 
         Request request = new Request.Builder().url(urlBuilder.build()).get().build();
 
-        client
+        DownloadService.sharedClient
             .newCall(request)
             .enqueue(
                 new okhttp3.Callback() {
@@ -1195,7 +1191,7 @@ public class CapgoUpdater {
             .post(RequestBody.create(json.toString(), MediaType.get("application/json")))
             .build();
 
-        client
+        DownloadService.sharedClient
             .newCall(request)
             .enqueue(
                 new okhttp3.Callback() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -67,7 +67,7 @@ public class DownloadService extends Worker {
     private static final String UPDATE_FILE = "update.dat";
 
     // Shared OkHttpClient to prevent resource leaks
-    private static OkHttpClient sharedClient;
+    protected static OkHttpClient sharedClient;
     private static String currentAppId = "unknown";
     private static String currentPluginVersion = "unknown";
 


### PR DESCRIPTION
This PR updates CapgoUpdater to use the shared HTTP client instead of a default client. The shared client is configured to include a custom User-Agent header, which prevents requests from being flagged as bot traffic by Akamai CDN in our use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated all network requests to use a shared client for improved consistency and connection reuse.
  - Adjusted visibility to support shared networking across components.
  - Expected to reduce overhead and improve reliability of downloads and data submissions.
  - No changes to user workflows; existing behaviors, callbacks, and error handling remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->