### PR TITLE
fix: call notifyAppReady in the example-app

### DIFF
--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -5,6 +5,8 @@ import { CapacitorUpdater } from '@capgo/capacitor-updater';
 const plugin = CapacitorUpdater;
 const state = {};
 
+plugin.notifyAppReady();
+
 
 const actions = [
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App now signals readiness immediately upon startup, improving initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->