### PR TITLE
Fix: prevent JavaScript SyntaxError from unescaped error messages

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -513,7 +513,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 self.logger.error("Failed to download from: \(String(describing: url)) \(error.localizedDescription)")
                 self.notifyListeners("downloadFailed", data: ["version": version])
                 self.implementation.sendStats(action: "download_fail")
-                call.reject("Failed to download from: \(url!)", error.localizedDescription)
+                call.reject("Failed to download from: \(url!) - \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
Fixed a bug where error.localizedDescription passed as a second parameter to call.reject() could contain special characters (like apostrophes) that would cause JavaScript SyntaxError when sent to the frontend. We are frequently seeing Sentry error reports related when downloading in manual mode.

The issue seems to occur when error messages contained text like "don't..." or "can't...", resulting in Sentry errors such as:
- "Unexpected identifier 't'. Expected ')' to end an argument list."
- "Unexpected identifier 'notifyAppReady'. Expected ')' to end an argument list."

This serialization error was masking underlying errors.

Changed `CapacitorUpdaterPlugin.swift` to concatenate the error message into a single string parameter, ensuring proper escaping when serialized to JavaScript.

<details>
<summary><b>🐛 Deeper explanation:</b></summary>

### Problem
The iOS plugin seemed to be causing JavaScript `SyntaxError` exceptions when error messages contained special characters like apostrophes (`'`).

**Root Cause:**
In `CapacitorUpdaterPlugin.swift` line 516, we were calling:
```swift
call.reject("Failed to download from: \(url!)", error.localizedDescription)
```

This passes **two separate string parameters** to the Capacitor bridge. When `error.localizedDescription` contains special characters (e.g., "Don't have permission", "can't access", etc.), the second parameter gets improperly serialized to JavaScript without proper escaping.

**Example of the Issue:**
If the error message is `"Don't have permission"`, the bridge might generate JavaScript like:
```javascript
reject('Failed to download from: ...', 'Don't have permission')
```

The unescaped apostrophe in "Don't" breaks the JavaScript string literal, causing:
```
SyntaxError: Unexpected identifier 't'. Expected ')' to end an argument list.
```
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for failed downloads by including additional context about the underlying error, making it easier to diagnose download issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->