### PR TITLE
feat: document no new version available for getLatest()

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -698,9 +698,37 @@ export interface CapacitorUpdaterPlugin {
    * 2. Download it using {@link download}
    * 3. Apply it using {@link next} or {@link set}
    *
+   * **Important: Error handling for "no new version available"**
+   *
+   * When the device's current version matches the latest version on the server (i.e., the device is already
+   * up-to-date), the server returns a 200 response with `error: "no_new_version_available"` and
+   * `message: "No new version available"`. **This causes `getLatest()` to throw an error**, even though
+   * this is a normal, expected condition.
+   *
+   * You should catch this specific error to handle it gracefully:
+   *
+   * ```typescript
+   * try {
+   *   const latest = await CapacitorUpdater.getLatest();
+   *   // New version is available, proceed with download
+   * } catch (error) {
+   *   if (error.message === 'No new version available') {
+   *     // Device is already on the latest version - this is normal
+   *     console.log('Already up to date');
+   *   } else {
+   *     // Actual error occurred
+   *     console.error('Failed to check for updates:', error);
+   *   }
+   * }
+   * ```
+   *
+   * In this scenario, the server:
+   * - Logs the request with a "No new version available" message
+   * - Sends a "noNew" stat action to track that the device checked for updates but was already current (done on the backend)
+   *
    * @param options Optional {@link GetLatestOptions} to specify which channel to check.
    * @returns {Promise<LatestVersion>} Information about the latest available bundle version.
-   * @throws {Error} If the request fails or the server returns an error.
+   * @throws {Error} Always throws when no new version is available (`error: "no_new_version_available"`), or when the request fails.
    * @since 4.0.0
    */
   getLatest(options?: GetLatestOptions): Promise<LatestVersion>;
@@ -1355,12 +1383,29 @@ export interface LatestVersion {
    * @deprecated Use {@link LatestVersion.breaking} instead.
    */
   major?: boolean;
+  /**
+   * Optional message from the server.
+   * When no new version is available, this will be "No new version available".
+   */
   message?: string;
   sessionKey?: string;
+  /**
+   * Error code from the server, if any.
+   * Common values:
+   * - `"no_new_version_available"`: Device is already on the latest version (not a failure)
+   * - Other error codes indicate actual failures in the update process
+   */
   error?: string;
+  /**
+   * The previous/current version name (provided for reference).
+   */
   old?: string;
+  /**
+   * Download URL for the bundle (when a new version is available).
+   */
   url?: string;
   /**
+   * File list for partial updates (when using multi-file downloads).
    * @since 6.1
    */
   manifest?: ManifestEntry[];


### PR DESCRIPTION
I had a call with a guy that had not known that `getLatest` can fail when there is no new version available. I have decided to improve the docs, as it is simple to do.

Furthermore, I had added some documentation to the `LatestVersion` object, as we had some keys that were not documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced error handling guidance for version checks, clarifying expected behavior when no new version is available.

* **New Features**
  * Extended version check responses with optional fields: server-provided messages, error codes, prior version reference, and download URLs when applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->