### PR TITLE
Ensure backward compatibility for cleanupObsoleteversions method

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -358,7 +358,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func cleanupObsoleteVersions() {
-        let previous = UserDefaults.standard.string(forKey: "LatestNativeBuildVersion") ?? "0"
+        let previous = UserDefaults.standard.string(forKey: "LatestNativeBuildVersion") ?? UserDefaults.standard.string(forKey: "LatestVersionNative") ?? "0"
         if previous != "0" && self.currentBuildVersion != previous {
             _ = self._reset(toLastSuccessful: false)
             let res = implementation.list()


### PR DESCRIPTION
The key to store the previous native version was changed at [this commit](https://github.com/Cap-go/capacitor-updater/commit/e3696ea76381ff8211dd084f765dcf7672319682#diff-28b4efbe6587311e6c0bab1dd7d1adee3edec3ae2cbe5651fb97e532c55a0177L431).

This change has no backward compatibility and causes a bug where the previous web assets are used indefinitely, even after users update the native version from the App Store, if the developer updates this library version.

This PR solve this problem by using the key that this library used to use with the nullish coalescing operator.
To avoid introducing unintended bugs, I hope this change gets released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced app version tracking and improved cleanup of obsolete bundles during updates. Better backward-compatibility when transitioning from older app versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->