### PR TITLE
fix: correct isProd() to detect debug builds using FLAG_DEBUGGABLE

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -105,7 +105,10 @@ public class CapgoUpdater {
 
     private boolean isProd() {
         try {
-            return !Objects.requireNonNull(getClass().getPackage()).getName().contains(".debug");
+            if (activity == null) {
+                return true; // Default to production if no activity context
+            }
+            return (activity.getApplicationInfo().flags & android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) == 0;
         } catch (Exception e) {
             return true; // Default to production if we can't determine
         }


### PR DESCRIPTION
## Summary
- Fixed broken `isProd()` method in Android CapgoUpdater to properly detect debug vs release builds
- Now checks `ApplicationInfo.FLAG_DEBUGGABLE` instead of unreliable package name check
- Correctly identifies debug builds that were previously misclassified as production

## Test Plan
- [ ] Verify debug builds return `isProd() = false`
- [ ] Verify release builds return `isProd() = true`
- [ ] Confirm no regressions in build detection logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Android build-type detection in `CapgoUpdater`.
> 
> - Replaces package-name heuristic with `ApplicationInfo.FLAG_DEBUGGABLE` check in `isProd()` for reliable debug/release detection
> - Defaults to production when `activity` is null or when detection throws an exception
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ac06dc79bbca76d9a0aa8465654ea252e2f980b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of debug vs. production build status to ensure more reliable app behavior across different configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->