### PR TITLE
refactor: expand public key identifier from 4 to 20 characters

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -357,8 +357,10 @@ public class CryptoCipher {
     }
 
     /**
-     * Get first 4 characters of the public key for identification.
-     * Returns 4-character string or empty string if key is invalid/empty.
+     * Get first 20 characters of the public key for identification.
+     * Returns 20-character string or empty string if key is invalid/empty.
+     * The first 12 chars are always "MIIBCgKCAQEA" for RSA 2048-bit keys,
+     * so the unique part starts at character 13.
      */
     public static String calcKeyId(String publicKey) {
         if (publicKey == null || publicKey.isEmpty()) {
@@ -371,7 +373,7 @@ public class CryptoCipher {
             .replace("-----BEGINRSAPUBLICKEY-----", "")
             .replace("-----ENDRSAPUBLICKEY-----", "");
 
-        // Return first 4 characters of the base64-encoded key
-        return cleanedKey.length() >= 4 ? cleanedKey.substring(0, 4) : cleanedKey;
+        // Return first 20 characters of the base64-encoded key
+        return cleanedKey.length() >= 20 ? cleanedKey.substring(0, 20) : cleanedKey;
     }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -278,8 +278,10 @@ public struct CryptoCipher {
         }
     }
 
-    /// Get first 4 characters of the public key for identification
-    /// Returns 4-character string or empty string if key is invalid/empty
+    /// Get first 20 characters of the public key for identification
+    /// Returns 20-character string or empty string if key is invalid/empty
+    /// The first 12 chars are always "MIIBCgKCAQEA" for RSA 2048-bit keys,
+    /// so the unique part starts at character 13
     public static func calcKeyId(publicKey: String) -> String {
         if publicKey.isEmpty {
             return ""
@@ -293,7 +295,7 @@ public struct CryptoCipher {
             .replacingOccurrences(of: "\r", with: "")
             .replacingOccurrences(of: " ", with: "")
 
-        // Return first 4 characters of the base64-encoded key
-        return String(cleanedKey.prefix(4))
+        // Return first 20 characters of the base64-encoded key
+        return String(cleanedKey.prefix(20))
     }
 }


### PR DESCRIPTION
## Summary

Extended the public key identifier from 4 to 20 characters. The first 4 characters of RSA 2048-bit keys are always identical, making them useless for identification. The new 20-character identifier includes meaningful unique data while remaining easy for users to locate in their public key files.

## Changes

- Updated `calcKeyId()` in both iOS (`CryptoCipher.swift`) and Android (`CryptoCipher.java`)
- Key ID now uses first 20 characters instead of 4
- Added clarifying comments explaining the RSA key structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)