### PR TITLE
fix: validate public key format and parsing at startup

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -153,12 +153,25 @@ public class CapgoUpdater {
     }
 
     public void setPublicKey(String publicKey) {
-        this.publicKey = publicKey;
-        if (!publicKey.isEmpty()) {
-            this.cachedKeyId = CryptoCipher.calcKeyId(publicKey);
-        } else {
+        // Empty string means no encryption - proceed normally
+        if (publicKey == null || publicKey.isEmpty()) {
+            this.publicKey = "";
             this.cachedKeyId = "";
+            return;
         }
+
+        // Non-empty: must be a valid RSA key or crash
+        try {
+            CryptoCipher.stringToPublicKey(publicKey);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                "Invalid public key in capacitor.config.json: failed to parse RSA key. Remove the key or provide a valid PEM-formatted RSA public key.",
+                e
+            );
+        }
+
+        this.publicKey = publicKey;
+        this.cachedKeyId = CryptoCipher.calcKeyId(publicKey);
     }
 
     public String getKeyId() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -235,7 +235,8 @@ public class DownloadService extends Worker {
                         public void onResponse(@NonNull Call call, @NonNull Response response) {
                             try (ResponseBody body = response.body()) {
                                 // nothing else to do, just closing body
-                            } catch (Exception ignored) {} finally {
+                            } catch (Exception ignored) {
+                            } finally {
                                 response.close();
                             }
                         }
@@ -291,7 +292,7 @@ public class DownloadService extends Worker {
                 String fileHash = entry.getString("file_hash");
                 String downloadUrl = entry.getString("download_url");
 
-                if (!publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
+                if (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
                     try {
                         fileHash = CryptoCipher.decryptChecksum(fileHash, publicKey);
                     } catch (Exception e) {
@@ -633,7 +634,7 @@ public class DownloadService extends Worker {
                 // Use OkIO for atomic write
                 writeFileAtomic(compressedFile, responseBody.byteStream(), null);
 
-                if (!publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
+                if (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
                     logger.debug("Decrypting file " + targetFile.getName());
                     CryptoCipher.decryptFile(compressedFile, publicKey, sessionKey);
                 }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -387,13 +387,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             // The initial report: https://discord.com/channels/912707985829163099/1456985639345061969
             // The bug happens in a very specific scenario. Here is the reproduction steps, followed by the lackof busniess impact
             // Reproduction steps:
-            // 1. Install iOS app via app store. Version: 10.13.0. Version v10 of the app uses Capacitor 6 (6.3.13) - a version where the key was still "LatestVersionNative" 
+            // 1. Install iOS app via app store. Version: 10.13.0. Version v10 of the app uses Capacitor 6 (6.3.13) - a version where the key was still "LatestVersionNative"
             // 2. The plugin writes "10.13.0" to the key "LatestVersionNative"
             // 3. Update the app to version 10.17.0 via Capgo.
             // 4. Update the app via testflight to version 11.0.0. This version uses Capacitor 8 (8.41.3) - a version where the key was changed to "LatestNativeBuildVersion"
             // 5. During the initial load of then new native version, the plugin will read "LatestNativeBuildVersion", not find it, read "LatestVersionNative", find it and revert to builtin version sucessfully.
             // 6. The plugin writes "11.0.0" to the key "LatestNativeBuildVersion"
-            // 7. The app is now in a state where it is using the builtin version, but the key "LatestNativeBuildVersion" is still set to "11.0.0" and "LatestVersionNative" is still set to "10.13.0". 
+            // 7. The app is now in a state where it is using the builtin version, but the key "LatestNativeBuildVersion" is still set to "11.0.0" and "LatestVersionNative" is still set to "10.13.0".
             // 8. The user downgrades using app store back to version 10.13.0.
             // 9. The old plugin reads "LatestVersionNative", finds "10.13.0," so it doesn't revert to builtin version. // <--- THIS IS THE FIRST PART OF THE BUG
             // 10. "LatestVersionNative" is written to "10.13.0" but "LatestNativeBuildVersion" is not touched, and stays at "11.0.0"

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -80,12 +80,20 @@ import UIKit
     }
 
     public func setPublicKey(_ publicKey: String) {
-        self.publicKey = publicKey
-        if !publicKey.isEmpty {
-            self.cachedKeyId = CryptoCipher.calcKeyId(publicKey: publicKey)
-        } else {
+        // Empty string means no encryption - proceed normally
+        if publicKey.isEmpty {
+            self.publicKey = ""
             self.cachedKeyId = nil
+            return
         }
+
+        // Non-empty: must be a valid RSA key or crash
+        guard RSAPublicKey.load(rsaPublicKey: publicKey) != nil else {
+            fatalError("Invalid public key in capacitor.config.json: failed to parse RSA key. Remove the key or provide a valid PEM-formatted RSA public key.")
+        }
+
+        self.publicKey = publicKey
+        self.cachedKeyId = CryptoCipher.calcKeyId(publicKey: publicKey)
     }
 
     public func getKeyId() -> String? {
@@ -1306,7 +1314,7 @@ import UIKit
                 let fileName = url.lastPathComponent
                 // Only cleanup package_*.tmp and update_*.dat files
                 let isDownloadTemp = (fileName.hasPrefix("package_") && fileName.hasSuffix(".tmp")) ||
-                                     (fileName.hasPrefix("update_") && fileName.hasSuffix(".dat"))
+                    (fileName.hasPrefix("update_") && fileName.hasSuffix(".dat"))
                 if !isDownloadTemp {
                     continue
                 }


### PR DESCRIPTION
## Summary
- Reject invalid public keys at startup instead of silently failing during bundle updates
- Use proper boolean flag instead of magic string marker
- Empty string or null publicKey is treated as "no encryption" and works normally
- Invalid RSA keys cause immediate errors with helpful messages

## Test plan
- [ ] Verify with empty publicKey: no encryption error
- [ ] Verify with valid RSA key: encryption works
- [ ] Verify with invalid key format: app logs error and fails loudly
- [ ] Run Android and iOS builds
- [ ] Test bundle downloads with encryption enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced public key validation failure handling during updates, with explicit error tracking and improved recovery logic across encryption and decryption operations.

* **Refactor**
  * Updated internal decryption verification methods to properly handle and propagate public key validation states throughout the download and update verification workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->