### PR TITLE
fix: reset timeout flag for splash screen on app backgrounding

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -2109,6 +2109,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     public void appMovedToBackground() {
+        // Reset timeout flag at start of each background cycle
+        this.autoSplashscreenTimedOut = false;
+
         final BundleInfo current = CapacitorUpdaterPlugin.this.implementation.getCurrentBundle();
 
         // Show splashscreen FIRST, before any other background work to ensure launcher shows it

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1597,6 +1597,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func appMovedToBackground() {
+        // Reset timeout flag at start of each background cycle
+        self.autoSplashscreenTimedOut = false
+
         let current: BundleInfo = self.implementation.getCurrentBundle()
         self.implementation.sendStats(action: "app_moved_to_background", versionName: current.getVersionName())
         logger.info("Check for pending update")


### PR DESCRIPTION
## Changes (AI generated)

This change ensures that the timeout flag for the splash screen is reset at the start of each background cycle in both Android and iOS implementations of the CapacitorUpdaterPlugin.

## Changes (Human generated)

Before, if this flag were to ever be set to true, the splash screen would never be shown again

## Motivation

Martin asked me to fix splashscreen. Auto show splash screen is an imporant feature for Capgo users and as such, I consider fixing it to be beneficial to Capgo

## Business impact

Medium - providing a broken experience that affects the user is never good. Especially when this bad expeirence is visible to the end user (the clients of Capgo's clients)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed splash screen timeout state that was not being properly reset when the app moved to the background, ensuring correct splash screen behavior on both iOS and Android platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->