### PR TITLE
fix(android): use unqualified enum names in switch cases

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DelayUpdateUtils.java
@@ -43,7 +43,7 @@ public class DelayUpdateUtils {
             DelayUntilNext kind = condition.getKind();
             String value = condition.getValue();
             switch (kind) {
-                case DelayUntilNext.background:
+                case background:
                     if (source == CancelDelaySource.FOREGROUND) {
                         long backgroundedAt = getBackgroundTimestamp();
                         long now = System.currentTimeMillis();
@@ -86,7 +86,7 @@ public class DelayUpdateUtils {
                         );
                     }
                     break;
-                case DelayUntilNext.kill:
+                case kill:
                     if (source == CancelDelaySource.KILLED) {
                         logger.info("Kill delay (value: " + value + ") condition removed at index " + index + " after app kill");
                     } else {
@@ -96,7 +96,7 @@ public class DelayUpdateUtils {
                         );
                     }
                     break;
-                case DelayUntilNext.date:
+                case date:
                     if (!"".equals(value)) {
                         try {
                             final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
@@ -122,7 +122,7 @@ public class DelayUpdateUtils {
                         logger.debug("Date delay (value: " + value + ") condition removed due to empty value at index " + index);
                     }
                     break;
-                case DelayUntilNext.nativeVersion:
+                case nativeVersion:
                     if (!"".equals(value)) {
                         try {
                             final Version versionLimit = new Version(value);


### PR DESCRIPTION
## Summary

Java requires unqualified constant names in switch case labels. The current code uses qualified names like `DelayUntilNext.background` which causes compilation errors on JDK 17+.

## Problem

When building with JDK 17 or later, the Android build fails with:

```
error: an enum switch case label must be the unqualified name of an enumeration constant
case DelayUntilNext.background:
^
```

This affects all 4 switch cases in `DelayUpdateUtils.java` (lines 46, 89, 99, 125).

## Solution

Change qualified enum references to unqualified names:

- `case DelayUntilNext.background:` → `case background:`
- `case DelayUntilNext.kill:` → `case kill:`
- `case DelayUntilNext.date:` → `case date:`
- `case DelayUntilNext.nativeVersion:` → `case nativeVersion:`

## Testing

- Verified the fix compiles successfully with JDK 17 and JDK 20
- Tested on a real Android device (Samsung SM-S916B, API 36)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->