### PR TITLE
fix: android checksum_fail error

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -529,6 +529,8 @@ public class CapgoUpdater {
                     // V1 Encryption (privateKey) - deprecated not supported
                     this.sendStats("checksum_fail");
                     throw new IOException("V1 decryption is no longer supported for security reasons.");
+                } else {
+                  checksum = CryptoCipher.calcChecksum(downloaded);
                 }
                 CryptoCipher.logChecksumInfo("Calculated checksum", checksum);
                 CryptoCipher.logChecksumInfo("Expected checksum", checksumDecrypted);


### PR DESCRIPTION
When there's no encryption, Android app is not able to update, because the checksum is not correctly initialised.

v8 contains this fix already https://github.com/Cap-go/capacitor-updater/blob/3bc329f18f4a616328d56027c156584eb1a5966b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java#L525-L527 

