### PR TITLE
docs: clarify Capacitor v4 support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Perfect for fixing bugs immediately, A/B testing features, and maintaining contr
 - ⚔️ **Battle-Tested**: Used in more than 3000 projects.
 - 📊 View your deployment statistics
 - 🔋 Supports Android and iOS
-- ⚡️ Capacitor 6/7 support
+- ⚡️ Capacitor 4/5/6/7/8 support
 - 🌐 **Open Source**: Licensed under the Mozilla Public License 2.0
 - 🌐 **Open Source Backend**: Self install [our backend](https://github.com/Cap-go/capgo) in your infra
 
@@ -96,11 +96,11 @@ Starting from v8, the plugin uses [ZIPFoundation](https://github.com/weichsel/ZI
 | v7.\*.\*       | v7.\*.\*                | ✅                 |
 | v6.\*.\*       | v6.\*.\*                | ✅                 |
 | v5.\*.\*       | v5.\*.\*                | ✅ |
-| v4.\*.\*       | v4.\*.\*                | ⚠️ Deprecated |
+| v4.\*.\*       | v4.\*.\*                | ✅                 |
 | v3.\*.\*       | v3.\*.\*                | ⚠️ Deprecated     |
 | > 7            | v4.\*.\*                | ⚠️ Deprecated, our CI got crazy and bumped too much version     |
 
-> **Note:** Versions 5, 6, 7, and 8 all share the same features. The major version simply follows your Capacitor version. You can safely use any of these versions that matches your Capacitor installation.
+> **Note:** Versions 4, 5, 6, 7, and 8 all share the same features. The major version simply follows your Capacitor version. You can safely use any of these versions that matches your Capacitor installation.
 
 ### iOS
 
@@ -158,6 +158,9 @@ npm install @capgo/capacitor-updater@lts-v6
 
 # For Capacitor 5
 npm install @capgo/capacitor-updater@lts-v5
+
+# For Capacitor 4
+npm install @capgo/capacitor-updater@lts-v4
 ```
 
 ## Auto-update setup


### PR DESCRIPTION
## What
- Update README sections to include Capacitor v4 support in feature highlights, compatibility, and install tags.

## Why
- v4 is currently supported and should not be described as deprecated.

## How
- Updated the support bullet, v4 compatibility row, shared-version note, and added the `lts-v4` install example.

## Testing
- Reviewed the full diff with `git diff origin/main...`.

## Not Tested
- No runtime/platform checks were run because this is a documentation-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Capacitor compatibility support from versions 6/7 to versions 4/5/6/7/8
  * Capacitor 4 updated from deprecated to fully supported status
  * Added installation instructions and example commands specific to Capacitor 4
  * Updated compatibility tables and migration notes for broader version coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->