### PR TITLE
fix(ios): improve ListChannelsDec decoder to handle unexpected response formats

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/InternalUtils.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/InternalUtils.swift
@@ -81,21 +81,35 @@ struct ListChannelsDec: Decodable {
     let error: String?
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-
-        if let channelsArray = try? container.decode([ChannelInfo].self) {
-            // Backend returns direct array
+        // First, try to decode as a direct array (backend returns direct array format)
+        if let singleContainer = try? decoder.singleValueContainer(),
+           let channelsArray = try? singleContainer.decode([ChannelInfo].self) {
             self.channels = channelsArray
             self.error = nil
-        } else {
-            // Handle error response
-            let errorContainer = try decoder.container(keyedBy: CodingKeys.self)
+            return
+        }
+
+        // Fall back to keyed container for error responses or wrapped formats
+        // Use try? to avoid throwing a decode error when keys are missing
+        if let keyedContainer = try? decoder.container(keyedBy: CodingKeys.self) {
+            // Try wrapped channels array format: { "channels": [...] }
+            if let channelsArray = try? keyedContainer.decode([ChannelInfo].self, forKey: .channels) {
+                self.channels = channelsArray
+                self.error = try? keyedContainer.decode(String.self, forKey: .error)
+                return
+            }
+            // Error response format: { "error": "..." }
             self.channels = nil
-            self.error = try? errorContainer.decode(String.self, forKey: .error)
+            self.error = try? keyedContainer.decode(String.self, forKey: .error)
+        } else {
+            // Could not decode in any known format — return empty/nil gracefully
+            self.channels = nil
+            self.error = "Response could not be decoded: unexpected format"
         }
     }
 
     private enum CodingKeys: String, CodingKey {
+        case channels
         case error
     }
 }


### PR DESCRIPTION
## Problem

Fixes #706 - `listChannels()` was throwing a confusing error on iOS:
```
Request failed: Response could not be decoded because of error:
The data couldn't be read because it isn't in the correct format.
```

## Root Cause

The original `ListChannelsDec` custom decoder used `singleValueContainer()` as the primary decode path, then fell back to a keyed container for error responses.

When the backend returns a response in a format that is **not strictly a raw JSON array** (e.g. a wrapped object `{ "channels": [...] }` or an error object with unexpected keys), the decode chain fails silently at both stages — causing Swift's Codable to surface a cryptic format error instead of a useful message.

## Fix

Restructured the `init(from:)` decoder to handle three distinct response shapes:

1. **Direct array** `[...]` — primary backend format  
2. **Wrapped object** `{ "channels": [...] }` — handles potential future/wrapped formats
3. **Error object** `{ "error": "..." }` — properly surfaces server errors

As a safety net, when none of the known formats match, a descriptive error string is returned instead of propagating Swift's cryptic decode error.

## Testing

- Tested with direct array response ✅
- Tested with error response ✅  
- No regressions for the happy path

/claim #706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved channel list loading to support multiple data format variations with enhanced error handling, ensuring the app gracefully manages different API response structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->