### PR TITLE
fix: apply next bundle on reload

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1444,6 +1444,21 @@ public class CapacitorUpdaterPlugin extends Plugin {
     @PluginMethod
     public void reload(final PluginCall call) {
         try {
+            final BundleInfo current = this.implementation.getCurrentBundle();
+            final BundleInfo next = this.implementation.getNextBundle();
+
+            if (next != null && !next.isErrorStatus() && !next.getId().equals(current.getId())) {
+                logger.info("Applying pending bundle on reload: " + next.getVersionName());
+                if (this.implementation.set(next)) {
+                    this.implementation.setNextBundle(null);
+                    this.notifyBundleSet(next);
+                } else {
+                    logger.error("Failed to activate pending bundle on reload: " + next.getVersionName());
+                    call.reject("Failed to activate pending bundle on reload");
+                    return;
+                }
+            }
+
             if (this._reload()) {
                 call.resolve();
             } else {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -713,6 +713,21 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func reload(_ call: CAPPluginCall) {
+        let current: BundleInfo = self.implementation.getCurrentBundle()
+        let next: BundleInfo? = self.implementation.getNextBundle()
+
+        if next != nil && !next!.isErrorStatus() && next!.getId() != current.getId() {
+            logger.info("Applying pending bundle on reload: \(next!.toString())")
+            if self.implementation.set(bundle: next!) {
+                _ = self.implementation.setNextBundle(next: Optional<String>.none)
+                self.notifyBundleSet(next!)
+            } else {
+                logger.error("Failed to activate pending bundle on reload: \(next!.toString())")
+                call.reject("Failed to activate pending bundle on reload")
+                return
+            }
+        }
+
         if self._reload() {
             call.resolve()
         } else {


### PR DESCRIPTION
## Summary
Fixes #727
Fix `reload()` so it applies the queued pending bundle before reloading when `next()` was called.

## What changed

- check for a pending bundle in `reload()`
- activate that bundle when it differs from the current bundle
- clear the pending bundle after activation
- keep existing reload behavior unchanged when no pending bundle exists

## Test plan

- Not run locally in this environment
- Verified the diff is scoped to the native `reload()` implementation on Android and iOS only
- Verified the change matches the documented `next()` + `reload()` behavior in `src/definitions.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app reload behavior to activate pending bundle updates before reloading on Android and iOS platforms. Failed activation attempts are now properly handled with error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->