### PR TITLE
Fix: app startup crash, use PackageInfoCompat for API <28 compatibility

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -22,6 +22,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
+import androidx.core.content.pm.PackageInfoCompat;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.CapConfig;
 import com.getcapacitor.JSArray;
@@ -191,7 +192,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private String getVersionCode(final PackageInfo packageInfo) {
-        return Long.toString(packageInfo.getLongVersionCode());
+        return Long.toString(PackageInfoCompat.getLongVersionCode(packageInfo));
     }
 
     private void notifyBreakingEvents(final String version) {


### PR DESCRIPTION
Found when upgrading to Capacitor 8 and the latest capacitor-updater on an older Oppo Android 8.1 phone - it crashed on startup.

## Summary

- `PackageInfo.getLongVersionCode()` requires API 28+, but the plugin minSdkVersion is 24 (it seems). This causes a `NoSuchMethodError` crash on Android 8.x (API 26-27) devices during plugin `load()`, before any web content renders.
- Replaced with `PackageInfoCompat.getLongVersionCode()` from `androidx.core`, which is backwards-compatible to API 14.
- Regression introduced in 7ee8c62 (2026-03-24).

## Test plan

- [x] `./gradlew clean build test` passes
- [x] Verify app boots without crash on an Android 8.x (API 26-27) device or emulator
- [x] Verify app still works correctly on API 28+ devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android compatibility for version code retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->