### PR TITLE
[codex] fix npm release tagging for issue 742

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,21 +45,13 @@ jobs:
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-      - name: Publish lts-v6 to npm
-        if: ${{ startsWith(github.ref, 'refs/tags/6.') }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag lts-v6 --provenance --access public
+      - name: Resolve npm dist-tag
+        id: npm_tag
+        run: echo "value=$(bun scripts/resolve-npm-dist-tag.mjs \"$GITHUB_REF\")" >> "$GITHUB_OUTPUT"
       - name: Publish to npm
-        if: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/6.') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
-      - name: Publish to npm with next tag
-        if: ${{ contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/6.')  }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag next --provenance --access public
+        run: npm publish --tag "${{ steps.npm_tag.outputs.value }}" --provenance --access public
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/scripts/resolve-npm-dist-tag.mjs
+++ b/scripts/resolve-npm-dist-tag.mjs
@@ -18,10 +18,10 @@ const versionTag = ref.slice(tagRefPrefix.length);
 // still contains an accidental 10.0.0 release from an older workflow bug.
 let npmTag = 'latest';
 
-if (versionTag.startsWith('6.')) {
-  npmTag = 'lts-v6';
-} else if (versionTag.includes('-alpha.')) {
+if (versionTag.includes('-alpha.')) {
   npmTag = 'next';
+} else if (versionTag.startsWith('6.')) {
+  npmTag = 'lts-v6';
 }
 
 process.stdout.write(npmTag);

--- a/scripts/resolve-npm-dist-tag.mjs
+++ b/scripts/resolve-npm-dist-tag.mjs
@@ -1,0 +1,27 @@
+const ref = process.argv[2];
+
+if (!ref) {
+  console.error('Expected a Git ref argument.');
+  process.exit(1);
+}
+
+const tagRefPrefix = 'refs/tags/';
+
+if (!ref.startsWith(tagRefPrefix)) {
+  console.error(`Expected a tag ref, received "${ref}".`);
+  process.exit(1);
+}
+
+const versionTag = ref.slice(tagRefPrefix.length);
+
+// Stable 8.x releases must publish with an explicit "latest" tag because npm
+// still contains an accidental 10.0.0 release from an older workflow bug.
+let npmTag = 'latest';
+
+if (versionTag.startsWith('6.')) {
+  npmTag = 'lts-v6';
+} else if (versionTag.includes('-alpha.')) {
+  npmTag = 'next';
+}
+
+process.stdout.write(npmTag);


### PR DESCRIPTION
## What
- make npm publish always use an explicit dist-tag
- resolve the npm dist-tag from the pushed Git tag in a small script

## Why
- npm publish started failing once npm already had an accidental 10.0.0 release, because stable 8.x releases were trying to apply `latest` implicitly
- this restores tagged releases and keeps the `latest`, `next`, and `lts-v6` mapping explicit

## How
- add `scripts/resolve-npm-dist-tag.mjs` to centralize the publish-tag logic
- simplify `.github/workflows/build.yml` to call the resolver before publishing
- prepared with Codex assistance

## Testing
- `bun scripts/resolve-npm-dist-tag.mjs refs/tags/8.45.6`
- `bun scripts/resolve-npm-dist-tag.mjs refs/tags/8.45.6-alpha.1`
- `bun scripts/resolve-npm-dist-tag.mjs refs/tags/6.99.0`
- `bun run fmt`
- `bun run verify`

## Not Tested
- an actual npm publish from GitHub Actions, which requires the next tagged release after merge

Fixes #742


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined npm publishing process in CI by consolidating tag selection into a single dynamic step.
  * Added an automated tag-resolution utility so releases are published with the correct npm dist-tag (e.g., latest, next, lts-v6) based on the release ref.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->