### PR TITLE
[codex] fix android direct update startup deadlock

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -135,8 +135,12 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private volatile long downloadStartTimeMs = 0;
     private static final long DOWNLOAD_TIMEOUT_MS = 3600000; // 1 hour timeout
 
-    //  private static final CountDownLatch semaphoreReady = new CountDownLatch(1);
-    private static final Phaser semaphoreReady = new Phaser(1);
+    private final Phaser semaphoreReady = new Phaser(0) {
+        @Override
+        protected boolean onAdvance(final int phase, final int registeredParties) {
+            return false;
+        }
+    };
 
     // Lock to ensure cleanup completes before downloads start
     private final Object cleanupLock = new Object();
@@ -516,29 +520,43 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
     }
 
-    private boolean semaphoreWait(Number waitTime) {
+    private boolean semaphoreWait(final int phase, Number waitTime) {
         try {
-            semaphoreReady.awaitAdvanceInterruptibly(semaphoreReady.getPhase(), waitTime.longValue(), TimeUnit.MILLISECONDS);
+            semaphoreReady.awaitAdvanceInterruptibly(phase, waitTime.longValue(), TimeUnit.MILLISECONDS);
             logger.info("semaphoreReady count " + semaphoreReady.getPhase());
             return true;
         } catch (InterruptedException e) {
             logger.info("semaphoreWait InterruptedException");
+            cleanupTimedOutSemaphoreWait(phase);
             Thread.currentThread().interrupt(); // Restore interrupted status
             return false;
         } catch (TimeoutException e) {
             logger.error("Semaphore timeout: " + e.getMessage());
+            cleanupTimedOutSemaphoreWait(phase);
             return false;
         }
     }
 
-    private void semaphoreUp() {
+    private int semaphoreUp() {
         logger.info("semaphoreUp");
-        semaphoreReady.register();
+        return semaphoreReady.register();
     }
 
     private void semaphoreDown() {
+        if (semaphoreReady.getRegisteredParties() == 0) {
+            logger.info("semaphoreDown skipped, no pending app ready wait");
+            return;
+        }
         logger.info("semaphoreDown");
         logger.info("semaphoreDown count " + semaphoreReady.getPhase());
+        semaphoreReady.arriveAndDeregister();
+    }
+
+    private void cleanupTimedOutSemaphoreWait(final int phase) {
+        if (semaphoreReady.getPhase() != phase || semaphoreReady.getRegisteredParties() == 0) {
+            return;
+        }
+        logger.info("Cleaning up stale app ready wait for phase " + phase);
         semaphoreReady.arriveAndDeregister();
     }
 
@@ -1474,7 +1492,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     protected boolean _reload() {
-        this.semaphoreUp();
+        final int phase = this.semaphoreUp();
         this.applyCurrentBundleToBridge();
 
         final long waitTimeMs = this.resolveAppReadyCheckTimeoutMs();
@@ -1482,7 +1500,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.notifyListeners("appReloaded", new JSObject());
 
         // Wait for the reload to complete (until notifyAppReady is called)
-        return this.semaphoreWait(waitTimeMs);
+        return this.semaphoreWait(phase, waitTimeMs);
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -88,6 +88,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private static final String SPLASH_SCREEN_PLUGIN_ID = "SplashScreen";
     private static final int SPLASH_SCREEN_RETRY_DELAY_MS = 100;
     private static final int SPLASH_SCREEN_MAX_RETRIES = 20;
+    private static final long PENDING_BUNDLE_APP_READY_MIN_TIMEOUT_MS = 30000L;
 
     private final String pluginVersion = "8.45.8";
     private static final String DELAY_CONDITION_PREFERENCES = "";
@@ -515,16 +516,18 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
     }
 
-    private void semaphoreWait(Number waitTime) {
+    private boolean semaphoreWait(Number waitTime) {
         try {
             semaphoreReady.awaitAdvanceInterruptibly(semaphoreReady.getPhase(), waitTime.longValue(), TimeUnit.MILLISECONDS);
             logger.info("semaphoreReady count " + semaphoreReady.getPhase());
+            return true;
         } catch (InterruptedException e) {
             logger.info("semaphoreWait InterruptedException");
             Thread.currentThread().interrupt(); // Restore interrupted status
+            return false;
         } catch (TimeoutException e) {
             logger.error("Semaphore timeout: " + e.getMessage());
-            // Don't throw runtime exception, just log and continue
+            return false;
         }
     }
 
@@ -537,6 +540,29 @@ public class CapacitorUpdaterPlugin extends Plugin {
         logger.info("semaphoreDown");
         logger.info("semaphoreDown count " + semaphoreReady.getPhase());
         semaphoreReady.arriveAndDeregister();
+    }
+
+    protected long getMinimumPendingBundleAppReadyTimeoutMs() {
+        return PENDING_BUNDLE_APP_READY_MIN_TIMEOUT_MS;
+    }
+
+    private long resolveAppReadyCheckTimeoutMs() {
+        long configuredTimeoutMs = this.appReadyTimeout.longValue();
+        try {
+            if (this.implementation == null) {
+                return configuredTimeoutMs;
+            }
+
+            final BundleInfo current = this.implementation.getCurrentBundle();
+            if (current == null || BundleStatus.SUCCESS == current.getStatus()) {
+                return configuredTimeoutMs;
+            }
+
+            return Math.max(configuredTimeoutMs, this.getMinimumPendingBundleAppReadyTimeoutMs());
+        } catch (final Exception e) {
+            logger.warn("Falling back to configured appReadyTimeout: " + e.getMessage());
+            return configuredTimeoutMs;
+        }
     }
 
     private void sendReadyToJs(final BundleInfo current, final String msg) {
@@ -1451,18 +1477,12 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.semaphoreUp();
         this.applyCurrentBundleToBridge();
 
-        this.checkAppReady();
+        final long waitTimeMs = this.resolveAppReadyCheckTimeoutMs();
+        this.checkAppReady(waitTimeMs);
         this.notifyListeners("appReloaded", new JSObject());
 
         // Wait for the reload to complete (until notifyAppReady is called)
-        try {
-            this.semaphoreWait(this.appReadyTimeout);
-        } catch (Exception e) {
-            logger.error("Error waiting for app ready: " + e.getMessage());
-            return false;
-        }
-
-        return true;
+        return this.semaphoreWait(waitTimeMs);
     }
 
     @PluginMethod
@@ -1939,11 +1959,15 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private void checkAppReady() {
+        this.checkAppReady(this.resolveAppReadyCheckTimeoutMs());
+    }
+
+    private void checkAppReady(final long waitTimeMs) {
         try {
             if (this.appReadyCheck != null) {
                 this.appReadyCheck.interrupt();
             }
-            this.appReadyCheck = startNewThread(new DeferredNotifyAppReadyCheck());
+            this.appReadyCheck = startNewThread(new DeferredNotifyAppReadyCheck(waitTimeMs));
         } catch (final Exception e) {
             logger.error("Failed to start " + DeferredNotifyAppReadyCheck.class.getName() + " " + e.getMessage());
         }
@@ -2386,11 +2410,17 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private class DeferredNotifyAppReadyCheck implements Runnable {
 
+        private final long waitTimeMs;
+
+        DeferredNotifyAppReadyCheck(final long waitTimeMs) {
+            this.waitTimeMs = waitTimeMs;
+        }
+
         @Override
         public void run() {
             try {
-                logger.info("Wait for " + CapacitorUpdaterPlugin.this.appReadyTimeout + "ms, then check for notifyAppReady");
-                Thread.sleep(CapacitorUpdaterPlugin.this.appReadyTimeout);
+                logger.info("Wait for " + this.waitTimeMs + "ms, then check for notifyAppReady");
+                Thread.sleep(this.waitTimeMs);
                 CapacitorUpdaterPlugin.this.checkRevert();
                 CapacitorUpdaterPlugin.this.appReadyCheck = null;
             } catch (final InterruptedException e) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -2359,13 +2359,15 @@ public class CapacitorUpdaterPlugin extends Plugin {
             if (next != null && !next.isErrorStatus() && !next.getId().equals(current.getId())) {
                 // There is a next bundle waiting for activation
                 logger.debug("Next bundle is: " + next.getVersionName());
-                if (this.implementation.set(next) && this._reload()) {
-                    logger.info("Updated to bundle: " + next.getVersionName());
-                    this.notifyBundleSet(next);
-                    this.implementation.setNextBundle(null);
-                } else {
-                    logger.error("Update to bundle: " + next.getVersionName() + " Failed!");
-                }
+                startNewThread(() -> {
+                    if (this.implementation.set(next) && this._reload()) {
+                        logger.info("Updated to bundle: " + next.getVersionName());
+                        this.notifyBundleSet(next);
+                        this.implementation.setNextBundle(null);
+                    } else {
+                        logger.error("Update to bundle: " + next.getVersionName() + " Failed!");
+                    }
+                });
             }
         } catch (final Exception e) {
             logger.error("Error during onActivityStopped " + e.getMessage());

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -517,7 +517,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private void semaphoreWait(Number waitTime) {
         try {
-            semaphoreReady.awaitAdvanceInterruptibly(semaphoreReady.getPhase(), waitTime.longValue(), TimeUnit.SECONDS);
+            semaphoreReady.awaitAdvanceInterruptibly(semaphoreReady.getPhase(), waitTime.longValue(), TimeUnit.MILLISECONDS);
             logger.info("semaphoreReady count " + semaphoreReady.getPhase());
         } catch (InterruptedException e) {
             logger.info("semaphoreWait InterruptedException");

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -2370,7 +2370,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 });
             }
         } catch (final Exception e) {
-            logger.error("Error during onActivityStopped " + e.getMessage());
+            logger.error("Error during installNext " + e);
         }
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -335,15 +335,57 @@ public class CapacitorUpdaterUnitTest {
         }
     }
 
+    private static final class ConfigurableTimeoutCapacitorUpdaterPlugin extends TestableCapacitorUpdaterPlugin {
+
+        private final long minimumPendingBundleAppReadyTimeoutMs;
+
+        ConfigurableTimeoutCapacitorUpdaterPlugin(final long minimumPendingBundleAppReadyTimeoutMs) {
+            this.minimumPendingBundleAppReadyTimeoutMs = minimumPendingBundleAppReadyTimeoutMs;
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function, Number waitTime) {
+            return this.startNewThread(function);
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function) {
+            return new Thread();
+        }
+
+        @Override
+        protected long getMinimumPendingBundleAppReadyTimeoutMs() {
+            return this.minimumPendingBundleAppReadyTimeoutMs;
+        }
+    }
+
     private static final class FixedPathCapgoUpdater extends CapgoUpdater {
 
         private final String currentBundlePath;
         private final boolean usingBuiltin;
+        private final BundleInfo currentBundle;
 
         FixedPathCapgoUpdater(final String currentBundlePath, final boolean usingBuiltin) {
+            this(
+                currentBundlePath,
+                usingBuiltin,
+                usingBuiltin
+                    ? new BundleInfo(BundleInfo.ID_BUILTIN, "builtin", BundleStatus.SUCCESS, BundleInfo.DOWNLOADED_BUILTIN, "builtin")
+                    : new BundleInfo(
+                        "current-bundle-id",
+                        "current-bundle",
+                        BundleStatus.SUCCESS,
+                        new Date(),
+                        "current-bundle-checksum"
+                    )
+            );
+        }
+
+        FixedPathCapgoUpdater(final String currentBundlePath, final boolean usingBuiltin, final BundleInfo currentBundle) {
             super(null);
             this.currentBundlePath = currentBundlePath;
             this.usingBuiltin = usingBuiltin;
+            this.currentBundle = currentBundle;
         }
 
         @Override
@@ -354,6 +396,11 @@ public class CapacitorUpdaterUnitTest {
         @Override
         public Boolean isUsingBuiltin() {
             return this.usingBuiltin;
+        }
+
+        @Override
+        public BundleInfo getCurrentBundle() {
+            return this.currentBundle;
         }
     }
 
@@ -1045,10 +1092,42 @@ public class CapacitorUpdaterUnitTest {
             when(webView.post(any(Runnable.class))).thenReturn(true);
 
             final long start = System.nanoTime();
-            assertTrue(plugin._reload());
+            assertFalse(plugin._reload());
             final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
 
             assertTrue("Expected millisecond timeout but reload took " + elapsedMs + "ms", elapsedMs < 900);
+            verify(bridge).setServerBasePath("/tmp/capgo-bundle");
+        }
+    }
+
+    @Test
+    public void testReloadUsesExtendedTimeoutForPendingBundleValidation() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final ConfigurableTimeoutCapacitorUpdaterPlugin plugin = new ConfigurableTimeoutCapacitorUpdaterPlugin(50);
+            final Bridge bridge = mock(Bridge.class);
+            final WebView webView = mock(WebView.class);
+            final BundleInfo pendingBundle = new BundleInfo("pending-bundle-id", "2.0.0", BundleStatus.PENDING, new Date(), "abc123");
+
+            plugin.implementation = new FixedPathCapgoUpdater("/tmp/capgo-bundle", false, pendingBundle);
+            plugin.setLoggerForTesting(mock(Logger.class));
+            plugin.setBridge(bridge);
+            setPrivateField(plugin, "appReadyTimeout", 1);
+
+            when(bridge.getWebView()).thenReturn(webView);
+            when(bridge.getAppUrl()).thenReturn("https://local-app-domain.com");
+            when(webView.post(any(Runnable.class))).thenReturn(true);
+
+            final long start = System.nanoTime();
+            assertFalse(plugin._reload());
+            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+            assertTrue("Expected pending bundle timeout extension but reload took only " + elapsedMs + "ms", elapsedMs >= 40);
+            assertTrue("Expected bounded pending bundle timeout but reload took " + elapsedMs + "ms", elapsedMs < 1000);
             verify(bridge).setServerBasePath("/tmp/capgo-bundle");
         }
     }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -371,13 +371,7 @@ public class CapacitorUpdaterUnitTest {
                 usingBuiltin,
                 usingBuiltin
                     ? new BundleInfo(BundleInfo.ID_BUILTIN, "builtin", BundleStatus.SUCCESS, BundleInfo.DOWNLOADED_BUILTIN, "builtin")
-                    : new BundleInfo(
-                        "current-bundle-id",
-                        "current-bundle",
-                        BundleStatus.SUCCESS,
-                        new Date(),
-                        "current-bundle-checksum"
-                    )
+                    : new BundleInfo("current-bundle-id", "current-bundle", BundleStatus.SUCCESS, new Date(), "current-bundle-checksum")
             );
         }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -6,15 +6,18 @@ import static org.mockito.Mockito.*;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.appcompat.app.AppCompatActivity;
+import android.webkit.WebView;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginHandle;
 import io.github.g00fy2.versioncompare.Version;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import org.json.JSONArray;
 import org.junit.Test;
@@ -319,6 +322,41 @@ public class CapacitorUpdaterUnitTest {
         }
     }
 
+    private static final class NoOpThreadCapacitorUpdaterPlugin extends TestableCapacitorUpdaterPlugin {
+
+        @Override
+        public Thread startNewThread(final Runnable function, Number waitTime) {
+            return this.startNewThread(function);
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function) {
+            return new Thread();
+        }
+    }
+
+    private static final class FixedPathCapgoUpdater extends CapgoUpdater {
+
+        private final String currentBundlePath;
+        private final boolean usingBuiltin;
+
+        FixedPathCapgoUpdater(final String currentBundlePath, final boolean usingBuiltin) {
+            super(null);
+            this.currentBundlePath = currentBundlePath;
+            this.usingBuiltin = usingBuiltin;
+        }
+
+        @Override
+        public String getCurrentBundlePath() {
+            return this.currentBundlePath;
+        }
+
+        @Override
+        public Boolean isUsingBuiltin() {
+            return this.usingBuiltin;
+        }
+    }
+
     private static void invokeBackgroundDownload(final CapacitorUpdaterPlugin plugin) throws Exception {
         final Method backgroundDownload = CapacitorUpdaterPlugin.class.getDeclaredMethod("backgroundDownload");
         backgroundDownload.setAccessible(true);
@@ -368,6 +406,12 @@ public class CapacitorUpdaterUnitTest {
         );
         method.setAccessible(true);
         method.invoke(plugin, methodName, options, retriesRemaining, requestToken);
+    }
+
+    private static void setPrivateField(final Object target, final String fieldName, final Object value) throws Exception {
+        final Field field = CapacitorUpdaterPlugin.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 
     // BundleInfo Tests
@@ -976,6 +1020,36 @@ public class CapacitorUpdaterUnitTest {
             assertSame(updater.capturedState, updater.restoredState);
             assertEquals(1, plugin.restoreLiveBundleStateAfterFailedReloadCalls);
             verify(call).reject("Reload failed after applying pending bundle: builtin");
+        }
+    }
+
+    @Test
+    public void testReloadTimeoutUsesMilliseconds() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final NoOpThreadCapacitorUpdaterPlugin plugin = new NoOpThreadCapacitorUpdaterPlugin();
+            final Bridge bridge = mock(Bridge.class);
+            final WebView webView = mock(WebView.class);
+
+            plugin.implementation = new FixedPathCapgoUpdater("/tmp/capgo-bundle", false);
+            plugin.setLoggerForTesting(mock(Logger.class));
+            plugin.setBridge(bridge);
+            setPrivateField(plugin, "appReadyTimeout", 1);
+
+            when(bridge.getWebView()).thenReturn(webView);
+            when(bridge.getAppUrl()).thenReturn("https://local-app-domain.com");
+            when(webView.post(any(Runnable.class))).thenReturn(true);
+
+            final long start = System.nanoTime();
+            assertTrue(plugin._reload());
+            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+            assertTrue("Expected millisecond timeout but reload took " + elapsedMs + "ms", elapsedMs < 500);
+            verify(bridge).setServerBasePath("/tmp/capgo-bundle");
         }
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import org.json.JSONArray;
@@ -525,6 +526,20 @@ public class CapacitorUpdaterUnitTest {
                 field.setAccessible(true);
                 field.set(target, value);
                 return;
+            } catch (final NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+
+    private static Object getPrivateField(final Object target, final String fieldName) throws Exception {
+        Class<?> current = target.getClass();
+        while (current != null) {
+            try {
+                final Field field = current.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field.get(target);
             } catch (final NoSuchFieldException ignored) {
                 current = current.getSuperclass();
             }
@@ -1200,6 +1215,58 @@ public class CapacitorUpdaterUnitTest {
             assertTrue("Expected pending bundle timeout extension but reload took only " + elapsedMs + "ms", elapsedMs >= 40);
             assertTrue("Expected bounded pending bundle timeout but reload took " + elapsedMs + "ms", elapsedMs < 1000);
             verify(bridge).setServerBasePath("/tmp/capgo-bundle");
+        }
+    }
+
+    @Test
+    public void testReloadTimeoutCleansUpPendingSemaphoreParty() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final NoOpThreadCapacitorUpdaterPlugin plugin = new NoOpThreadCapacitorUpdaterPlugin();
+            final Bridge bridge = mock(Bridge.class);
+            final WebView webView = mock(WebView.class);
+
+            plugin.implementation = new FixedPathCapgoUpdater("/tmp/capgo-bundle", false);
+            plugin.setLoggerForTesting(mock(Logger.class));
+            plugin.setBridge(bridge);
+            setPrivateField(plugin, "appReadyTimeout", 1);
+
+            when(bridge.getWebView()).thenReturn(webView);
+            when(bridge.getAppUrl()).thenReturn("https://local-app-domain.com");
+            when(webView.post(any(Runnable.class))).thenReturn(true);
+
+            assertFalse(plugin._reload());
+
+            final Phaser semaphore = (Phaser) getPrivateField(plugin, "semaphoreReady");
+            assertEquals(0, semaphore.getRegisteredParties());
+        }
+    }
+
+    @Test
+    public void testNotifyAppReadyWithoutPendingReloadKeepsSemaphoreReusable() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final PluginCall call = mock(PluginCall.class);
+            final CapgoUpdater updater = mock(CapgoUpdater.class);
+            final BundleInfo bundle = new BundleInfo("current-bundle-id", "current-bundle", BundleStatus.SUCCESS, new Date(), "checksum");
+
+            plugin.implementation = updater;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            when(updater.getCurrentBundle()).thenReturn(bundle);
+
+            plugin.notifyAppReady(call);
+
+            final Phaser semaphore = (Phaser) getPrivateField(plugin, "semaphoreReady");
+            assertFalse(semaphore.isTerminated());
+            assertEquals(0, semaphore.getRegisteredParties());
+            verify(call).resolve(any(JSObject.class));
         }
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -1048,7 +1048,7 @@ public class CapacitorUpdaterUnitTest {
             assertTrue(plugin._reload());
             final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
 
-            assertTrue("Expected millisecond timeout but reload took " + elapsedMs + "ms", elapsedMs < 500);
+            assertTrue("Expected millisecond timeout but reload took " + elapsedMs + "ms", elapsedMs < 900);
             verify(bridge).setServerBasePath("/tmp/capgo-bundle");
         }
     }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -5,8 +5,8 @@ import static org.mockito.Mockito.*;
 
 import android.os.Handler;
 import android.os.Looper;
-import androidx.appcompat.app.AppCompatActivity;
 import android.webkit.WebView;
+import androidx.appcompat.app.AppCompatActivity;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3,6 +3,7 @@ package ee.forgr.capacitor_updater;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
 import android.webkit.WebView;
@@ -14,6 +15,7 @@ import com.getcapacitor.PluginHandle;
 import io.github.g00fy2.versioncompare.Version;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -86,6 +88,72 @@ public class CapacitorUpdaterUnitTest {
         @Override
         protected boolean _reload() {
             this.reloadCalled = true;
+            return true;
+        }
+    }
+
+    private static final class InstallNextDispatchPlugin extends TestableCapacitorUpdaterPlugin {
+
+        private boolean startNewThreadCalled = false;
+        private boolean reloadCalled = false;
+
+        @Override
+        public Thread startNewThread(final Runnable function, Number waitTime) {
+            return this.startNewThread(function);
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function) {
+            this.startNewThreadCalled = true;
+            function.run();
+            return new Thread();
+        }
+
+        @Override
+        protected boolean _reload() {
+            this.reloadCalled = true;
+            return true;
+        }
+    }
+
+    private static final class InstallNextCapgoUpdater extends CapgoUpdater {
+
+        private BundleInfo currentBundle = new BundleInfo(
+            BundleInfo.ID_BUILTIN,
+            "builtin",
+            BundleStatus.SUCCESS,
+            BundleInfo.DOWNLOADED_BUILTIN,
+            "builtin"
+        );
+        private BundleInfo nextBundle = new BundleInfo("next-bundle-id", "2.0.0", BundleStatus.PENDING, new Date(), "abc123");
+        private int setCalls = 0;
+        private String lastSetNextBundleId = "next-bundle-id";
+
+        InstallNextCapgoUpdater() {
+            super(null);
+        }
+
+        @Override
+        public BundleInfo getCurrentBundle() {
+            return this.currentBundle;
+        }
+
+        @Override
+        public BundleInfo getNextBundle() {
+            return this.nextBundle;
+        }
+
+        @Override
+        public Boolean set(final BundleInfo bundle) {
+            this.setCalls++;
+            this.currentBundle = bundle;
+            return true;
+        }
+
+        @Override
+        public boolean setNextBundle(final String next) {
+            this.lastSetNextBundleId = next;
+            this.nextBundle = next == null ? null : this.nextBundle;
             return true;
         }
     }
@@ -450,9 +518,18 @@ public class CapacitorUpdaterUnitTest {
     }
 
     private static void setPrivateField(final Object target, final String fieldName, final Object value) throws Exception {
-        final Field field = CapacitorUpdaterPlugin.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
+        Class<?> current = target.getClass();
+        while (current != null) {
+            try {
+                final Field field = current.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
     }
 
     // BundleInfo Tests
@@ -1123,6 +1200,34 @@ public class CapacitorUpdaterUnitTest {
             assertTrue("Expected pending bundle timeout extension but reload took only " + elapsedMs + "ms", elapsedMs >= 40);
             assertTrue("Expected bounded pending bundle timeout but reload took " + elapsedMs + "ms", elapsedMs < 1000);
             verify(bridge).setServerBasePath("/tmp/capgo-bundle");
+        }
+    }
+
+    @Test
+    public void testInstallNextDispatchesReloadOffLifecycleThread() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final InstallNextDispatchPlugin plugin = new InstallNextDispatchPlugin();
+            final InstallNextCapgoUpdater updater = new InstallNextCapgoUpdater();
+            final SharedPreferences prefs = mock(SharedPreferences.class);
+            final DelayUpdateUtils delayUpdateUtils = mock(DelayUpdateUtils.class);
+
+            plugin.implementation = updater;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            when(prefs.getString(DelayUpdateUtils.DELAY_CONDITION_PREFERENCES, "[]")).thenReturn("[]");
+            when(delayUpdateUtils.parseDelayConditions("[]")).thenReturn(new ArrayList<>());
+
+            setPrivateField(plugin, "prefs", prefs);
+            setPrivateField(plugin, "delayUpdateUtils", delayUpdateUtils);
+
+            invokePrivateVoidMethod(plugin, "installNext");
+
+            assertTrue(plugin.startNewThreadCalled);
+            assertTrue(plugin.reloadCalled);
+            assertEquals(1, updater.setCalls);
+            assertNull(updater.lastSetNextBundleId);
         }
     }
 

--- a/scripts/maestro/run-android-live-update.sh
+++ b/scripts/maestro/run-android-live-update.sh
@@ -305,6 +305,15 @@ wait_for_at_install_direct_update_ui_state() {
   local -a fragments=("$@")
   local attempt=1
   local max_attempts=2
+  local target_version=""
+  local fragment=""
+
+  for fragment in "${fragments[@]}"; do
+    if [[ "$fragment" == Current\ bundle\ version:\ * ]]; then
+      target_version="${fragment#Current bundle version: }"
+      break
+    fi
+  done
 
   while [[ $attempt -le $max_attempts ]]; do
     if wait_for_ui_state_with_timeout "$description" "$DIRECT_UPDATE_SETTLE_TIMEOUT_SECONDS" "${fragments[@]}"; then
@@ -312,6 +321,18 @@ wait_for_at_install_direct_update_ui_state() {
     fi
 
     if [[ $attempt -lt $max_attempts ]]; then
+      if [[ -n "$target_version" ]]; then
+        if ! wait_for_ui_state_with_timeout \
+          "atInstall finished preparing ${target_version} before the extra background cycle" \
+          "$DIRECT_UPDATE_SETTLE_TIMEOUT_SECONDS" \
+          'Direct update mode: atInstall' \
+          'Current bundle source: downloaded' \
+          "Next bundle version: ${target_version}" \
+          "Last completed download: ${target_version}"; then
+          echo "atInstall never exposed ${target_version} as the pending next bundle before the extra background cycle." >&2
+        fi
+      fi
+
       echo "atInstall UI did not settle for ${description}; driving one extra background cycle without force-stopping the current bundle." >&2
       background_and_resume_app "$DIRECT_UPDATE_BACKGROUND_SETTLE_SECONDS"
     fi


### PR DESCRIPTION
## What
- Fix the Android directUpdate reload path so fresh bundles are applied off the UI thread instead of blocking WebView startup.
- Correct the Android appReady timeout handling to use milliseconds, matching the documented configuration.
- Add Android unit tests covering the directUpdate scheduling path and the timeout unit regression.

## Why
- Capacitor 8 users can hit a startup freeze after a direct update because the plugin waits for notifyAppReady() on the same UI thread that must execute the WebView reload.
- The timeout unit mismatch makes failed reloads wait much longer than configured and makes startup failures harder to recover from.

## How
- Route directUpdate completion through a background plugin thread before calling the reload flow.
- Keep the existing reload behavior, but stop blocking the main thread that needs to run the posted WebView load.
- Update the phaser wait call to use milliseconds and add regression tests for both behaviors.
- Prepared with Codex.

## Testing
- bun run verify
- bun run verify:android
- ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.testScheduleDirectUpdateFinishRunsReloadOffCallerThread --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.testReloadTimeoutUsesMilliseconds

## Not Tested
- I did not run a real Capacitor app end-to-end on a physical Android device in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reload/timeouts now use millisecond timing, return explicit success/failure, and enforce a minimum wait for pending bundles — improving reload reliability and pending-bundle handling.
  * Install-on-next now runs its install+reload flow off the caller thread to avoid blocking the caller.

* **Tests**
  * Added unit tests and test helpers to validate millisecond timing, timeout behavior, and background install dispatch.

* **Chores**
  * Improved live-update test script to better detect and log the target bundle version during UI waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->