### PR TITLE
fix(android): wrap reload() PluginMethod in startNewThread (sibling of #746)

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1505,49 +1505,51 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     @PluginMethod
     public void reload(final PluginCall call) {
-        try {
-            final BundleInfo current = this.implementation.getCurrentBundle();
-            final BundleInfo next = this.implementation.getNextBundle();
+        startNewThread(() -> {
+            try {
+                final BundleInfo current = this.implementation.getCurrentBundle();
+                final BundleInfo next = this.implementation.getNextBundle();
 
-            if (next != null && !next.isErrorStatus() && !next.getId().equals(current.getId())) {
-                final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
-                final String previousBundleName = this.implementation.getCurrentBundle().getVersionName();
-                logger.info("Applying pending bundle before reload: " + next.getVersionName());
-                final boolean didApplyPendingBundle;
-                if (next.isBuiltin()) {
-                    this.implementation.prepareResetStateForTransition();
-                    didApplyPendingBundle = true;
-                } else {
-                    didApplyPendingBundle = this.implementation.stagePendingReload(next);
-                }
-                if (didApplyPendingBundle && this._reload()) {
+                if (next != null && !next.isErrorStatus() && !next.getId().equals(current.getId())) {
+                    final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
+                    final String previousBundleName = this.implementation.getCurrentBundle().getVersionName();
+                    logger.info("Applying pending bundle before reload: " + next.getVersionName());
+                    final boolean didApplyPendingBundle;
                     if (next.isBuiltin()) {
-                        this.implementation.finalizeResetTransition(previousBundleName, false);
+                        this.implementation.prepareResetStateForTransition();
+                        didApplyPendingBundle = true;
                     } else {
-                        this.implementation.finalizePendingReload(next, previousBundleName);
+                        didApplyPendingBundle = this.implementation.stagePendingReload(next);
                     }
-                    this.notifyBundleSet(next);
-                    this.implementation.setNextBundle(null);
-                    call.resolve();
+                    if (didApplyPendingBundle && this._reload()) {
+                        if (next.isBuiltin()) {
+                            this.implementation.finalizeResetTransition(previousBundleName, false);
+                        } else {
+                            this.implementation.finalizePendingReload(next, previousBundleName);
+                        }
+                        this.notifyBundleSet(next);
+                        this.implementation.setNextBundle(null);
+                        call.resolve();
+                        return;
+                    }
+                    this.implementation.restoreResetState(previousState);
+                    this.restoreLiveBundleStateAfterFailedReload();
+                    logger.error("Reload failed after applying pending bundle: " + next.getVersionName());
+                    call.reject("Reload failed after applying pending bundle: " + next.getVersionName());
                     return;
                 }
-                this.implementation.restoreResetState(previousState);
-                this.restoreLiveBundleStateAfterFailedReload();
-                logger.error("Reload failed after applying pending bundle: " + next.getVersionName());
-                call.reject("Reload failed after applying pending bundle: " + next.getVersionName());
-                return;
-            }
 
-            if (this._reload()) {
-                call.resolve();
-            } else {
-                logger.error("Reload failed");
-                call.reject("Reload failed");
+                if (this._reload()) {
+                    call.resolve();
+                } else {
+                    logger.error("Reload failed");
+                    call.reject("Reload failed");
+                }
+            } catch (final Exception e) {
+                logger.error("Could not reload " + e.getMessage());
+                call.reject("Could not reload", e);
             }
-        } catch (final Exception e) {
-            logger.error("Could not reload " + e.getMessage());
-            call.reject("Could not reload", e);
-        }
+        });
     }
 
     @PluginMethod

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -362,6 +362,17 @@ public class CapacitorUpdaterUnitTest {
     private static final class ReloadBypassCapacitorUpdaterPlugin extends TestableCapacitorUpdaterPlugin {
 
         @Override
+        public Thread startNewThread(final Runnable function, Number waitTime) {
+            return this.startNewThread(function);
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function) {
+            function.run();
+            return new Thread();
+        }
+
+        @Override
         protected boolean _reload() {
             return true;
         }
@@ -370,6 +381,17 @@ public class CapacitorUpdaterUnitTest {
     private static final class ReloadFailureCapacitorUpdaterPlugin extends TestableCapacitorUpdaterPlugin {
 
         private int restoreLiveBundleStateAfterFailedReloadCalls = 0;
+
+        @Override
+        public Thread startNewThread(final Runnable function, Number waitTime) {
+            return this.startNewThread(function);
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function) {
+            function.run();
+            return new Thread();
+        }
 
         @Override
         protected boolean _reload() {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -117,6 +117,30 @@ public class CapacitorUpdaterUnitTest {
         }
     }
 
+    private static final class ReloadDispatchPlugin extends TestableCapacitorUpdaterPlugin {
+
+        private boolean startNewThreadCalled = false;
+        private boolean reloadCalled = false;
+
+        @Override
+        public Thread startNewThread(final Runnable function, Number waitTime) {
+            return this.startNewThread(function);
+        }
+
+        @Override
+        public Thread startNewThread(final Runnable function) {
+            this.startNewThreadCalled = true;
+            function.run();
+            return new Thread();
+        }
+
+        @Override
+        protected boolean _reload() {
+            this.reloadCalled = true;
+            return true;
+        }
+    }
+
     private static final class InstallNextCapgoUpdater extends CapgoUpdater {
 
         private BundleInfo currentBundle = new BundleInfo(
@@ -156,6 +180,25 @@ public class CapacitorUpdaterUnitTest {
             this.lastSetNextBundleId = next;
             this.nextBundle = next == null ? null : this.nextBundle;
             return true;
+        }
+    }
+
+    private static final class ReloadCapgoUpdater extends CapgoUpdater {
+
+        private final BundleInfo currentBundle = new BundleInfo("current-id", "1.0.0", BundleStatus.SUCCESS, new Date(), "abc123");
+
+        ReloadCapgoUpdater() {
+            super(null);
+        }
+
+        @Override
+        public BundleInfo getCurrentBundle() {
+            return this.currentBundle;
+        }
+
+        @Override
+        public BundleInfo getNextBundle() {
+            return null;
         }
     }
 
@@ -1463,6 +1506,29 @@ public class CapacitorUpdaterUnitTest {
             assertTrue(plugin.reloadCalled);
             assertEquals(1, updater.setCalls);
             assertSame(plugin.activity, updater.activity);
+        }
+    }
+
+    @Test
+    public void testReloadUsesBackgroundDispatchPath() {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final ReloadDispatchPlugin plugin = new ReloadDispatchPlugin();
+            final ReloadCapgoUpdater updater = new ReloadCapgoUpdater();
+            final PluginCall call = mock(PluginCall.class);
+
+            plugin.implementation = updater;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            plugin.reload(call);
+
+            assertTrue(plugin.startNewThreadCalled);
+            assertTrue(plugin.reloadCalled);
+            verify(call).resolve();
         }
     }
 


### PR DESCRIPTION
Closes #753

## What
Wrap the `reload()` `@PluginMethod` body in `startNewThread(...)` so `_reload()` runs off the `CapacitorPlugins` HandlerThread.

## Why
Same root cause as #746: `_reload()` synchronously blocks the `CapacitorPlugins` HandlerThread waiting for the new bundle's `notifyAppReady()`, which is itself a `@PluginMethod` queued behind it on the same thread. Result is a 30s deadlock and a silent rollback. PR #746 fixed this for `installNext` and `scheduleDirectUpdateFinish`; the JS-driven `reload()` was the missing sibling case.

Affects all `autoUpdate: false` consumers calling `CapacitorUpdater.reload()` from JS (apply-update pill, compatibility-cascade reload, pre-mount catch-up flows).

## How
Wraps the entire body of the `reload()` `@PluginMethod` in `startNewThread(() -> { ... })`, mirroring the pattern #746 introduced for the sibling methods in the same file. Behavior inside the wrap is unchanged.

## Testing
- Added `testReloadUsesBackgroundDispatchPath` mirroring `testScheduleDirectUpdateFinishUsesBackgroundDispatchPath` from #746.
- Verified end-to-end on a real Android device with an `autoUpdate: false` app: pill-tap "apply update" no longer rolls back; pre-mount catch-up flow lands correctly.

## Not Tested
- iOS unchanged (no patch applied; iOS `_reload()` doesn't `semaphoreWait`).

## Note re: #750
Aware of the open revert proposal. This change targets a different method (`reload()`) than #746 or #750 touch, so it's conceptually independent of the directUpdate-path discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reload now executes asynchronously on a background thread. The full reload lifecycle—including bundle staging/finalization, state capture/restore, and error handling—runs in that background context, with call resolution occurring there.

* **Tests**
  * New unit tests ensure the background dispatch path is used for reload and that reload completes and resolves calls as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->