### PR TITLE
[codex] fix android v7 native reset fallback

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -482,7 +482,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         // Check if app was recently installed/updated BEFORE cleanupObsoleteVersions updates LatestVersionNative
         this.wasRecentlyInstalledOrUpdated = this.checkIfRecentlyInstalledOrUpdated();
 
-        this.implementation.autoReset();
+        this.implementation.autoReset(this.currentBuildVersion);
         if (resetWhenUpdate) {
             this.cleanupObsoleteVersions();
         }
@@ -810,7 +810,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private boolean checkIfRecentlyInstalledOrUpdated() {
         String currentVersion = this.currentBuildVersion;
-        String lastKnownVersion = this.prefs.getString("LatestNativeBuildVersion", "");
+        String lastKnownVersion = this.getStoredNativeBuildVersion();
 
         if (lastKnownVersion.isEmpty()) {
             // First time running, consider it as recently installed
@@ -932,7 +932,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         cleanupThread = startNewThread(() -> {
             synchronized (cleanupLock) {
                 try {
-                    final String previous = this.prefs.getString("LatestNativeBuildVersion", "");
+                    final String previous = this.getStoredNativeBuildVersion();
                     if (!"".equals(previous) && !Objects.equals(this.currentBuildVersion, previous)) {
                         logger.info("New native build version detected: " + this.currentBuildVersion);
                         this.implementation.reset(true);
@@ -991,6 +991,14 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 // Watchdog thread was interrupted, that's fine
             }
         });
+    }
+
+    String getStoredNativeBuildVersion() {
+        String previous = this.prefs.getString("LatestNativeBuildVersion", "");
+        if (previous == null || previous.isEmpty()) {
+            previous = this.prefs.getString("LatestVersionNative", "");
+        }
+        return previous == null ? "" : previous;
     }
 
     private void waitForCleanupIfNeeded() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -482,9 +482,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
         // Check if app was recently installed/updated BEFORE cleanupObsoleteVersions updates LatestVersionNative
         this.wasRecentlyInstalledOrUpdated = this.checkIfRecentlyInstalledOrUpdated();
 
-        this.implementation.autoReset(this.currentBuildVersion);
+        this.implementation.autoReset(this.currentBuildVersion, resetWhenUpdate);
         if (resetWhenUpdate) {
             this.cleanupObsoleteVersions();
+        } else {
+            this.persistCurrentNativeBuildVersion();
         }
 
         // Check for 'kill' delay condition on app launch
@@ -999,6 +1001,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
             previous = this.prefs.getString("LatestVersionNative", "");
         }
         return previous == null ? "" : previous;
+    }
+
+    void persistCurrentNativeBuildVersion() {
+        this.editor.putString("LatestNativeBuildVersion", this.currentBuildVersion);
+        this.editor.apply();
     }
 
     private void waitForCleanupIfNeeded() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1094,6 +1094,10 @@ public class CapgoUpdater {
     }
 
     public void autoReset(final String currentNativeBuildVersion) {
+        this.autoReset(currentNativeBuildVersion, true);
+    }
+
+    public void autoReset(final String currentNativeBuildVersion, final boolean resetWhenNativeVersionChanged) {
         final BundleInfo currentBundle = this.getCurrentBundle();
         if (!currentBundle.isBuiltin() && !this.bundleExists(currentBundle.getId())) {
             logger.info("Folder at bundle path does not exist. Triggering reset.");
@@ -1108,6 +1112,7 @@ public class CapgoUpdater {
         }
         final String previousNativeBuildVersion = this.getStoredNativeBuildVersion();
         if (
+            resetWhenNativeVersionChanged &&
             !previousNativeBuildVersion.isEmpty() &&
             currentNativeBuildVersion != null &&
             !currentNativeBuildVersion.isEmpty() &&

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1088,7 +1088,12 @@ public class CapgoUpdater {
         this.sendStats("set", bundle.getVersionName(), previousBundleName);
     }
 
+    @Deprecated
     public void autoReset() {
+        this.autoReset(this.versionCode == null ? "" : this.versionCode);
+    }
+
+    public void autoReset(final String currentNativeBuildVersion) {
         final BundleInfo currentBundle = this.getCurrentBundle();
         if (!currentBundle.isBuiltin() && !this.bundleExists(currentBundle.getId())) {
             logger.info("Folder at bundle path does not exist. Triggering reset.");
@@ -1099,7 +1104,35 @@ public class CapgoUpdater {
         if (shouldResetForForeignBundle(bundlePath, currentBundle.isBuiltin(), this.hasStoredBundleInfo(currentBundle.getId()))) {
             logger.info("Current bundle id is not one of the bundle ids stored by this plugin. Triggering reset.");
             this.reset();
+            return;
         }
+        final String previousNativeBuildVersion = this.getStoredNativeBuildVersion();
+        if (
+            !previousNativeBuildVersion.isEmpty() &&
+            currentNativeBuildVersion != null &&
+            !currentNativeBuildVersion.isEmpty() &&
+            !Objects.equals(previousNativeBuildVersion, currentNativeBuildVersion)
+        ) {
+            logger.info(
+                "Stored native build version " +
+                    previousNativeBuildVersion +
+                    " does not match current native build version " +
+                    currentNativeBuildVersion +
+                    ". Triggering reset."
+            );
+            this.reset();
+        }
+    }
+
+    private String getStoredNativeBuildVersion() {
+        if (this.prefs == null) {
+            return "";
+        }
+        String previousNativeBuildVersion = this.prefs.getString("LatestNativeBuildVersion", "");
+        if (previousNativeBuildVersion == null || previousNativeBuildVersion.isEmpty()) {
+            previousNativeBuildVersion = this.prefs.getString("LatestVersionNative", "");
+        }
+        return previousNativeBuildVersion == null ? "" : previousNativeBuildVersion;
     }
 
     public void reset() {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -669,6 +669,20 @@ public class CapacitorUpdaterUnitTest {
         }
     }
 
+    private static Path createExistingBundleDirectory(final String prefix, final String bundleId) throws Exception {
+        final Path tempDir = Files.createTempDirectory(prefix);
+        tempDir.toFile().deleteOnExit();
+        final Path versionsDir = tempDir.resolve("versions");
+        final Path bundleDir = versionsDir.resolve(bundleId);
+        Files.createDirectories(bundleDir);
+        versionsDir.toFile().deleteOnExit();
+        bundleDir.toFile().deleteOnExit();
+        final Path indexFile = bundleDir.resolve("index.html");
+        Files.createFile(indexFile);
+        indexFile.toFile().deleteOnExit();
+        return tempDir;
+    }
+
     private static void invokeBackgroundDownload(final CapacitorUpdaterPlugin plugin) throws Exception {
         final Method backgroundDownload = CapacitorUpdaterPlugin.class.getDeclaredMethod("backgroundDownload");
         backgroundDownload.setAccessible(true);
@@ -992,12 +1006,29 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void testPersistCurrentNativeBuildVersionWritesCurrentBuildKey() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+
+            setPrivateField(plugin, "editor", editor);
+            setPrivateField(plugin, "currentBuildVersion", "8");
+            when(editor.putString("LatestNativeBuildVersion", "8")).thenReturn(editor);
+
+            plugin.persistCurrentNativeBuildVersion();
+
+            verify(editor).putString("LatestNativeBuildVersion", "8");
+            verify(editor).apply();
+        }
+    }
+
+    @Test
     public void testAutoResetFallsBackToLegacyNativeBuildVersionKey() throws Exception {
         final String bundleId = "legacy-bundle-id";
-        final Path tempDir = Files.createTempDirectory("capgo-autoreset");
+        final Path tempDir = createExistingBundleDirectory("capgo-autoreset", bundleId);
         final Path bundleDir = tempDir.resolve("versions").resolve(bundleId);
-        Files.createDirectories(bundleDir);
-        Files.createFile(bundleDir.resolve("index.html"));
 
         final AutoResetNativeVersionCapgoUpdater updater = new AutoResetNativeVersionCapgoUpdater();
         final SharedPreferences prefs = mock(SharedPreferences.class);
@@ -1019,6 +1050,32 @@ public class CapacitorUpdaterUnitTest {
         updater.autoReset("8");
 
         assertTrue(updater.resetCalled);
+    }
+
+    @Test
+    public void testAutoResetSkipsNativeBuildVersionResetWhenDisabled() throws Exception {
+        final String bundleId = "legacy-bundle-id";
+        final Path tempDir = createExistingBundleDirectory("capgo-autoreset-disabled", bundleId);
+        final Path bundleDir = tempDir.resolve("versions").resolve(bundleId);
+
+        final AutoResetNativeVersionCapgoUpdater updater = new AutoResetNativeVersionCapgoUpdater();
+        final SharedPreferences prefs = mock(SharedPreferences.class);
+        final BundleInfo storedBundle = new BundleInfo(bundleId, "1.0.0", BundleStatus.SUCCESS, new Date(), "checksum");
+
+        updater.documentsDir = tempDir.toFile();
+        updater.CAP_SERVER_PATH = "server-path";
+        updater.prefs = prefs;
+
+        when(prefs.getString("server-path", "public")).thenReturn(bundleDir.toString());
+        when(prefs.getString("server-path", null)).thenReturn(bundleDir.toString());
+        when(prefs.contains(bundleId + "_info")).thenReturn(true);
+        when(prefs.getString(bundleId + "_info", "")).thenReturn(storedBundle.toString());
+        when(prefs.getString("LatestNativeBuildVersion", "")).thenReturn("");
+        when(prefs.getString("LatestVersionNative", "")).thenReturn("7");
+
+        updater.autoReset("8", false);
+
+        assertFalse(updater.resetCalled);
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -16,6 +16,8 @@ import com.getcapacitor.PluginHandle;
 import io.github.g00fy2.versioncompare.Version;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -609,6 +611,25 @@ public class CapacitorUpdaterUnitTest {
         }
     }
 
+    private static final class AutoResetNativeVersionCapgoUpdater extends CapgoUpdater {
+
+        private boolean resetCalled = false;
+
+        AutoResetNativeVersionCapgoUpdater() {
+            super(mock(Logger.class));
+        }
+
+        @Override
+        public void reset() {
+            this.resetCalled = true;
+        }
+
+        @Override
+        public void reset(final boolean internal) {
+            this.resetCalled = true;
+        }
+    }
+
     private static final class FixedPathCapgoUpdater extends CapgoUpdater {
 
         private final String currentBundlePath;
@@ -952,6 +973,52 @@ public class CapacitorUpdaterUnitTest {
         assertEquals(BundleInfo.ID_BUILTIN, bundleInfo.getId());
         assertEquals(BundleInfo.ID_BUILTIN, bundleInfo.getVersionName());
         assertEquals(BundleStatus.SUCCESS, bundleInfo.getStatus());
+    }
+
+    @Test
+    public void testGetStoredNativeBuildVersionFallsBackToLegacyKey() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final SharedPreferences prefs = mock(SharedPreferences.class);
+
+            setPrivateField(plugin, "prefs", prefs);
+            when(prefs.getString("LatestNativeBuildVersion", "")).thenReturn("");
+            when(prefs.getString("LatestVersionNative", "")).thenReturn("7");
+
+            assertEquals("7", plugin.getStoredNativeBuildVersion());
+        }
+    }
+
+    @Test
+    public void testAutoResetFallsBackToLegacyNativeBuildVersionKey() throws Exception {
+        final String bundleId = "legacy-bundle-id";
+        final Path tempDir = Files.createTempDirectory("capgo-autoreset");
+        final Path bundleDir = tempDir.resolve("versions").resolve(bundleId);
+        Files.createDirectories(bundleDir);
+        Files.createFile(bundleDir.resolve("index.html"));
+
+        final AutoResetNativeVersionCapgoUpdater updater = new AutoResetNativeVersionCapgoUpdater();
+        final SharedPreferences prefs = mock(SharedPreferences.class);
+        final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+        final BundleInfo storedBundle = new BundleInfo(bundleId, "1.0.0", BundleStatus.SUCCESS, new Date(), "checksum");
+
+        updater.documentsDir = tempDir.toFile();
+        updater.CAP_SERVER_PATH = "server-path";
+        updater.prefs = prefs;
+        updater.editor = editor;
+
+        when(prefs.getString("server-path", "public")).thenReturn(bundleDir.toString());
+        when(prefs.getString("server-path", null)).thenReturn(bundleDir.toString());
+        when(prefs.contains(bundleId + "_info")).thenReturn(true);
+        when(prefs.getString(bundleId + "_info", "")).thenReturn(storedBundle.toString());
+        when(prefs.getString("LatestNativeBuildVersion", "")).thenReturn("");
+        when(prefs.getString("LatestVersionNative", "")).thenReturn("7");
+
+        updater.autoReset("8");
+
+        assertTrue(updater.resetCalled);
     }
 
     @Test


### PR DESCRIPTION
## What
- Restore Android fallback reads from the legacy `LatestVersionNative` preference when `LatestNativeBuildVersion` is not present.
- Pass the current native build version into Android startup `autoReset()` so stale live bundles can be reset when migrating from older updater versions.
- Add Android unit coverage for the v7 legacy-key path.

## Why
- Android v7 wrote the native version to `LatestVersionNative`, while current v8 Android only checked `LatestNativeBuildVersion`.
- A user upgrading from v7 to v8 could keep running an older downloaded JS bundle instead of resetting to the new builtin bundle after a native app update.

## How
- Centralized Android native-build-version lookup to prefer `LatestNativeBuildVersion` and fall back to `LatestVersionNative`.
- Reused that lookup in install/update detection, obsolete-bundle cleanup, and `CapgoUpdater.autoReset(String)`.
- Kept the existing no-argument `autoReset()` as a deprecated compatibility wrapper.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.testGetStoredNativeBuildVersionFallsBackToLegacyKey --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.testAutoResetFallsBackToLegacyNativeBuildVersionKey`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME="$HOME/Library/Android/sdk" bun run verify:android`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME="$HOME/Library/Android/sdk" bun run verify`

## Not Tested
- Physical Android device migration from an installed v7 app to a v8 app; the regression is covered with Android unit tests using the same persisted key state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced native build version tracking for more reliable app updates.
  * Improved automatic reset detection when native components change.

* **Tests**
  * Added test coverage for native version detection and update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->