### PR TITLE
Constrain manifest file paths - Security Vulnerability

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -79,6 +79,31 @@ public class DownloadService extends Worker {
     public static final String IS_EMULATOR = "is_emulator";
     private static final String UPDATE_FILE = "update.dat";
 
+    static File resolveManifestFile(File destFolder, String fileName) throws IOException {
+        if (fileName == null || fileName.trim().isEmpty()) {
+            throw new IOException("Manifest file_name is empty");
+        }
+        if (fileName.contains("\\")) {
+            throw new IOException("Manifest file_name must use POSIX separators");
+        }
+
+        File relativeFile = new File(fileName);
+        if (relativeFile.isAbsolute()) {
+            throw new IOException("Manifest file_name must be relative");
+        }
+
+        File targetFile = new File(destFolder, fileName);
+        String canonicalTarget = targetFile.getCanonicalPath();
+        String canonicalDest = destFolder.getCanonicalPath();
+        String canonicalDestPrefix = canonicalDest.endsWith(File.separator) ? canonicalDest : canonicalDest + File.separator;
+
+        if (!canonicalTarget.startsWith(canonicalDestPrefix)) {
+            throw new IOException("Manifest file_name escapes destination directory");
+        }
+
+        return targetFile;
+    }
+
     // Shared OkHttpClient to prevent resource leaks
     protected static OkHttpClient sharedClient;
     private static String currentAppId = "unknown";
@@ -338,7 +363,14 @@ public class DownloadService extends Worker {
                 boolean isBrotli = fileName.endsWith(".br");
                 String targetFileName = isBrotli ? fileName.substring(0, fileName.length() - 3) : fileName;
 
-                File targetFile = new File(destFolder, targetFileName);
+                File targetFile;
+                try {
+                    targetFile = resolveManifestFile(destFolder, targetFileName);
+                } catch (IOException e) {
+                    logger.error("Invalid manifest file_name: " + fileName);
+                    hasError.set(true);
+                    continue;
+                }
                 String cacheBaseName = new File(isBrotli ? targetFileName : fileName).getName();
                 File cacheFile = new File(cacheFolder, finalFileHash + "_" + cacheBaseName);
                 final File legacyCacheFile = isBrotli ? new File(cacheFolder, finalFileHash + "_" + new File(fileName).getName()) : null;

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -15,6 +15,8 @@ import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginHandle;
 import io.github.g00fy2.versioncompare.Version;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -58,6 +60,34 @@ public class CapacitorUpdaterUnitTest {
         JSObject getNotifiedEventPayload(final String eventName) {
             return this.notifiedEventPayloads.get(eventName);
         }
+    }
+
+    @Test
+    public void resolveManifestFileAllowsNestedRelativePaths() throws Exception {
+        final Path root = Files.createTempDirectory("capgo-manifest-safe");
+        final File dest = root.resolve("bundle").toFile();
+
+        final File resolved = DownloadService.resolveManifestFile(dest, "assets/index.html");
+
+        assertEquals(dest.toPath().resolve("assets/index.html").toFile().getCanonicalPath(), resolved.getCanonicalPath());
+    }
+
+    @Test
+    public void resolveManifestFileRejectsTraversalPaths() throws Exception {
+        final Path root = Files.createTempDirectory("capgo-manifest-traversal");
+        final File dest = root.resolve("bundle").toFile();
+
+        assertThrows(IOException.class, () -> DownloadService.resolveManifestFile(dest, "../escape.txt"));
+        assertThrows(IOException.class, () -> DownloadService.resolveManifestFile(dest, "assets/../../escape.txt"));
+    }
+
+    @Test
+    public void resolveManifestFileRejectsAbsoluteAndWindowsPaths() throws Exception {
+        final Path root = Files.createTempDirectory("capgo-manifest-absolute");
+        final File dest = root.resolve("bundle").toFile();
+
+        assertThrows(IOException.class, () -> DownloadService.resolveManifestFile(dest, root.resolve("escape.txt").toString()));
+        assertThrows(IOException.class, () -> DownloadService.resolveManifestFile(dest, "assets\\index.html"));
     }
 
     private static final class ImmediateThreadCapacitorUpdaterPlugin extends TestableCapacitorUpdaterPlugin {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -874,6 +874,34 @@ import UIKit
         return actualHash == expectedHash
     }
 
+    func resolveManifestDestinationPath(fileName: String, isBrotli: Bool, destFolder: URL) throws -> URL {
+        let destFileName = isBrotli ? String(fileName.dropLast(3)) : fileName
+        let trimmedFileName = destFileName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedFileName.isEmpty else {
+            throw NSError(domain: "ManifestEntryError", code: 3, userInfo: [NSLocalizedDescriptionKey: "Manifest file_name is empty"])
+        }
+
+        guard !trimmedFileName.contains("\\") else {
+            throw NSError(domain: "ManifestEntryError", code: 4, userInfo: [NSLocalizedDescriptionKey: "Manifest file_name must use POSIX separators"])
+        }
+
+        guard !(trimmedFileName as NSString).isAbsolutePath else {
+            throw NSError(domain: "ManifestEntryError", code: 5, userInfo: [NSLocalizedDescriptionKey: "Manifest file_name must be relative"])
+        }
+
+        let destFilePath = destFolder.appendingPathComponent(trimmedFileName)
+        let canonicalPath = destFilePath.standardizedFileURL.path
+        let canonicalDir = destFolder.standardizedFileURL.path
+        let canonicalDirPrefix = canonicalDir.hasSuffix("/") ? canonicalDir : "\(canonicalDir)/"
+
+        guard canonicalPath.hasPrefix(canonicalDirPrefix) else {
+            throw NSError(domain: "ManifestEntryError", code: 6, userInfo: [NSLocalizedDescriptionKey: "Manifest file_name escapes destination directory"])
+        }
+
+        return destFilePath
+    }
+
     public func downloadManifest(manifest: [ManifestEntry], version: String, sessionKey: String, link: String? = nil, comment: String? = nil) throws -> BundleInfo {
         let id = self.randomString(length: 10)
         logger.info("downloadManifest start \(id)")
@@ -972,7 +1000,19 @@ import UIKit
             let legacyCacheFilePath: URL? = isBrotli ? cacheFolder.appendingPathComponent("\(finalFileHash)_\(fileNameWithoutPath)") : nil
 
             let destFileName = isBrotli ? String(fileName.dropLast(3)) : fileName
-            let destFilePath = destFolder.appendingPathComponent(destFileName)
+            let destFilePath: URL
+            do {
+                destFilePath = try resolveManifestDestinationPath(fileName: fileName, isBrotli: isBrotli, destFolder: destFolder)
+            } catch {
+                errorLock.lock()
+                if downloadError == nil {
+                    downloadError = error
+                }
+                errorLock.unlock()
+                hasError.value = true
+                logger.error("Invalid manifest file_name: \(fileName)")
+                continue
+            }
             let builtinFilePath = builtinFolder.appendingPathComponent(fileName)
 
             // Create parent directories synchronously (before operations start)

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -1510,6 +1510,37 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertNotNil(updater)
     }
 
+    func testResolveManifestDestinationPathAllowsNestedRelativePaths() throws {
+        let updater = CapgoUpdater()
+        let destFolder = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("bundle")
+
+        let resolved = try updater.resolveManifestDestinationPath(fileName: "assets/index.html", isBrotli: false, destFolder: destFolder)
+
+        XCTAssertEqual(resolved.standardizedFileURL.path, destFolder.appendingPathComponent("assets/index.html").standardizedFileURL.path)
+    }
+
+    func testResolveManifestDestinationPathRejectsTraversalPaths() {
+        let updater = CapgoUpdater()
+        let destFolder = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("bundle")
+
+        XCTAssertThrowsError(try updater.resolveManifestDestinationPath(fileName: "../escape.txt", isBrotli: false, destFolder: destFolder))
+        XCTAssertThrowsError(try updater.resolveManifestDestinationPath(fileName: "assets/../../escape.txt", isBrotli: false, destFolder: destFolder))
+    }
+
+    func testResolveManifestDestinationPathRejectsAbsoluteAndWindowsPaths() {
+        let updater = CapgoUpdater()
+        let destFolder = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("bundle")
+
+        XCTAssertThrowsError(try updater.resolveManifestDestinationPath(fileName: "/tmp/escape.txt", isBrotli: false, destFolder: destFolder))
+        XCTAssertThrowsError(try updater.resolveManifestDestinationPath(fileName: "assets\\index.html", isBrotli: false, destFolder: destFolder))
+    }
+
     // MARK: - Performance Tests
 
     func testPerformanceStringTrim() {


### PR DESCRIPTION
## Summary

This PR constrains manifest download `file_name` paths to the intended bundle destination directory on Android and iOS.

Changes include:
- Android: validate manifest target paths before creating parent directories or writing files.
- iOS: validate manifest destination paths before copy/download/cache operations.
- Regression tests for allowed nested relative paths.
- Regression tests for rejected `../` traversal, nested traversal, absolute paths, and Windows-style separators.

## Root cause

Manifest `file_name` values were used to construct filesystem destinations without first enforcing that the canonical resolved path stayed inside the destination bundle directory. File checksums validate content integrity, but they do not constrain where a valid file is written.

## Restored invariant

Each manifest file path must be non-empty, relative, POSIX-separated, and canonically inside the bundle destination directory.

## Validation

- `git diff --check` passes.
- Local invariant checks confirmed `assets/index.html` is accepted while `../escape.txt`, `assets/../../escape.txt`, absolute paths, and Windows separators are rejected.

Full Android/iOS test execution was not possible in my local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced manifest file path validation across Android and iOS platforms. Invalid manifest entries—including those with absolute paths, directory traversal sequences, or Windows-style separators—are now properly rejected and marked as failed during downloads.

* **Tests**
  * Added comprehensive unit tests validating manifest path validation behavior on both platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/767)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

/bounty