### PR TITLE
fix(android): notify breaking update listeners

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/ci/install-bun.sh
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Install dependencies
         id: install_code
         run: bun i
@@ -66,6 +70,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/ci/install-bun.sh
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Install dependencies
         id: install_code
         run: bun i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         id: test_ios
         run: bun run test:ios
   maestro_android_example_app:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
     strategy:
@@ -253,7 +253,7 @@ jobs:
         id: verify_code
         run: bun run verify:web
   maestro_android_scenarios:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     name: maestro_android / ${{ matrix.scenario }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           script: >-
             CAPGO_MAESTRO_FLOW_TIMEOUT_SECONDS=720
-            CAPGO_MAESTRO_FLOW_RETRIES=1
+            CAPGO_MAESTRO_FLOW_RETRIES=2
             CAPGO_MAESTRO_SPLIT_RETRIES=1
             CAPGO_MAESTRO_UI_STATE_TIMEOUT_SECONDS=180
             CAPGO_MAESTRO_DIRECT_UPDATE_SETTLE_TIMEOUT_SECONDS=180

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -218,6 +218,26 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
     }
 
+    private boolean shouldNotifyBreakingEvents(final JSObject response) {
+        if (response == null) {
+            return false;
+        }
+
+        if (response.optBoolean("breaking", false)) {
+            return true;
+        }
+
+        final String error = response.optString("error", "");
+        final String message = response.optString("message", "");
+        return "disable_auto_update_to_major".equals(error) || "store_update_required".equals(message);
+    }
+
+    private void notifyBreakingEventsIfNeeded(final JSObject response, final String version) {
+        if (shouldNotifyBreakingEvents(response)) {
+            notifyBreakingEvents(version);
+        }
+    }
+
     private void persistLastFailedBundle(BundleInfo bundle) {
         if (this.prefs == null) {
             return;
@@ -2183,7 +2203,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
                     String error = jsRes.has("error") ? jsRes.getString("error") : "";
                     String errorMessage = jsRes.has("message") ? jsRes.getString("message") : "server did not provide a message";
                     String kind = CapacitorUpdaterPlugin.this.getUpdateResponseKind(jsRes.has("kind") ? jsRes.getString("kind") : null);
+                    String latestVersion = jsRes.has("version") ? jsRes.getString("version") : "";
                     jsRes.put("kind", kind);
+                    CapacitorUpdaterPlugin.this.notifyBreakingEventsIfNeeded(jsRes, latestVersion);
                     if ("failed".equals(kind)) {
                         logger.error("getLatest failed with error: " + error + ", message: " + errorMessage);
                         call.reject(error.isEmpty() ? errorMessage : error);
@@ -2196,6 +2218,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
                     }
                     return;
                 } else if (jsRes.has("message")) {
+                    String latestVersion = jsRes.has("version") ? jsRes.getString("version") : "";
+                    CapacitorUpdaterPlugin.this.notifyBreakingEventsIfNeeded(jsRes, latestVersion);
                     call.reject(jsRes.getString("message"));
                     return;
                 } else {
@@ -2682,6 +2706,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
                         String kind = CapacitorUpdaterPlugin.this.getUpdateResponseKind(jsRes.has("kind") ? jsRes.getString("kind") : null);
                         String latestVersion = jsRes.has("version") ? jsRes.getString("version") : current.getVersionName();
                         CapacitorUpdaterPlugin.this.notifyUpdateCheckResult(kind, error, errorMessage, statusCode, latestVersion, current);
+                        CapacitorUpdaterPlugin.this.notifyBreakingEventsIfNeeded(
+                            jsRes,
+                            jsRes.has("version") ? jsRes.getString("version") : ""
+                        );
 
                         if ("up_to_date".equals(kind)) {
                             logger.info("No new version available");
@@ -2744,6 +2772,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                         }
 
                         if (!jsRes.has("url") || !CapacitorUpdaterPlugin.this.isValidURL(jsRes.getString("url"))) {
+                            CapacitorUpdaterPlugin.this.notifyBreakingEventsIfNeeded(jsRes, latestVersionName);
                             logger.error("Error no url or wrong format");
                             CapacitorUpdaterPlugin.this.endBackGroundTaskWithNotif(
                                 "Error no url or wrong format",

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -337,6 +337,36 @@ public class CapacitorUpdaterUnitTest {
         }
     }
 
+    private static final class BreakingNoUrlCapgoUpdater extends CapgoUpdater {
+
+        private final BundleInfo currentBundle = new BundleInfo("current-id", "1.0.0", BundleStatus.SUCCESS, new Date(), "abc123");
+        private boolean downloadFailStatsCalled = false;
+
+        BreakingNoUrlCapgoUpdater() {
+            super(null);
+        }
+
+        @Override
+        public void getLatest(final String updateUrl, final String channel, final Callback callback) {
+            final Map<String, Object> response = new HashMap<>();
+            response.put("version", "1.0.17");
+            response.put("breaking", true);
+            response.put("message", "store_update_required");
+            response.put("statusCode", 200);
+            callback.callback(response);
+        }
+
+        @Override
+        public BundleInfo getCurrentBundle() {
+            return this.currentBundle;
+        }
+
+        @Override
+        public void sendStats(final String action, final String versionName, final String oldVersionName) {
+            this.downloadFailStatsCalled = "download_fail".equals(action);
+        }
+    }
+
     private static final class FailedUpdateCapgoUpdater extends CapgoUpdater {
 
         private final BundleInfo currentBundle = new BundleInfo("current-id", "1.0.0", BundleStatus.SUCCESS, new Date(), "abc123");
@@ -1846,6 +1876,55 @@ public class CapacitorUpdaterUnitTest {
             assertEquals("1.0.0", payload.getString("version"));
             assertFalse(plugin.hasNotifiedEvent("downloadFailed"));
             assertFalse(updater.sendStatsCalled);
+        }
+    }
+
+    @Test
+    public void testBreakingNoUrlUpdateCheckNotifiesBreakingListeners() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            ImmediateThreadCapacitorUpdaterPlugin plugin = new ImmediateThreadCapacitorUpdaterPlugin();
+            BreakingNoUrlCapgoUpdater updater = new BreakingNoUrlCapgoUpdater();
+
+            plugin.implementation = updater;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            invokeBackgroundDownload(plugin);
+
+            assertTrue(plugin.hasNotifiedEvent("breakingAvailable"));
+            assertTrue(plugin.hasNotifiedEvent("majorAvailable"));
+            assertEquals("1.0.17", plugin.getNotifiedEventPayload("breakingAvailable").getString("version"));
+            assertEquals("1.0.17", plugin.getNotifiedEventPayload("majorAvailable").getString("version"));
+            assertTrue(plugin.hasNotifiedEvent("downloadFailed"));
+            assertTrue(updater.downloadFailStatsCalled);
+        }
+    }
+
+    @Test
+    public void testGetLatestBreakingResponseNotifiesBreakingListeners() {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            ImmediateThreadCapacitorUpdaterPlugin plugin = new ImmediateThreadCapacitorUpdaterPlugin();
+            PluginCall call = mock(PluginCall.class);
+
+            plugin.implementation = new BreakingNoUrlCapgoUpdater();
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            plugin.getLatest(call);
+
+            assertTrue(plugin.hasNotifiedEvent("breakingAvailable"));
+            assertTrue(plugin.hasNotifiedEvent("majorAvailable"));
+            assertEquals("1.0.17", plugin.getNotifiedEventPayload("breakingAvailable").getString("version"));
+            assertEquals("1.0.17", plugin.getNotifiedEventPayload("majorAvailable").getString("version"));
+            verify(call).reject("store_update_required");
         }
     }
 


### PR DESCRIPTION
## What
- Fire `breakingAvailable` and legacy `majorAvailable` when Android receives a self-hosted breaking update response.
- Cover both automatic background checks and manual `getLatest()` responses.
- Add regression coverage for a `breaking: true` response with `message: "store_update_required"` and no download URL.

## Why
Fixes #766.

The Android helper for breaking/major update events existed, but Android did not reach it for self-hosted responses that intentionally omit a bundle URL and instead return `breaking: true` / `store_update_required`. Apps could not react to the documented event and route users to the store update flow.

## How
- Detect `breaking: true`, `store_update_required`, and `disable_auto_update_to_major` responses.
- Notify breaking listeners only when a response version is available.
- Preserve the existing no-url failure behavior for responses that cannot be downloaded.

## Testing
- `git diff --check`
- `cd android && .\gradlew.bat testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.testBreakingNoUrlUpdateCheckNotifiesBreakingListeners --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.testGetLatestBreakingResponseNotifiesBreakingListeners`

## Not Tested
- iOS runtime behavior. The issue reports Android reproduction only.
- End-to-end device validation against a self-hosted update server.

Note: I also ran the full `CapacitorUpdaterUnitTest` class after installing local Android tooling; the two new regression tests passed, but two unrelated existing tests failed with `CapgoUpdater.getBundleInfo` null handling in the auto-reset tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breaking/major update notifications now fire consistently across foreground and background checks and record related failure stats.

* **Tests**
  * Added unit tests validating breaking-update handling, notification emission, and stats for missing-update scenarios.

* **Refactor**
  * Centralized gating for breaking-event notifications so it runs uniformly across update flows.

* **Chores**
  * CI: explicit Node.js setup and increased test timeouts; packaging script conditionally initializes mobile platform projects before sync/build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/769)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->