### PR TITLE
test: use direct download in manifest smoke flows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         id: test_ios
         run: bun run native:test:ios
   maestro_android_example_app:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
     strategy:

--- a/.maestro/ios/manual-manifest-flow.yaml
+++ b/.maestro/ios/manual-manifest-flow.yaml
@@ -40,17 +40,17 @@ appId: app.capgo.updater
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: 'Quick observe downloaded bundle'
+      text: 'Quick download latest bundle'
     direction: DOWN
     timeout: 30000
     centerElement: true
     visibilityPercentage: 1
     waitToSettleTimeoutMs: 500
 - tapOn:
-    text: 'Quick observe downloaded bundle'
+    text: 'Quick download latest bundle'
     retryTapIfNoChange: true
 - extendedWaitUntil:
-    visible: '.*(Marker: download-store:success|M:download-store:success).*'
+    visible: '.*(Marker: download:success|M:download:success).*'
     timeout: 120000
 - scrollUntilVisible:
     element:
@@ -117,16 +117,16 @@ appId: app.capgo.updater
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: 'Quick observe downloaded bundle'
+      text: 'Quick download latest bundle'
     direction: DOWN
     timeout: 30000
     centerElement: false
     visibilityPercentage: 1
 - tapOn:
-    text: 'Quick observe downloaded bundle'
+    text: 'Quick download latest bundle'
     retryTapIfNoChange: true
 - extendedWaitUntil:
-    visible: '.*(Marker: download-store:success|M:download-store:success).*'
+    visible: '.*(Marker: download:success|M:download:success).*'
     timeout: 120000
 - scrollUntilVisible:
     element:

--- a/.maestro/manual-manifest-flow.yaml
+++ b/.maestro/manual-manifest-flow.yaml
@@ -44,18 +44,18 @@ appId: app.capgo.updater
     timeout: 30000
 - scrollUntilVisible:
     element:
-      id: 'quick-action-download-latest-bundle-observe-store'
+      id: 'quick-action-download-latest-bundle'
     direction: DOWN
     timeout: 30000
     centerElement: true
     visibilityPercentage: 1
     waitToSettleTimeoutMs: 500
 - tapOn:
-    id: 'quick-action-download-latest-bundle-observe-store'
+    id: 'quick-action-download-latest-bundle'
     retryTapIfNoChange: true
     waitToSettleTimeoutMs: 500
 - extendedWaitUntil:
-    visible: '.*(Marker: download-store:success|M:download-store:success).*'
+    visible: '.*(Marker: download:success|M:download:success).*'
     timeout: 120000
 - scrollUntilVisible:
     element:
@@ -122,16 +122,16 @@ appId: app.capgo.updater
     timeout: 30000
 - scrollUntilVisible:
     element:
-      id: 'quick-action-download-latest-bundle-observe-store'
+      id: 'quick-action-download-latest-bundle'
     direction: DOWN
     timeout: 30000
     centerElement: false
     visibilityPercentage: 1
 - tapOn:
-    id: 'quick-action-download-latest-bundle-observe-store'
+    id: 'quick-action-download-latest-bundle'
     waitToSettleTimeoutMs: 500
 - extendedWaitUntil:
-    visible: '.*(Marker: download-store:success|M:download-store:success).*'
+    visible: '.*(Marker: download:success|M:download:success).*'
     timeout: 120000
 - scrollUntilVisible:
     element:

--- a/.maestro/manual-manifest-v1-flow.yaml
+++ b/.maestro/manual-manifest-v1-flow.yaml
@@ -45,18 +45,18 @@ appId: app.capgo.updater
     timeout: 30000
 - scrollUntilVisible:
     element:
-      id: 'quick-action-download-latest-bundle-observe-store'
+      id: 'quick-action-download-latest-bundle'
     direction: DOWN
     timeout: 30000
     centerElement: true
     visibilityPercentage: 1
     waitToSettleTimeoutMs: 500
 - tapOn:
-    id: 'quick-action-download-latest-bundle-observe-store'
+    id: 'quick-action-download-latest-bundle'
     retryTapIfNoChange: true
     waitToSettleTimeoutMs: 500
 - extendedWaitUntil:
-    visible: '.*(Marker: download-store:success|M:download-store:success).*'
+    visible: '.*(Marker: download:success|M:download:success).*'
     timeout: 120000
 - scrollUntilVisible:
     element:

--- a/.maestro/manual-manifest-v2-flow.yaml
+++ b/.maestro/manual-manifest-v2-flow.yaml
@@ -22,16 +22,16 @@ appId: app.capgo.updater
     timeout: 30000
 - scrollUntilVisible:
     element:
-      id: 'quick-action-download-latest-bundle-observe-store'
+      id: 'quick-action-download-latest-bundle'
     direction: DOWN
     timeout: 30000
     centerElement: false
     visibilityPercentage: 1
 - tapOn:
-    id: 'quick-action-download-latest-bundle-observe-store'
+    id: 'quick-action-download-latest-bundle'
     waitToSettleTimeoutMs: 500
 - extendedWaitUntil:
-    visible: '.*(Marker: download-store:success|M:download-store:success).*'
+    visible: '.*(Marker: download:success|M:download:success).*'
     timeout: 120000
 - scrollUntilVisible:
     element:

--- a/scripts/maestro/run-ios-live-update.sh
+++ b/scripts/maestro/run-ios-live-update.sh
@@ -125,6 +125,21 @@ PY
   return $?
 }
 
+flow_has_retryable_failure() {
+  local output_file="$1"
+  local debug_log="$2"
+
+  if grep -Eq "$FLOW_RETRY_PATTERN" "$output_file"; then
+    return 0
+  fi
+
+  if [[ -f "$debug_log" ]] && grep -Eq "$FLOW_RETRY_PATTERN" "$debug_log"; then
+    return 0
+  fi
+
+  return 1
+}
+
 resolve_path() {
   python3 - "$1" <<'PY'
 import os
@@ -357,7 +372,9 @@ run_flow() {
       echo "Maestro flow timed out after ${MAESTRO_TIMEOUT_SECONDS} seconds: ${flow_path}" >&2
     fi
 
-    if [[ $attempt -lt $MAESTRO_TEST_RETRIES ]] && { [[ $status -eq 124 ]] || grep -Eq "$FLOW_RETRY_PATTERN" "$output_file"; }; then
+    if [[ $attempt -lt $MAESTRO_TEST_RETRIES ]] && {
+      [[ $status -eq 124 ]] || flow_has_retryable_failure "$output_file" "$flow_results_dir/debug/maestro.log"
+    }; then
       echo "Retrying iOS Maestro flow after simulator/XCTest instability: ${flow_path}" >&2
       rm -f "$output_file"
       xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true

--- a/scripts/maestro/run-ios-live-update.sh
+++ b/scripts/maestro/run-ios-live-update.sh
@@ -17,6 +17,7 @@ export MAESTRO_CLI_NO_ANALYTICS="${MAESTRO_CLI_NO_ANALYTICS:-1}"
 export MAESTRO_DRIVER_STARTUP_TIMEOUT="${MAESTRO_DRIVER_STARTUP_TIMEOUT:-600000}"
 MAESTRO_TEST_RETRIES="${CAPGO_MAESTRO_TEST_RETRIES:-3}"
 FLOW_RETRY_PATTERN="iOS driver not ready in time|Failed to connect to /127\\.0\\.0\\.1:[0-9]+|Connection refused|Broken pipe|No visible element found|Request for viewHierarchy failed, because of unknown reason|XCTestDriver request failed\\. Status code: 500, path: viewHierarchy|Application .* is not running|Detected app crash|App crashed or stopped|failed to terminate dev\\.mobile\\.maestro-driver-iosUITests\\.xctrunner|found nothing to terminate|Assertion is false: \"@capgo/capacitor-updater\" is visible|Assertion is false: \".*Harness: ready.*\" is visible|Marker: download:success|Marker: download-store:success"
+DEBUG_LOG_FAILURE_PATTERN="fail|Fail|failure|Failure|error|Error|Exception|CommandFailed|Assertion is false|crash|Crash"
 SCENARIO_SEQUENCE=(deferred always legacy-true at-install on-launch manual-zip manual-zip-config-guards manual-manifest)
 APP_MARKETING_VERSION=""
 readonly ASSERT_AUTO_UPDATE_ENABLED='Auto update enabled: true'
@@ -125,6 +126,20 @@ PY
   return $?
 }
 
+debug_log_has_retryable_failure() {
+  local debug_log="$1"
+
+  awk -v failure_pattern="$DEBUG_LOG_FAILURE_PATTERN" -v retry_pattern="$FLOW_RETRY_PATTERN" '
+    $0 ~ failure_pattern && $0 ~ retry_pattern {
+      found = 1
+      exit
+    }
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$debug_log"
+}
+
 flow_has_retryable_failure() {
   local output_file="$1"
   local debug_log="$2"
@@ -133,7 +148,7 @@ flow_has_retryable_failure() {
     return 0
   fi
 
-  if [[ -f "$debug_log" ]] && grep -Eq "$FLOW_RETRY_PATTERN" "$debug_log"; then
+  if [[ -f "$debug_log" ]] && debug_log_has_retryable_failure "$debug_log"; then
     return 0
   fi
 


### PR DESCRIPTION
## What
- Replace the manual-manifest Maestro store-observation download action with the direct download action.
- Update the related assertions from download-store success to download success on Android and iOS manifest flows.

## Why
- PR #770 removed store-update coverage from these smoke paths, but the iOS manual-manifest flow still waited for the old store marker in CI.

## How
- Kept the manifest flow behavior the same after download: queue the downloaded bundle, reload, and assert the expected manifest version.
- Applied the same marker/action change to the split manifest flows so future isolated runs use the same path.

## Testing
- bunx prettier --check .maestro/ios/manual-manifest-flow.yaml .maestro/manual-manifest-flow.yaml .maestro/manual-manifest-v1-flow.yaml .maestro/manual-manifest-v2-flow.yaml
- bun run native:contract
- git diff --check origin/main...HEAD

## Not Tested
- Local Maestro execution, because the local machine does not have the Maestro CLI installed. CI will run the affected simulator/emulator flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Unified automated flows to use a single "download latest bundle" action and assert a general download success marker for bundle verification across platforms.
* **Chores**
  * Improved live-update runner reliability by expanding retry detection to include debug output.
  * Increased CI job timeout to reduce spurious test timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/771)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->