### PR TITLE
fix(ios): notify breaking update listeners

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1025,6 +1025,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             if let error = res.error, !error.isEmpty {
                 let responseKind = self.updateResponseKind(kind: res.kind)
                 res.kind = responseKind
+                self.notifyBreakingEventsIfNeeded(response: res, version: res.version)
                 if responseKind == "failed" {
                     self.rejectCall(call, message: error)
                 } else {
@@ -1036,6 +1037,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             } else if let kind = res.kind, !kind.isEmpty {
                 let responseKind = self.updateResponseKind(kind: kind)
                 res.kind = responseKind
+                self.notifyBreakingEventsIfNeeded(response: res, version: res.version)
                 if responseKind != "failed" {
                     if res.version.isEmpty {
                         res.version = self.implementation.getCurrentBundle().getVersionName()
@@ -1045,6 +1047,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                     self.rejectCall(call, message: res.message ?? "server did not provide a message")
                 }
             } else if let message = res.message, !message.isEmpty {
+                self.notifyBreakingEventsIfNeeded(response: res, version: res.version)
                 self.rejectCall(call, message: message)
             } else {
                 self.resolveCall(call, data: res.toDict())
@@ -1821,6 +1824,20 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.notifyListeners("majorAvailable", data: payload)
     }
 
+    private func shouldNotifyBreakingEvents(response: AppVersion) -> Bool {
+        if response.breaking == true {
+            return true
+        }
+
+        return response.error == "disable_auto_update_to_major" || response.message == "store_update_required"
+    }
+
+    private func notifyBreakingEventsIfNeeded(response: AppVersion, version: String) {
+        if self.shouldNotifyBreakingEvents(response: response) {
+            self.notifyBreakingEvents(version: version)
+        }
+    }
+
     static func normalizedUpdateResponseKind(kind: String?) -> String {
         if let kind, ["up_to_date", "blocked", "failed"].contains(kind) {
             return kind
@@ -1851,6 +1868,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             "version": latestVersionName,
             "bundle": current.toJSON()
         ])
+        self.notifyBreakingEventsIfNeeded(response: res, version: res.version)
 
         if responseKind == "up_to_date" {
             self.logger.info("No new version available")
@@ -2017,17 +2035,18 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             }
             let sessionKey = res.sessionKey ?? ""
+            let latestVersionName = res.version
             guard let downloadUrl = URL(string: res.url) else {
+                self.notifyBreakingEventsIfNeeded(response: res, version: latestVersionName)
                 self.logger.error("Error no url or wrong format")
                 self.endBackGroundTaskWithNotif(
                     msg: "Error no url or wrong format",
-                    latestVersionName: res.version,
+                    latestVersionName: latestVersionName,
                     current: current,
                     plannedDirectUpdate: plannedDirectUpdate
                 )
                 return
             }
-            let latestVersionName = res.version
             if latestVersionName != "" && current.getVersionName() != latestVersionName {
                 do {
                     self.logger.info("New bundle: \(latestVersionName) found. Current is: \(current.getVersionName()). \(messageUpdate)")

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1834,7 +1834,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func notifyBreakingEventsIfNeeded(response: AppVersion, version: String) {
         if self.shouldNotifyBreakingEvents(response: response) {
-            self.notifyBreakingEvents(version: version)
+            let eventVersion = version.isEmpty ? self.implementation.getCurrentBundle().getVersionName() : version
+            self.notifyBreakingEvents(version: eventVersion)
         }
     }
 

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -5,9 +5,13 @@ import Version
 
 private class TestableCapacitorUpdaterPlugin: CapacitorUpdaterPlugin {
     private(set) var notifiedEventNames: [String] = []
+    private(set) var notifiedEventPayloads: [String: [String: Any]] = [:]
 
     override func notifyListeners(_ eventName: String, data: [String: Any]?, retainUntilConsumed retain: Bool) {
         notifiedEventNames.append(eventName)
+        if let data {
+            notifiedEventPayloads[eventName] = data
+        }
     }
 
     override func endBackGroundTask() {
@@ -1256,6 +1260,42 @@ class CapacitorUpdaterTests: XCTestCase {
         wait(for: [rejected], timeout: 10)
     }
 
+    func testGetLatestBreakingResponseNotifiesBreakingListeners() throws {
+        let latest = AppVersion()
+        latest.version = "2.0.0"
+        latest.breaking = true
+        latest.message = "store_update_required"
+        latest.statusCode = 200
+
+        let breakingImplementation = FreshDownloadCapgoUpdater()
+        breakingImplementation.latestResponse = latest
+
+        let testPlugin = TestableCapacitorUpdaterPlugin()
+        testPlugin.implementation = breakingImplementation
+        testPlugin.setUpdateUrlForTesting("https://example.com/channel")
+
+        let rejected = expectation(description: "getLatest rejects store update response")
+        let call = try XCTUnwrap(CAPPluginCall(
+            callbackId: "get-latest-breaking-response-test",
+            options: [:],
+            success: { _, _ in
+                XCTFail("getLatest should reject store update responses")
+            },
+            error: { error in
+                XCTAssertEqual(error?.message, "store_update_required")
+                rejected.fulfill()
+            }
+        ))
+
+        testPlugin.getLatest(call)
+        wait(for: [rejected], timeout: 10)
+
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("breakingAvailable"))
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("majorAvailable"))
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["breakingAvailable"]?["version"] as? String, "2.0.0")
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["majorAvailable"]?["version"] as? String, "2.0.0")
+    }
+
     func testBlockedUpdateCheckDoesNotNotifyDownloadFailed() {
         let current = BundleInfo(
             id: "test-id",
@@ -1265,6 +1305,7 @@ class CapacitorUpdaterTests: XCTestCase {
             checksum: "abc123"
         )
         let latest = AppVersion()
+        latest.version = "2.0.0"
         latest.error = "disable_auto_update_to_major"
         latest.kind = "blocked"
         latest.message = "Cannot upgrade major version"
@@ -1282,8 +1323,44 @@ class CapacitorUpdaterTests: XCTestCase {
 
         XCTAssertTrue(testPlugin.notifiedEventNames.contains("noNeedUpdate"))
         XCTAssertTrue(testPlugin.notifiedEventNames.contains("updateCheckResult"))
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("breakingAvailable"))
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("majorAvailable"))
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["breakingAvailable"]?["version"] as? String, "2.0.0")
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["majorAvailable"]?["version"] as? String, "2.0.0")
         XCTAssertFalse(testPlugin.notifiedEventNames.contains("downloadFailed"))
         XCTAssertFalse(blockedImplementation.sentStatsActions.contains("download_fail"))
+    }
+
+    func testBreakingNoUrlUpdateCheckNotifiesBreakingListeners() {
+        let current = BundleInfo(
+            id: "test-id",
+            version: "1.0.0",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "abc123"
+        )
+        let latest = AppVersion()
+        latest.version = "2.0.0"
+        latest.breaking = true
+        latest.message = "store_update_required"
+        latest.statusCode = 200
+
+        let breakingImplementation = FreshDownloadCapgoUpdater()
+        breakingImplementation.currentBundleValue = current
+        breakingImplementation.latestResponse = latest
+
+        let testPlugin = TestableCapacitorUpdaterPlugin()
+        testPlugin.implementation = breakingImplementation
+        testPlugin.setUpdateUrlForTesting("https://example.com/channel")
+
+        testPlugin.backgroundDownload()
+
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("breakingAvailable"))
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("majorAvailable"))
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["breakingAvailable"]?["version"] as? String, "2.0.0")
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["majorAvailable"]?["version"] as? String, "2.0.0")
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("downloadFailed"))
+        XCTAssertTrue(breakingImplementation.sentStatsActions.contains("download_fail"))
     }
 
     func testFailedUpdateCheckNotifiesDownloadFailed() {

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -1296,6 +1296,49 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertEqual(testPlugin.notifiedEventPayloads["majorAvailable"]?["version"] as? String, "2.0.0")
     }
 
+    func testGetLatestBreakingResponseWithoutVersionNotifiesCurrentBundleVersion() throws {
+        let current = BundleInfo(
+            id: "test-id",
+            version: "1.0.0",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "abc123"
+        )
+        let latest = AppVersion()
+        latest.error = "disable_auto_update_to_major"
+        latest.kind = "blocked"
+        latest.message = "Cannot upgrade major version"
+        latest.statusCode = 200
+
+        let breakingImplementation = FreshDownloadCapgoUpdater()
+        breakingImplementation.currentBundleValue = current
+        breakingImplementation.latestResponse = latest
+
+        let testPlugin = TestableCapacitorUpdaterPlugin()
+        testPlugin.implementation = breakingImplementation
+        testPlugin.setUpdateUrlForTesting("https://example.com/channel")
+
+        let resolved = expectation(description: "getLatest resolves blocked breaking response")
+        let call = try XCTUnwrap(CAPPluginCall(
+            callbackId: "get-latest-breaking-response-no-version-test",
+            options: [:],
+            success: { _, _ in
+                resolved.fulfill()
+            },
+            error: { _ in
+                XCTFail("getLatest should resolve blocked breaking responses")
+            }
+        ))
+
+        testPlugin.getLatest(call)
+        wait(for: [resolved], timeout: 10)
+
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("breakingAvailable"))
+        XCTAssertTrue(testPlugin.notifiedEventNames.contains("majorAvailable"))
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["breakingAvailable"]?["version"] as? String, "1.0.0")
+        XCTAssertEqual(testPlugin.notifiedEventPayloads["majorAvailable"]?["version"] as? String, "1.0.0")
+    }
+
     func testBlockedUpdateCheckDoesNotNotifyDownloadFailed() {
         let current = BundleInfo(
             id: "test-id",


### PR DESCRIPTION
## What
- Fix iOS so `/check` responses that represent a breaking/native-store update emit `breakingAvailable` and the legacy `majorAvailable` event.
- Add iOS tests for `getLatest`, blocked update checks, store-update/no-url responses, and missing-version breaking responses.

## Why
- Fixes #773. Android already emits these listener events for breaking responses; iOS had the event emitter but did not call it from the relevant response paths.

## How
- Added the same breaking-signal detection used by Android: `breaking: true`, `disable_auto_update_to_major`, and `store_update_required`.
- Wired that detection into iOS `getLatest`, backend error/kind handling, and no-download-url handling.
- Added a current-bundle version fallback so breaking listener payloads are still emitted when the backend omits `version`.
- Extended the iOS test plugin helper to retain listener payloads so the emitted `version` can be asserted.

## Testing
- `bun run test:ios -- -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testGetLatestBreakingResponseNotifiesBreakingListeners -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testGetLatestBreakingResponseWithoutVersionNotifiesCurrentBundleVersion -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testBlockedUpdateCheckDoesNotNotifyDownloadFailed -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testBreakingNoUrlUpdateCheckNotifiesBreakingListeners`
- `bun run fmt`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$HOME/Library/Android/sdk bun run verify`
- GitHub Actions passed on PR #774 after rerunning two flaky iOS Maestro smoke jobs.
- CodeRabbit completed with no actionable comments in the latest review.

## Not Tested
- Nothing known.

Generated with Codex.