### PR TITLE
Fix manifest path traversal and enforce session key in manifest mode

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -129,6 +129,28 @@ public class DownloadService extends Worker {
         return result.isEmpty() ? "unknown" : result;
     }
 
+    private File resolveManifestFile(File baseDir, String fileName) throws IOException {
+        if (fileName == null || fileName.isEmpty() || fileName.contains("\\")) {
+            throw new IOException("Invalid manifest file path: " + fileName);
+        }
+
+        File requestedFile = new File(fileName);
+        if (requestedFile.isAbsolute()) {
+            throw new IOException("Manifest file path must be relative: " + fileName);
+        }
+
+        File targetFile = new File(baseDir, fileName);
+        String canonicalBase = baseDir.getCanonicalPath();
+        String canonicalTarget = targetFile.getCanonicalPath();
+        String canonicalBasePrefix = canonicalBase.endsWith(File.separator) ? canonicalBase : canonicalBase + File.separator;
+
+        if (!canonicalTarget.equals(canonicalBase) && !canonicalTarget.startsWith(canonicalBasePrefix)) {
+            throw new IOException("Manifest file path escapes bundle directory: " + fileName);
+        }
+
+        return targetFile;
+    }
+
     // Method to update User-Agent values
     public static void updateUserAgent(String appId, String pluginVersion, String versionOs) {
         currentAppId = sanitizeUserAgentValue(appId);
@@ -285,6 +307,11 @@ public class DownloadService extends Worker {
         try {
             logger.debug("handleManifestDownload");
 
+            if (publicKey != null && !publicKey.isEmpty() && (sessionKey == null || sessionKey.isEmpty())) {
+                sendStatsAsync("checksum_required", version);
+                throw new IOException("Session key required when public key is present for manifest download: " + version);
+            }
+
             // Send stats for manifest download start
             sendStatsAsync("download_manifest_start", version);
 
@@ -338,11 +365,11 @@ public class DownloadService extends Worker {
                 boolean isBrotli = fileName.endsWith(".br");
                 String targetFileName = isBrotli ? fileName.substring(0, fileName.length() - 3) : fileName;
 
-                File targetFile = new File(destFolder, targetFileName);
+                File targetFile = resolveManifestFile(destFolder, targetFileName);
                 String cacheBaseName = new File(isBrotli ? targetFileName : fileName).getName();
                 File cacheFile = new File(cacheFolder, finalFileHash + "_" + cacheBaseName);
                 final File legacyCacheFile = isBrotli ? new File(cacheFolder, finalFileHash + "_" + new File(fileName).getName()) : null;
-                File builtinFile = new File(builtinFolder, fileName);
+                File builtinFile = resolveManifestFile(builtinFolder, fileName);
 
                 // Ensure parent directories of the target file exist
                 if (!Objects.requireNonNull(targetFile.getParentFile()).exists() && !targetFile.getParentFile().mkdirs()) {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -874,9 +874,30 @@ import UIKit
         return actualHash == expectedHash
     }
 
+    private func resolveManifestFile(baseURL: URL, fileName: String) throws -> URL {
+        if fileName.isEmpty || fileName.contains("\\") || fileName.hasPrefix("/") {
+            throw NSError(domain: "ManifestEntryError", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid manifest file path: \(fileName)"])
+        }
+
+        let targetURL = baseURL.appendingPathComponent(fileName).standardizedFileURL
+        let canonicalPath = targetURL.path
+        let canonicalBase = baseURL.standardizedFileURL.path
+        let canonicalBasePrefix = canonicalBase.hasSuffix("/") ? canonicalBase : "\(canonicalBase)/"
+
+        if canonicalPath != canonicalBase && !canonicalPath.hasPrefix(canonicalBasePrefix) {
+            throw NSError(domain: "ManifestEntryError", code: 4, userInfo: [NSLocalizedDescriptionKey: "Manifest file path escapes bundle directory: \(fileName)"])
+        }
+
+        return targetURL
+    }
+
     public func downloadManifest(manifest: [ManifestEntry], version: String, sessionKey: String, link: String? = nil, comment: String? = nil) throws -> BundleInfo {
         let id = self.randomString(length: 10)
         logger.info("downloadManifest start \(id)")
+        if !self.publicKey.isEmpty && sessionKey.isEmpty {
+            self.sendStats(action: "checksum_required", versionName: version)
+            throw NSError(domain: "ManifestEncryptionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Session key required when public key is present for manifest download"])
+        }
         let destFolder = self.getBundleDirectory(id: id)
         let builtinFolder = Bundle.main.bundleURL.appendingPathComponent("public")
 
@@ -972,8 +993,8 @@ import UIKit
             let legacyCacheFilePath: URL? = isBrotli ? cacheFolder.appendingPathComponent("\(finalFileHash)_\(fileNameWithoutPath)") : nil
 
             let destFileName = isBrotli ? String(fileName.dropLast(3)) : fileName
-            let destFilePath = destFolder.appendingPathComponent(destFileName)
-            let builtinFilePath = builtinFolder.appendingPathComponent(fileName)
+            let destFilePath = try self.resolveManifestFile(baseURL: destFolder, fileName: destFileName)
+            let builtinFilePath = try self.resolveManifestFile(baseURL: builtinFolder, fileName: fileName)
 
             // Create parent directories synchronously (before operations start)
             try? FileManager.default.createDirectory(at: destFilePath.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)


### PR DESCRIPTION
Fixes manifest delta security issues by:
- Rejecting path traversal outside bundle directory on Android and iOS
- Enforcing encrypted-session-key requirement when publicKey is configured
- Closing session-key-enforcement gap that allowed plaintext manifest files

This PR addresses advisory-related findings related to path traversal and manifest encryption handling.

/attempt #?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security validation for manifest file path handling on Android and iOS
  * Added stricter authentication requirements when using public key validation for downloads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->