### PR TITLE
fix: avoid Android app exit info startup crash

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/AndroidAppExitReporter.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/AndroidAppExitReporter.java
@@ -1,0 +1,92 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package ee.forgr.capacitor_updater;
+
+import android.annotation.TargetApi;
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@TargetApi(Build.VERSION_CODES.R)
+final class AndroidAppExitReporter {
+
+    private AndroidAppExitReporter() {}
+
+    static void reportPreviousAppExitReasons(
+        final Context context,
+        final SharedPreferences prefs,
+        final CapgoUpdater implementation,
+        final Logger logger,
+        final String lastReportedAppExitTimestampPrefKey
+    ) {
+        try {
+            final ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+            if (activityManager == null) {
+                return;
+            }
+
+            final List<ApplicationExitInfo> exitReasons = activityManager.getHistoricalProcessExitReasons(context.getPackageName(), 0, 8);
+            if (exitReasons == null || exitReasons.isEmpty()) {
+                return;
+            }
+
+            final long lastReportedTimestamp = prefs.getLong(lastReportedAppExitTimestampPrefKey, 0L);
+            long newestReportedTimestamp = lastReportedTimestamp;
+            final BundleInfo current = implementation.getCurrentBundle();
+            final String versionName = current == null ? "" : current.getVersionName();
+
+            for (final ApplicationExitInfo exitInfo : exitReasons) {
+                if (exitInfo == null || exitInfo.getTimestamp() <= lastReportedTimestamp) {
+                    continue;
+                }
+
+                final String action = CapacitorUpdaterPlugin.statsActionForApplicationExitReason(exitInfo.getReason());
+                if (action == null) {
+                    continue;
+                }
+
+                implementation.sendStats(action, versionName, "", buildApplicationExitMetadata(exitInfo));
+                newestReportedTimestamp = Math.max(newestReportedTimestamp, exitInfo.getTimestamp());
+            }
+
+            if (newestReportedTimestamp > lastReportedTimestamp) {
+                prefs.edit().putLong(lastReportedAppExitTimestampPrefKey, newestReportedTimestamp).apply();
+            }
+        } catch (final Exception e) {
+            logger.warn("Unable to report previous app exit reason: " + e.getMessage());
+        }
+    }
+
+    private static Map<String, String> buildApplicationExitMetadata(final ApplicationExitInfo exitInfo) {
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("exit_reason", CapacitorUpdaterPlugin.applicationExitReasonName(exitInfo.getReason()));
+        metadata.put("exit_reason_code", Integer.toString(exitInfo.getReason()));
+        metadata.put("exit_status", Integer.toString(exitInfo.getStatus()));
+        metadata.put("exit_importance", Integer.toString(exitInfo.getImportance()));
+        metadata.put("exit_timestamp", Long.toString(exitInfo.getTimestamp()));
+        metadata.put("pid", Integer.toString(exitInfo.getPid()));
+        metadata.put("pss_kb", Long.toString(exitInfo.getPss()));
+        metadata.put("rss_kb", Long.toString(exitInfo.getRss()));
+
+        final String processName = exitInfo.getProcessName();
+        if (processName != null && !processName.isEmpty()) {
+            metadata.put("process_name", CapacitorUpdaterPlugin.truncateStatsMetadataValue(processName, 128));
+        }
+
+        final String description = exitInfo.getDescription();
+        if (description != null && !description.isEmpty()) {
+            metadata.put("exit_description", CapacitorUpdaterPlugin.truncateStatsMetadataValue(description, 512));
+        }
+
+        return metadata;
+    }
+}

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -7,8 +7,6 @@
 package ee.forgr.capacitor_updater;
 
 import android.app.Activity;
-import android.app.ActivityManager;
-import android.app.ApplicationExitInfo;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -95,6 +93,18 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private static final int SPLASH_SCREEN_RETRY_DELAY_MS = 100;
     private static final int SPLASH_SCREEN_MAX_RETRIES = 20;
     private static final long PENDING_BUNDLE_APP_READY_MIN_TIMEOUT_MS = 30000L;
+    static final int APPLICATION_EXIT_REASON_UNKNOWN = 0;
+    static final int APPLICATION_EXIT_REASON_EXIT_SELF = 1;
+    static final int APPLICATION_EXIT_REASON_SIGNALED = 2;
+    static final int APPLICATION_EXIT_REASON_LOW_MEMORY = 3;
+    static final int APPLICATION_EXIT_REASON_CRASH = 4;
+    static final int APPLICATION_EXIT_REASON_CRASH_NATIVE = 5;
+    static final int APPLICATION_EXIT_REASON_ANR = 6;
+    static final int APPLICATION_EXIT_REASON_INITIALIZATION_FAILURE = 7;
+    static final int APPLICATION_EXIT_REASON_PERMISSION_CHANGE = 8;
+    static final int APPLICATION_EXIT_REASON_EXCESSIVE_RESOURCE_USAGE = 9;
+    static final int APPLICATION_EXIT_REASON_USER_REQUESTED = 10;
+    static final int APPLICATION_EXIT_REASON_DEPENDENCY_DIED = 12;
 
     private final String pluginVersion = "8.46.0";
     private static final String DELAY_CONDITION_PREFERENCES = "";
@@ -855,61 +865,28 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return;
         }
 
-        try {
-            final ActivityManager activityManager = (ActivityManager) this.getContext().getSystemService(Context.ACTIVITY_SERVICE);
-            if (activityManager == null) {
-                return;
-            }
-
-            final List<ApplicationExitInfo> exitReasons = activityManager.getHistoricalProcessExitReasons(
-                this.getContext().getPackageName(),
-                0,
-                8
-            );
-            if (exitReasons == null || exitReasons.isEmpty()) {
-                return;
-            }
-
-            final long lastReportedTimestamp = this.prefs.getLong(LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY, 0L);
-            long newestReportedTimestamp = lastReportedTimestamp;
-            final BundleInfo current = this.implementation.getCurrentBundle();
-            final String versionName = current == null ? "" : current.getVersionName();
-
-            for (final ApplicationExitInfo exitInfo : exitReasons) {
-                if (exitInfo == null || exitInfo.getTimestamp() <= lastReportedTimestamp) {
-                    continue;
-                }
-
-                final String action = statsActionForApplicationExitReason(exitInfo.getReason());
-                if (action == null) {
-                    continue;
-                }
-
-                this.implementation.sendStats(action, versionName, "", buildApplicationExitMetadata(exitInfo));
-                newestReportedTimestamp = Math.max(newestReportedTimestamp, exitInfo.getTimestamp());
-            }
-
-            if (newestReportedTimestamp > lastReportedTimestamp) {
-                this.prefs.edit().putLong(LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY, newestReportedTimestamp).apply();
-            }
-        } catch (final Exception e) {
-            logger.warn("Unable to report previous app exit reason: " + e.getMessage());
-        }
+        AndroidAppExitReporter.reportPreviousAppExitReasons(
+            this.getContext(),
+            this.prefs,
+            this.implementation,
+            this.logger,
+            LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY
+        );
     }
 
     static String statsActionForApplicationExitReason(final int reason) {
         switch (reason) {
-            case ApplicationExitInfo.REASON_CRASH:
+            case APPLICATION_EXIT_REASON_CRASH:
                 return "app_crash";
-            case ApplicationExitInfo.REASON_CRASH_NATIVE:
+            case APPLICATION_EXIT_REASON_CRASH_NATIVE:
                 return "app_crash_native";
-            case ApplicationExitInfo.REASON_ANR:
+            case APPLICATION_EXIT_REASON_ANR:
                 return "app_anr";
-            case ApplicationExitInfo.REASON_LOW_MEMORY:
+            case APPLICATION_EXIT_REASON_LOW_MEMORY:
                 return "app_killed_low_memory";
-            case ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE:
+            case APPLICATION_EXIT_REASON_EXCESSIVE_RESOURCE_USAGE:
                 return "app_killed_excessive_resource_usage";
-            case ApplicationExitInfo.REASON_INITIALIZATION_FAILURE:
+            case APPLICATION_EXIT_REASON_INITIALIZATION_FAILURE:
                 return "app_initialization_failure";
             default:
                 return null;
@@ -918,58 +895,34 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     static String applicationExitReasonName(final int reason) {
         switch (reason) {
-            case ApplicationExitInfo.REASON_EXIT_SELF:
+            case APPLICATION_EXIT_REASON_EXIT_SELF:
                 return "exit_self";
-            case ApplicationExitInfo.REASON_SIGNALED:
+            case APPLICATION_EXIT_REASON_SIGNALED:
                 return "signaled";
-            case ApplicationExitInfo.REASON_LOW_MEMORY:
+            case APPLICATION_EXIT_REASON_LOW_MEMORY:
                 return "low_memory";
-            case ApplicationExitInfo.REASON_CRASH:
+            case APPLICATION_EXIT_REASON_CRASH:
                 return "crash";
-            case ApplicationExitInfo.REASON_CRASH_NATIVE:
+            case APPLICATION_EXIT_REASON_CRASH_NATIVE:
                 return "crash_native";
-            case ApplicationExitInfo.REASON_ANR:
+            case APPLICATION_EXIT_REASON_ANR:
                 return "anr";
-            case ApplicationExitInfo.REASON_INITIALIZATION_FAILURE:
+            case APPLICATION_EXIT_REASON_INITIALIZATION_FAILURE:
                 return "initialization_failure";
-            case ApplicationExitInfo.REASON_PERMISSION_CHANGE:
+            case APPLICATION_EXIT_REASON_PERMISSION_CHANGE:
                 return "permission_change";
-            case ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE:
+            case APPLICATION_EXIT_REASON_EXCESSIVE_RESOURCE_USAGE:
                 return "excessive_resource_usage";
-            case ApplicationExitInfo.REASON_USER_REQUESTED:
+            case APPLICATION_EXIT_REASON_USER_REQUESTED:
                 return "user_requested";
-            case ApplicationExitInfo.REASON_DEPENDENCY_DIED:
+            case APPLICATION_EXIT_REASON_DEPENDENCY_DIED:
                 return "dependency_died";
             default:
                 return "unknown";
         }
     }
 
-    private static Map<String, String> buildApplicationExitMetadata(final ApplicationExitInfo exitInfo) {
-        final Map<String, String> metadata = new HashMap<>();
-        metadata.put("exit_reason", applicationExitReasonName(exitInfo.getReason()));
-        metadata.put("exit_reason_code", Integer.toString(exitInfo.getReason()));
-        metadata.put("exit_status", Integer.toString(exitInfo.getStatus()));
-        metadata.put("exit_importance", Integer.toString(exitInfo.getImportance()));
-        metadata.put("exit_timestamp", Long.toString(exitInfo.getTimestamp()));
-        metadata.put("pid", Integer.toString(exitInfo.getPid()));
-        metadata.put("pss_kb", Long.toString(exitInfo.getPss()));
-        metadata.put("rss_kb", Long.toString(exitInfo.getRss()));
-
-        final String processName = exitInfo.getProcessName();
-        if (processName != null && !processName.isEmpty()) {
-            metadata.put("process_name", truncateStatsMetadataValue(processName, 128));
-        }
-
-        final String description = exitInfo.getDescription();
-        if (description != null && !description.isEmpty()) {
-            metadata.put("exit_description", truncateStatsMetadataValue(description, 512));
-        }
-
-        return metadata;
-    }
-
-    private static String truncateStatsMetadataValue(final String value, final int maxLength) {
+    static String truncateStatsMetadataValue(final String value, final int maxLength) {
         return value.length() <= maxLength ? value : value.substring(0, maxLength);
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -820,11 +820,19 @@ public class CapacitorUpdaterUnitTest {
     public void pluginMethodsDoNotExposeApplicationExitInfoToReflection() {
         final String applicationExitInfoClassName = ApplicationExitInfo.class.getName();
         for (final Method method : CapacitorUpdaterPlugin.class.getDeclaredMethods()) {
-            assertNotEquals(applicationExitInfoClassName, method.getReturnType().getName());
+            assertFalse(exposesApplicationExitInfoType(method.getReturnType(), applicationExitInfoClassName));
             for (final Class<?> parameterType : method.getParameterTypes()) {
-                assertNotEquals(applicationExitInfoClassName, parameterType.getName());
+                assertFalse(exposesApplicationExitInfoType(parameterType, applicationExitInfoClassName));
             }
         }
+    }
+
+    private static boolean exposesApplicationExitInfoType(final Class<?> type, final String applicationExitInfoClassName) {
+        Class<?> currentType = type;
+        while (currentType.isArray()) {
+            currentType = currentType.getComponentType();
+        }
+        return applicationExitInfoClassName.equals(currentType.getName());
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -817,6 +817,17 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void pluginMethodsDoNotExposeApplicationExitInfoToReflection() {
+        final String applicationExitInfoClassName = ApplicationExitInfo.class.getName();
+        for (final Method method : CapacitorUpdaterPlugin.class.getDeclaredMethods()) {
+            assertNotEquals(applicationExitInfoClassName, method.getReturnType().getName());
+            for (final Class<?> parameterType : method.getParameterTypes()) {
+                assertNotEquals(applicationExitInfoClassName, parameterType.getName());
+            }
+        }
+    }
+
+    @Test
     public void ignoresExpectedApplicationExitReasonsForStats() {
         assertNull(CapacitorUpdaterPlugin.statsActionForApplicationExitReason(ApplicationExitInfo.REASON_EXIT_SELF));
         assertNull(CapacitorUpdaterPlugin.statsActionForApplicationExitReason(ApplicationExitInfo.REASON_USER_REQUESTED));


### PR DESCRIPTION
## What
- Moves Android 11+ app exit reason reporting into a guarded helper class.
- Removes direct `ApplicationExitInfo` references from `CapacitorUpdaterPlugin`.
- Adds a regression test ensuring reflected plugin methods do not expose `ApplicationExitInfo`.

## Why
- Fixes #772.
- `ApplicationExitInfo` only exists on Android 11+ and can crash Android 10 and below when Capacitor reflects over plugin methods during startup.

## How
- Keeps the existing `Build.VERSION.SDK_INT >= Build.VERSION_CODES.R` guard in the main plugin class.
- Uses integer constants for exit reason mapping so the reflected plugin class does not need to resolve API 30-only types.
- Loads `AndroidAppExitReporter` only after the API-level guard passes.

## Testing
- `bun run test:android`
- `bun run verify`
- Targeted Java formatting check for touched files
- Verified compiled `CapacitorUpdaterPlugin` bytecode has no `ApplicationExitInfo` reference.

## Not Tested
- Physical Android 8, 9, or 10 device startup. The regression is covered by removing the API 30-only type from the reflected plugin class and by the new reflection test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reporting of historical app process exit reasons to help monitor stability and diagnose crashes
  * Sends structured exit metadata alongside app version and process diagnostics

* **Tests**
  * Added unit test ensuring internal platform-specific types are not exposed via plugin method signatures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->