### PR TITLE
feat: add preview session shake menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ export default config;
 * [`download(...)`](#download)
 * [`next(...)`](#next)
 * [`set(...)`](#set)
+* [`startPreviewSession()`](#startpreviewsession)
 * [`delete(...)`](#delete)
 * [`setBundleError(...)`](#setbundleerror)
 * [`list(...)`](#list)
@@ -691,6 +692,25 @@ For other state preservation needs, save your data before calling this method (e
 | Param         | Type                                          | Description                                                                                       |
 | ------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#bundleid">BundleId</a></code> | A {@link <a href="#bundleid">BundleId</a>} object containing the new bundle id to set as current. |
+
+--------------------
+
+
+#### startPreviewSession()
+
+```typescript
+startPreviewSession() => Promise<void>
+```
+
+Start a temporary preview/testing session.
+
+This stores the currently active bundle as the pending fallback, enables the
+native shake menu, and makes the next applied bundle show a native notice
+explaining that shaking the device can reload or leave the preview.
+
+Use this before calling {@link set} for Expo Go-style preview flows.
+
+**Since:** 8.47.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -7,6 +7,7 @@
 package ee.forgr.capacitor_updater;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -85,6 +86,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private static final String STATS_URL_PREF_KEY = "CapacitorUpdater.statsUrl";
     private static final String CHANNEL_URL_PREF_KEY = "CapacitorUpdater.channelUrl";
     private static final String DEFAULT_CHANNEL_PREF_KEY = "CapacitorUpdater.defaultChannel";
+    private static final String PREVIEW_SESSION_PREF_KEY = "CapacitorUpdater.previewSession";
+    private static final String PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY = "CapacitorUpdater.previewPreviousShakeMenu";
+    private static final String PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY = "CapacitorUpdater.previewPreviousShakeChannelSelector";
+    private static final String PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY = "CapacitorUpdater.previewPreviousNextBundle";
     private static final String[] BREAKING_EVENT_NAMES = { "breakingAvailable", "majorAvailable" };
     private static final String LAST_FAILED_BUNDLE_PREF_KEY = "CapacitorUpdater.lastFailedBundle";
     private static final String LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY = "CapacitorUpdater.lastReportedAppExitTimestamp";
@@ -106,7 +111,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     static final int APPLICATION_EXIT_REASON_USER_REQUESTED = 10;
     static final int APPLICATION_EXIT_REASON_DEPENDENCY_DIED = 12;
 
-    private final String pluginVersion = "8.46.3";
+    private final String pluginVersion = "8.47.0";
     private static final String DELAY_CONDITION_PREFERENCES = "";
 
     private SharedPreferences.Editor editor;
@@ -136,6 +141,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private volatile boolean onLaunchDirectUpdateUsed = false;
     Boolean shakeMenuEnabled = false;
     Boolean shakeChannelSelectorEnabled = false;
+    Boolean previewSessionEnabled = false;
+    private Boolean previewSessionAlertPending = false;
     private Boolean allowManualBundleError = false;
     Boolean allowSetDefaultChannel = true;
 
@@ -509,12 +516,21 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.implementation.timeout = this.getConfig().getInt("responseTimeout", 20) * 1000;
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
+        this.previewSessionEnabled = this.prefs.getBoolean(PREVIEW_SESSION_PREF_KEY, false);
+        if (Boolean.TRUE.equals(this.previewSessionEnabled)) {
+            this.shakeMenuEnabled = true;
+            this.shakeChannelSelectorEnabled = false;
+        }
         boolean resetWhenUpdate = this.getConfig().getBoolean("resetWhenUpdate", true);
 
         // Check if app was recently installed/updated BEFORE cleanupObsoleteVersions updates LatestVersionNative
         this.wasRecentlyInstalledOrUpdated = this.checkIfRecentlyInstalledOrUpdated();
+        final boolean nativeBuildVersionChanged = this.hasNativeBuildVersionChanged();
 
         this.implementation.autoReset(this.currentBuildVersion, resetWhenUpdate);
+        if (nativeBuildVersionChanged) {
+            this.clearPreviewSessionForNativeBuildChange();
+        }
         this.reportPreviousAppExitReasons();
         this.reportPreviousWebViewRenderProcessGone();
         this.installWebViewStatsReporter();
@@ -858,6 +874,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
 
         return false;
+    }
+
+    private boolean hasNativeBuildVersionChanged() {
+        final String lastKnownVersion = this.getStoredNativeBuildVersion();
+        return !lastKnownVersion.isEmpty() && !lastKnownVersion.equals(this.currentBuildVersion);
     }
 
     private void reportPreviousAppExitReasons() {
@@ -2004,6 +2025,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                         }
                         this.notifyBundleSet(next);
                         this.implementation.setNextBundle(null);
+                        this.showPreviewSessionNoticeIfNeeded();
                         call.resolve();
                         return;
                     }
@@ -2015,6 +2037,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 }
 
                 if (this._reload()) {
+                    this.showPreviewSessionNoticeIfNeeded();
                     call.resolve();
                 } else {
                     logger.error("Reload failed");
@@ -2069,6 +2092,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 } else {
                     logger.info("Bundle successfully set to " + id);
                     this.notifyBundleSet(this.implementation.getBundleInfo(id));
+                    this.showPreviewSessionNoticeIfNeeded();
                     call.resolve();
                 }
             } catch (final Exception e) {
@@ -2076,6 +2100,228 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 call.reject("Could not set id " + id, e);
             }
         });
+    }
+
+    @PluginMethod
+    public void startPreviewSession(final PluginCall call) {
+        startNewThread(() -> {
+            try {
+                if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
+                    final BundleInfo current = this.implementation.getCurrentBundle();
+                    if (!this.implementation.setPreviewFallbackBundle(current.getId())) {
+                        logger.error("Could not save current bundle as preview fallback");
+                        call.reject("Could not save current bundle as preview fallback");
+                        return;
+                    }
+
+                    final BundleInfo previousNext = this.implementation.getNextBundle();
+                    if (previousNext == null || previousNext.isDeleted() || previousNext.isErrorStatus()) {
+                        this.editor.remove(PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY);
+                    } else {
+                        this.editor.putString(PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY, previousNext.getId());
+                    }
+
+                    this.editor.putBoolean(PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY, Boolean.TRUE.equals(this.shakeMenuEnabled));
+                    this.editor.putBoolean(
+                        PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY,
+                        Boolean.TRUE.equals(this.shakeChannelSelectorEnabled)
+                    );
+                    logger.info("Preview session started with fallback bundle: " + current);
+                }
+
+                this.previewSessionEnabled = true;
+                this.previewSessionAlertPending = true;
+                this.shakeMenuEnabled = true;
+                this.shakeChannelSelectorEnabled = false;
+                this.editor.putBoolean(PREVIEW_SESSION_PREF_KEY, true);
+                this.editor.apply();
+                this.ensureShakeMenuStarted();
+                call.resolve();
+            } catch (final Exception e) {
+                logger.error("Could not start preview session " + e.getMessage());
+                call.reject("Could not start preview session", e);
+            }
+        });
+    }
+
+    public boolean leavePreviewSessionFromShakeMenu() {
+        final BundleInfo previewBundle = this.implementation.getCurrentBundle();
+
+        final boolean didReset = this.resetToPreviewFallbackBundle();
+        if (!didReset) {
+            return false;
+        }
+
+        if (!this.clearPreviewChannelOverride()) {
+            return false;
+        }
+        final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
+        this.endPreviewSession();
+        final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
+        if (
+            !previewBundle.isBuiltin() &&
+            (previewFallbackBundle == null || !previewBundle.getId().equals(previewFallbackBundle.getId())) &&
+            (restoredNextBundle == null || !previewBundle.getId().equals(restoredNextBundle.getId()))
+        ) {
+            try {
+                this.implementation.delete(previewBundle.getId(), false);
+            } catch (final Exception err) {
+                logger.warn("Cannot delete preview bundle " + previewBundle.getId() + ": " + err.getMessage());
+            }
+        }
+        return true;
+    }
+
+    public boolean reloadPreviewSessionFromShakeMenu() {
+        return this._reload();
+    }
+
+    public boolean hasActivePreviewSession() {
+        return Boolean.TRUE.equals(this.previewSessionEnabled);
+    }
+
+    private boolean resetToPreviewFallbackBundle() {
+        final BundleInfo fallback = this.implementation.getPreviewFallbackBundle();
+        if (fallback == null || fallback.isErrorStatus()) {
+            logger.error("No preview fallback bundle available");
+            return false;
+        }
+        if (!this.implementation.canSet(fallback)) {
+            logger.error("Preview fallback bundle is not installable");
+            return false;
+        }
+
+        final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
+        final String previousBundleName = this.implementation.getCurrentBundle().getVersionName();
+        logger.info("Resetting to preview fallback bundle: " + fallback.getVersionName());
+        if (this.implementation.stagePreviewFallbackReload(fallback) && this._reload()) {
+            this.implementation.finalizeResetTransition(previousBundleName, false);
+            this.notifyBundleSet(fallback);
+            return true;
+        }
+        this.implementation.restoreResetState(previousState);
+        this.restoreLiveBundleStateAfterFailedReload();
+        return false;
+    }
+
+    private void endPreviewSession() {
+        final boolean previousShakeMenuEnabled = this.prefs.getBoolean(
+            PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY,
+            this.getConfig().getBoolean("shakeMenu", false)
+        );
+        final boolean previousShakeChannelSelectorEnabled = this.prefs.getBoolean(
+            PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY,
+            this.getConfig().getBoolean("allowShakeChannelSelector", false)
+        );
+        this.restorePreviewPreviousNextBundle();
+
+        this.previewSessionEnabled = false;
+        this.previewSessionAlertPending = false;
+        this.shakeMenuEnabled = previousShakeMenuEnabled;
+        this.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled;
+        this.editor.remove(PREVIEW_SESSION_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY);
+        this.implementation.setPreviewFallbackBundle(null);
+        this.editor.apply();
+        logger.info("Preview session ended");
+    }
+
+    private void clearPreviewSessionForNativeBuildChange() {
+        if (!Boolean.TRUE.equals(this.previewSessionEnabled) && this.implementation.getPreviewFallbackBundle() == null) {
+            return;
+        }
+        logger.info("Native build changed; clearing preview session state");
+        this.previewSessionEnabled = false;
+        this.previewSessionAlertPending = false;
+        this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
+        this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
+        this.editor.remove(PREVIEW_SESSION_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY);
+        this.implementation.setPreviewFallbackBundle(null);
+        this.implementation.setNextBundle(null);
+        this.clearPreviewChannelOverride();
+        this.editor.apply();
+    }
+
+    private boolean clearPreviewChannelOverride() {
+        final String configDefaultChannel = this.getConfig().getString("defaultChannel", "");
+        final AtomicReference<Map<String, Object>> unsetChannelResult = new AtomicReference<>();
+        try {
+            this.implementation.unsetChannel(this.editor, DEFAULT_CHANNEL_PREF_KEY, configDefaultChannel, unsetChannelResult::set);
+        } catch (final Exception err) {
+            logger.error("Could not clear preview channel override: " + err.getMessage());
+            return false;
+        }
+
+        final Map<String, Object> result = unsetChannelResult.get();
+        if (result == null) {
+            logger.error("Could not clear preview channel override: no result");
+            return false;
+        }
+        if (result.containsKey("error")) {
+            final Object message = result.getOrDefault("message", result.get("error"));
+            logger.error("Could not clear preview channel override: " + message);
+            return false;
+        }
+        return true;
+    }
+
+    private void restorePreviewPreviousNextBundle() {
+        final String previousNextBundleId = this.prefs.getString(PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY, null);
+        if (previousNextBundleId == null || previousNextBundleId.isEmpty()) {
+            this.implementation.setNextBundle(null);
+            return;
+        }
+        if (!this.implementation.setNextBundle(previousNextBundleId)) {
+            logger.warn("Could not restore pre-preview next bundle: " + previousNextBundleId);
+            this.implementation.setNextBundle(null);
+        }
+    }
+
+    private void ensureShakeMenuStarted() {
+        if (getActivity() instanceof com.getcapacitor.BridgeActivity && shakeMenu == null) {
+            try {
+                shakeMenu = new ShakeMenu(this, (com.getcapacitor.BridgeActivity) getActivity(), logger);
+                logger.info("Shake menu initialized");
+            } catch (Exception e) {
+                logger.error("Failed to initialize shake menu: " + e.getMessage());
+            }
+        }
+    }
+
+    private void showPreviewSessionNoticeIfNeeded() {
+        if (!Boolean.TRUE.equals(this.previewSessionEnabled) || !Boolean.TRUE.equals(this.previewSessionAlertPending)) {
+            return;
+        }
+        this.previewSessionAlertPending = false;
+
+        new Handler(Looper.getMainLooper()).postDelayed(
+            () -> {
+                try {
+                    if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
+                        return;
+                    }
+                    if (getActivity() == null || getActivity().isFinishing()) {
+                        this.previewSessionAlertPending = true;
+                        return;
+                    }
+
+                    new AlertDialog.Builder(getActivity())
+                        .setTitle("Preview started")
+                        .setMessage("Shake your device anytime to reload or leave the test app.")
+                        .setPositiveButton("Got it", (dialog, which) -> dialog.dismiss())
+                        .show();
+                } catch (final Exception e) {
+                    this.previewSessionAlertPending = true;
+                    logger.warn("Could not show preview session notice: " + e.getMessage());
+                }
+            },
+            600
+        );
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -60,6 +60,7 @@ public class CapgoUpdater {
 
     private static final String FALLBACK_VERSION = "pastVersion";
     private static final String NEXT_VERSION = "nextVersion";
+    private static final String PREVIEW_FALLBACK_VERSION = "previewFallbackVersion";
     private static final String bundleDirectory = "versions";
     private static final String TEMP_UNZIP_PREFIX = "capgo_unzip_";
 
@@ -941,6 +942,17 @@ public class CapgoUpdater {
             logger.debug("Bundle ID: " + id);
             return false;
         }
+        final BundleInfo previewFallback = this.getPreviewFallbackBundle();
+        if (
+            previewFallback != null &&
+            !previewFallback.isDeleted() &&
+            !previewFallback.isErrorStatus() &&
+            previewFallback.getId().equals(id)
+        ) {
+            logger.error("Cannot delete the preview fallback bundle");
+            logger.debug("Bundle ID: " + id);
+            return false;
+        }
         final BundleInfo next = this.getNextBundle();
         if (next != null && !next.isDeleted() && !next.isErrorStatus() && next.getId().equals(id)) {
             logger.error("Cannot delete the next bundle");
@@ -1081,6 +1093,21 @@ public class CapgoUpdater {
         return true;
     }
 
+    boolean stagePreviewFallbackReload(final BundleInfo bundle) {
+        if (bundle == null || bundle.isErrorStatus()) {
+            return false;
+        }
+        if (bundle.isBuiltin()) {
+            this.setCurrentBundle(new File("public"));
+            return true;
+        }
+        if (!this.bundleExists(bundle.getId())) {
+            return false;
+        }
+        this.setCurrentBundle(this.getBundleDirectory(bundle.getId()));
+        return true;
+    }
+
     void finalizePendingReload(final BundleInfo bundle, final String previousBundleName) {
         if (bundle == null || bundle.isBuiltin()) {
             return;
@@ -1147,12 +1174,20 @@ public class CapgoUpdater {
     public void setSuccess(final BundleInfo bundle, Boolean autoDeletePrevious) {
         this.setBundleStatus(bundle.getId(), BundleStatus.SUCCESS);
         final BundleInfo fallback = this.getFallbackBundle();
+        final BundleInfo previewFallback = this.getPreviewFallbackBundle();
+        final boolean fallbackIsPreviewFallback = previewFallback != null && previewFallback.getId().equals(fallback.getId());
         logger.debug("Fallback bundle is: " + fallback);
         logger.info("Version successfully loaded: " + bundle.getVersionName());
         // Only attempt to delete when the fallback is a different bundle than the
         // currently loaded one. Otherwise we spam logs with "Cannot delete <id>"
         // because delete() protects the current bundle from removal.
-        if (autoDeletePrevious && !fallback.isBuiltin() && fallback.getId() != null && !fallback.getId().equals(bundle.getId())) {
+        if (
+            autoDeletePrevious &&
+            !fallback.isBuiltin() &&
+            fallback.getId() != null &&
+            !fallback.getId().equals(bundle.getId()) &&
+            !fallbackIsPreviewFallback
+        ) {
             final Boolean res = this.delete(fallback.getId());
             if (res) {
                 logger.info("Deleted previous bundle: " + fallback.getVersionName());
@@ -1969,6 +2004,31 @@ public class CapgoUpdater {
         final String id = this.prefs.getString(NEXT_VERSION, null);
         if (id == null) return null;
         return this.getBundleInfo(id);
+    }
+
+    public BundleInfo getPreviewFallbackBundle() {
+        final String id = this.prefs.getString(PREVIEW_FALLBACK_VERSION, null);
+        if (id == null) return null;
+        final BundleInfo bundle = this.getBundleInfo(id);
+        if (bundle.isErrorStatus() || (!bundle.isBuiltin() && !this.bundleExists(id))) {
+            this.setPreviewFallbackBundle(null);
+            return null;
+        }
+        return bundle;
+    }
+
+    public boolean setPreviewFallbackBundle(final String fallback) {
+        if (fallback == null) {
+            this.editor.remove(PREVIEW_FALLBACK_VERSION);
+        } else {
+            final BundleInfo newBundle = this.getBundleInfo(fallback);
+            if (newBundle.isErrorStatus() || (!newBundle.isBuiltin() && !this.bundleExists(fallback))) {
+                return false;
+            }
+            this.editor.putString(PREVIEW_FALLBACK_VERSION, fallback);
+        }
+        this.editor.commit();
+        return true;
     }
 
     public boolean setNextBundle(final String next) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
@@ -66,8 +66,9 @@ public class ShakeMenu implements ShakeDetector.Listener {
 
         isShowing = true;
 
-        // Check if channel selector mode is enabled
-        if (plugin.shakeChannelSelectorEnabled) {
+        if (plugin.hasActivePreviewSession()) {
+            showDefaultMenu();
+        } else if (plugin.shakeChannelSelectorEnabled) {
             showChannelSelector();
         } else {
             showDefaultMenu();
@@ -75,6 +76,98 @@ public class ShakeMenu implements ShakeDetector.Listener {
     }
 
     private void showDefaultMenu() {
+        activity.runOnUiThread(() -> {
+            try {
+                if (!plugin.hasActivePreviewSession()) {
+                    showConfiguredDefaultMenu();
+                    return;
+                }
+                String appName = activity.getPackageManager().getApplicationLabel(activity.getApplicationInfo()).toString();
+                String title = "Preview " + appName + " Menu";
+                String message = "Reload the current preview or leave the test app.";
+                String okButtonTitle = "Leave test app";
+                String reloadButtonTitle = "Reload app";
+                String cancelButtonTitle = "Close menu";
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                builder.setTitle(title);
+                builder.setMessage(message);
+
+                builder.setPositiveButton(okButtonTitle, null);
+                builder.setNeutralButton(reloadButtonTitle, null);
+
+                // Cancel button
+                builder.setNegativeButton(
+                    cancelButtonTitle,
+                    new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            logger.info("Shake menu cancelled");
+                            dialog.dismiss();
+                            isShowing = false;
+                        }
+                    }
+                );
+
+                AlertDialog dialog = builder.create();
+                dialog.setOnDismissListener((dialogInterface) -> isShowing = false);
+                dialog.show();
+                dialog
+                    .getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setOnClickListener((view) -> {
+                        setPreviewMenuButtonsEnabled(dialog, false);
+                        new Thread(() -> {
+                            try {
+                                if (!plugin.leavePreviewSessionFromShakeMenu()) {
+                                    activity.runOnUiThread(() -> showError("Could not leave the test app."));
+                                }
+                            } catch (Exception e) {
+                                logger.error("Error leaving test app: " + e.getMessage());
+                                activity.runOnUiThread(() -> showError("Error leaving test app: " + e.getMessage()));
+                            } finally {
+                                activity.runOnUiThread(() -> {
+                                    dialog.dismiss();
+                                    isShowing = false;
+                                });
+                            }
+                        })
+                            .start();
+                    });
+                dialog
+                    .getButton(AlertDialog.BUTTON_NEUTRAL)
+                    .setOnClickListener((view) -> {
+                        setPreviewMenuButtonsEnabled(dialog, false);
+                        new Thread(() -> {
+                            try {
+                                logger.info("Reloading webview");
+                                if (!plugin.reloadPreviewSessionFromShakeMenu()) {
+                                    activity.runOnUiThread(() -> showError("Could not reload the test app."));
+                                }
+                            } catch (Exception e) {
+                                logger.error("Error in Reload action: " + e.getMessage());
+                                activity.runOnUiThread(() -> showError("Error reloading test app: " + e.getMessage()));
+                            } finally {
+                                activity.runOnUiThread(() -> {
+                                    dialog.dismiss();
+                                    isShowing = false;
+                                });
+                            }
+                        })
+                            .start();
+                    });
+            } catch (Exception e) {
+                logger.error("Error showing shake menu: " + e.getMessage());
+                isShowing = false;
+            }
+        });
+    }
+
+    private void setPreviewMenuButtonsEnabled(AlertDialog dialog, boolean enabled) {
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(enabled);
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setEnabled(enabled);
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setEnabled(enabled);
+    }
+
+    private void showConfiguredDefaultMenu() {
         activity.runOnUiThread(() -> {
             try {
                 String appName = activity.getPackageManager().getApplicationLabel(activity.getApplicationInfo()).toString();
@@ -120,7 +213,6 @@ public class ShakeMenu implements ShakeDetector.Listener {
                                     bridge.setServerAssetPath(path);
                                 }
 
-                                // Try to delete the current bundle
                                 try {
                                     updater.delete(current.getId());
                                 } catch (Exception err) {

--- a/api.md
+++ b/api.md
@@ -66,6 +66,7 @@ CapacitorUpdater can be configured with these options:
 - [`download`](#download)
 - [`next`](#next)
 - [`set`](#set)
+- [`startPreviewSession`](#startpreviewsession)
 - [`delete`](#delete)
 - [`setBundleError`](#setbundleerror)
 - [`list`](#list)
@@ -376,6 +377,30 @@ For other state preservation needs, save your data before calling this method (e
 `Promise<void>` — A promise that will never resolve because the JavaScript context is destroyed.
 
 **Throws:** {Error} When there is no index.html file inside the bundle folder.
+
+
+--------------------
+
+
+### startPreviewSession
+
+```typescript
+startPreviewSession() => Promise<void>
+```
+
+Start a temporary preview/testing session.
+
+This stores the currently active bundle as the pending fallback, enables the
+native shake menu, and makes the next applied bundle show a native notice
+explaining that shaking the device can reload or leave the preview.
+
+Use this before calling {@link set} for Expo Go-style preview flows.
+
+**Returns**
+
+`Promise<void>` — Resolves when preview session state is prepared.
+
+**Since:** 8.47.0
 
 
 --------------------

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -37,6 +37,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setStatsUrl", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setChannelUrl", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "set", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "startPreviewSession", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "list", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "delete", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setBundleError", returnType: CAPPluginReturnPromise),
@@ -76,7 +77,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "completeFlexibleUpdate", returnType: CAPPluginReturnPromise)
     ]
     public var implementation = CapgoUpdater()
-    private let pluginVersion: String = "8.46.3"
+    private let pluginVersion: String = "8.47.0"
     static let updateUrlDefault = "https://plugin.capgo.app/updates"
     static let statsUrlDefault = "https://plugin.capgo.app/stats"
     static let channelUrlDefault = "https://plugin.capgo.app/channel_self"
@@ -87,6 +88,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private let channelUrlDefaultsKey = "CapacitorUpdater.channelUrl"
     private let defaultChannelDefaultsKey = "CapacitorUpdater.defaultChannel"
     private let lastFailedBundleDefaultsKey = "CapacitorUpdater.lastFailedBundle"
+    private let previewSessionDefaultsKey = "CapacitorUpdater.previewSession"
+    private let previewPreviousShakeMenuDefaultsKey = "CapacitorUpdater.previewPreviousShakeMenu"
+    private let previewPreviousShakeChannelSelectorDefaultsKey = "CapacitorUpdater.previewPreviousShakeChannelSelector"
+    private let previewPreviousNextBundleDefaultsKey = "CapacitorUpdater.previewPreviousNextBundle"
     // Note: DELAY_CONDITION_PREFERENCES is now defined in DelayUpdateUtils.DELAY_CONDITION_PREFERENCES
     private var updateUrl = ""
     private var backgroundTaskID: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
@@ -136,6 +141,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private var webViewStatsReporter: WebViewStatsReporter?
     public var shakeMenuEnabled = false
     public var shakeChannelSelectorEnabled = false
+    public var previewSessionEnabled = false
+    private var previewSessionAlertPending = false
     let semaphoreReady = DispatchSemaphore(value: 0)
 
     private var delayUpdateUtils: DelayUpdateUtils!
@@ -232,6 +239,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         resetWhenUpdate = getConfig().getBoolean("resetWhenUpdate", true)
         shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
         shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
+        previewSessionEnabled = UserDefaults.standard.bool(forKey: previewSessionDefaultsKey)
+        if previewSessionEnabled {
+            shakeMenuEnabled = true
+            shakeChannelSelectorEnabled = false
+        }
         periodCheckDelay = Self.normalizedPeriodCheckDelaySeconds(getConfig().getInt("periodCheckDelay", 0))
 
         implementation.setPublicKey(getConfig().getString("publicKey") ?? "")
@@ -298,6 +310,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         // Check if app was recently installed/updated BEFORE cleanup updates the stored native build version.
         self.wasRecentlyInstalledOrUpdated = self.checkIfRecentlyInstalledOrUpdated()
+        let nativeBuildVersionChanged = self.hasNativeBuildVersionChanged()
+        if nativeBuildVersionChanged {
+            self.clearPreviewSessionForNativeBuildChange()
+        }
 
         if resetWhenUpdate {
             let didResetCurrentBundle = self.resetCurrentBundleForNativeBuildChangeIfNeeded()
@@ -908,6 +924,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
                 self.notifyBundleSet(next)
                 _ = self.implementation.setNextBundle(next: Optional<String>.none)
+                self.showPreviewSessionNoticeIfNeeded()
                 call.resolve()
                 return
             }
@@ -919,6 +936,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         if self._reload() {
+            self.showPreviewSessionNoticeIfNeeded()
             call.resolve()
         } else {
             logger.error("Reload failed")
@@ -956,7 +974,172 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("Reload failed after setting bundle \(id)")
         } else {
             self.notifyBundleSet(self.implementation.getBundleInfo(id: id))
+            self.showPreviewSessionNoticeIfNeeded()
             call.resolve()
+        }
+    }
+
+    @objc func startPreviewSession(_ call: CAPPluginCall) {
+        if !self.previewSessionEnabled {
+            let current = self.implementation.getCurrentBundle()
+            guard self.implementation.setPreviewFallbackBundle(fallback: current.getId()) else {
+                logger.error("Could not save current bundle as preview fallback")
+                call.reject("Could not save current bundle as preview fallback")
+                return
+            }
+
+            if let previousNext = self.implementation.getNextBundle(),
+               !previousNext.isDeleted(),
+               !previousNext.isErrorStatus() {
+                UserDefaults.standard.set(previousNext.getId(), forKey: self.previewPreviousNextBundleDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: self.previewPreviousNextBundleDefaultsKey)
+            }
+
+            UserDefaults.standard.set(self.shakeMenuEnabled, forKey: self.previewPreviousShakeMenuDefaultsKey)
+            UserDefaults.standard.set(self.shakeChannelSelectorEnabled, forKey: self.previewPreviousShakeChannelSelectorDefaultsKey)
+            logger.info("Preview session started with fallback bundle: \(current.toString())")
+        }
+
+        self.previewSessionEnabled = true
+        self.previewSessionAlertPending = true
+        self.shakeMenuEnabled = true
+        self.shakeChannelSelectorEnabled = false
+        UserDefaults.standard.set(true, forKey: self.previewSessionDefaultsKey)
+        UserDefaults.standard.synchronize()
+        call.resolve()
+    }
+
+    func leavePreviewSessionFromShakeMenu() -> Bool {
+        let previewBundle = self.implementation.getCurrentBundle()
+        let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
+
+        let didReset = self.resetToPreviewFallbackBundle()
+        guard didReset else {
+            return false
+        }
+
+        _ = self.implementation.unsetChannel(defaultChannelKey: self.defaultChannelDefaultsKey, configDefaultChannel: configDefaultChannel)
+        let previewFallbackBundle = self.implementation.getPreviewFallbackBundle()
+        self.endPreviewSession()
+        let restoredNextBundle = self.implementation.getNextBundle()
+        if !previewBundle.isBuiltin() &&
+            previewFallbackBundle?.getId() != previewBundle.getId() &&
+            restoredNextBundle?.getId() != previewBundle.getId() {
+            _ = self.implementation.delete(id: previewBundle.getId(), removeInfo: false)
+        }
+        return true
+    }
+
+    func reloadPreviewSessionFromShakeMenu() -> Bool {
+        self._reload()
+    }
+
+    func hasActivePreviewSession() -> Bool {
+        self.previewSessionEnabled
+    }
+
+    private func resetToPreviewFallbackBundle() -> Bool {
+        guard self.canPerformResetTransition() else { return false }
+        guard let fallback = self.implementation.getPreviewFallbackBundle(), !fallback.isErrorStatus() else {
+            logger.error("No preview fallback bundle available")
+            return false
+        }
+        guard self.implementation.canSet(bundle: fallback) else {
+            logger.error("Preview fallback bundle is not installable")
+            return false
+        }
+
+        let previousState = self.implementation.captureResetState()
+        let previousBundleName = self.implementation.getCurrentBundle().getVersionName()
+        logger.info("Resetting to preview fallback bundle: \(fallback.toString())")
+        if self.implementation.stagePreviewFallbackReload(bundle: fallback) && self._reload() {
+            self.implementation.finalizeResetTransition(previousBundleName: previousBundleName, isInternal: false)
+            self.notifyBundleSet(fallback)
+            return true
+        }
+        self.implementation.restoreResetState(previousState)
+        self.restoreLiveBundleStateAfterFailedReload()
+        return false
+    }
+
+    private func endPreviewSession() {
+        let previousShakeMenuEnabled = UserDefaults.standard.object(forKey: self.previewPreviousShakeMenuDefaultsKey) as? Bool
+            ?? getConfig().getBoolean("shakeMenu", false)
+        let previousShakeChannelSelectorEnabled = UserDefaults.standard.object(forKey: self.previewPreviousShakeChannelSelectorDefaultsKey) as? Bool
+            ?? getConfig().getBoolean("allowShakeChannelSelector", false)
+        self.restorePreviewPreviousNextBundle()
+
+        self.previewSessionEnabled = false
+        self.previewSessionAlertPending = false
+        self.shakeMenuEnabled = previousShakeMenuEnabled
+        self.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled
+        UserDefaults.standard.removeObject(forKey: self.previewSessionDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousShakeMenuDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousShakeChannelSelectorDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousNextBundleDefaultsKey)
+        _ = self.implementation.setPreviewFallbackBundle(fallback: nil)
+        UserDefaults.standard.synchronize()
+        logger.info("Preview session ended")
+    }
+
+    private func clearPreviewSessionForNativeBuildChange() {
+        guard self.previewSessionEnabled || self.implementation.getPreviewFallbackBundle() != nil else {
+            return
+        }
+        logger.info("Native build changed; clearing preview session state")
+        self.previewSessionEnabled = false
+        self.previewSessionAlertPending = false
+        self.shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
+        self.shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
+        UserDefaults.standard.removeObject(forKey: self.previewSessionDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousShakeMenuDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousShakeChannelSelectorDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousNextBundleDefaultsKey)
+        _ = self.implementation.setPreviewFallbackBundle(fallback: nil)
+        _ = self.implementation.setNextBundle(next: Optional<String>.none)
+        let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
+        _ = self.implementation.unsetChannel(defaultChannelKey: self.defaultChannelDefaultsKey, configDefaultChannel: configDefaultChannel)
+        UserDefaults.standard.synchronize()
+    }
+
+    private func restorePreviewPreviousNextBundle() {
+        guard let previousNextBundleId = UserDefaults.standard.string(forKey: self.previewPreviousNextBundleDefaultsKey),
+              !previousNextBundleId.isEmpty else {
+            _ = self.implementation.setNextBundle(next: Optional<String>.none)
+            return
+        }
+        if !self.implementation.setNextBundle(next: previousNextBundleId) {
+            logger.warn("Could not restore pre-preview next bundle: \(previousNextBundleId)")
+            _ = self.implementation.setNextBundle(next: Optional<String>.none)
+        }
+    }
+
+    private func showPreviewSessionNoticeIfNeeded() {
+        guard self.previewSessionEnabled && self.previewSessionAlertPending else {
+            return
+        }
+        self.previewSessionAlertPending = false
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(600)) {
+            guard self.previewSessionEnabled else {
+                return
+            }
+            if let topVC = UIApplication.topViewController(),
+               topVC.isKind(of: UIAlertController.self) {
+                self.previewSessionAlertPending = true
+                return
+            }
+
+            let alert = UIAlertController(
+                title: "Preview started",
+                message: "Shake your device anytime to reload or leave the test app.",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "Got it", style: .default))
+            if let topVC = UIApplication.topViewController() {
+                topVC.present(alert, animated: true)
+            }
         }
     }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -21,6 +21,7 @@ import UIKit
     private let INFO_SUFFIX: String = "_info"
     private let FALLBACK_VERSION: String = "pastVersion"
     private let NEXT_VERSION: String = "nextVersion"
+    private let PREVIEW_FALLBACK_VERSION: String = "previewFallbackVersion"
     private var unzipPercent = 0
     private let TEMP_UNZIP_PREFIX: String = "capgo_unzip_"
 
@@ -1599,6 +1600,15 @@ import UIKit
             return false
         }
 
+        if let previewFallback = self.getPreviewFallbackBundle(),
+           !previewFallback.isDeleted(),
+           !previewFallback.isErrorStatus(),
+           previewFallback.getId() == id {
+            logger.info("Cannot delete the preview fallback bundle")
+            logger.debug("Bundle ID: \(id)")
+            return false
+        }
+
         // Check if this is the next bundle and prevent deletion if it is
         if let next = self.getNextBundle(),
            !next.isDeleted() &&
@@ -1883,6 +1893,21 @@ import UIKit
         return true
     }
 
+    func stagePreviewFallbackReload(bundle: BundleInfo) -> Bool {
+        guard !bundle.isErrorStatus() else {
+            return false
+        }
+        if bundle.isBuiltin() {
+            self.setCurrentBundle(bundle: self.DEFAULT_FOLDER)
+            return true
+        }
+        guard bundleExists(id: bundle.getId()) else {
+            return false
+        }
+        self.setCurrentBundle(bundle: self.getBundleDirectory(id: bundle.getId()).path)
+        return true
+    }
+
     func finalizePendingReload(bundle: BundleInfo, previousBundleName: String) {
         guard !bundle.isBuiltin() else {
             return
@@ -1922,9 +1947,11 @@ import UIKit
     public func setSuccess(bundle: BundleInfo, autoDeletePrevious: Bool) {
         self.setBundleStatus(id: bundle.getId(), status: BundleStatus.SUCCESS)
         let fallback: BundleInfo = self.getFallbackBundle()
+        let previewFallback = self.getPreviewFallbackBundle()
+        let fallbackIsPreviewFallback = previewFallback?.getId() == fallback.getId()
         logger.info("Fallback bundle is: \(fallback.toString())")
         logger.info("Version successfully loaded: \(bundle.toString())")
-        if autoDeletePrevious && !fallback.isBuiltin() && fallback.getId() != bundle.getId() {
+        if autoDeletePrevious && !fallback.isBuiltin() && fallback.getId() != bundle.getId() && !fallbackIsPreviewFallback {
             let res = self.delete(id: fallback.getId())
             if res {
                 logger.info("Deleted previous bundle")
@@ -2456,6 +2483,33 @@ import UIKit
     public func getNextBundle() -> BundleInfo? {
         let id: String? = UserDefaults.standard.string(forKey: self.NEXT_VERSION)
         return self.getBundleInfo(id: id)
+    }
+
+    public func getPreviewFallbackBundle() -> BundleInfo? {
+        guard let id = UserDefaults.standard.string(forKey: self.PREVIEW_FALLBACK_VERSION) else {
+            return nil
+        }
+        let bundle = self.getBundleInfo(id: id)
+        if !bundle.isBuiltin() && !self.bundleExists(id: id) {
+            _ = self.setPreviewFallbackBundle(fallback: nil)
+            return nil
+        }
+        return bundle
+    }
+
+    public func setPreviewFallbackBundle(fallback: String?) -> Bool {
+        guard let fallbackId = fallback else {
+            UserDefaults.standard.removeObject(forKey: self.PREVIEW_FALLBACK_VERSION)
+            UserDefaults.standard.synchronize()
+            return true
+        }
+        let newBundle: BundleInfo = self.getBundleInfo(id: fallbackId)
+        if !newBundle.isBuiltin() && !self.bundleExists(id: fallbackId) {
+            return false
+        }
+        UserDefaults.standard.set(fallbackId, forKey: self.PREVIEW_FALLBACK_VERSION)
+        UserDefaults.standard.synchronize()
+        return true
     }
 
     public func setNextBundle(next: String?) -> Bool {

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -27,7 +27,8 @@ extension UIWindow {
     override open func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         if motion == .motionShake {
             // Find the CapacitorUpdaterPlugin instance
-            guard let bridge = (rootViewController as? CAPBridgeProtocol),
+            guard let bridgeViewController = rootViewController as? CAPBridgeViewController,
+                  let bridge = bridgeViewController.bridge,
                   let plugin = bridge.plugin(withName: "CapacitorUpdaterPlugin") as? CapacitorUpdaterPlugin else {
                 return
             }
@@ -37,8 +38,9 @@ extension UIWindow {
                 return
             }
 
-            // Check if channel selector mode is enabled
-            if plugin.shakeChannelSelectorEnabled {
+            if plugin.hasActivePreviewSession() {
+                showDefaultMenu(plugin: plugin, bridge: bridge)
+            } else if plugin.shakeChannelSelectorEnabled {
                 showChannelSelector(plugin: plugin, bridge: bridge)
             } else {
                 showDefaultMenu(plugin: plugin, bridge: bridge)
@@ -54,6 +56,48 @@ extension UIWindow {
             return
         }
 
+        if !plugin.hasActivePreviewSession() {
+            showConfiguredDefaultMenu(plugin: plugin, bridge: bridge)
+            return
+        }
+
+        let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "App"
+        let title = "Preview \(appName) Menu"
+        let message = "Reload the current preview or leave the test app."
+        let okButtonTitle = "Leave test app"
+        let reloadButtonTitle = "Reload app"
+        let cancelButtonTitle = "Close menu"
+
+        let alertShake = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+        alertShake.addAction(UIAlertAction(title: okButtonTitle, style: .default) { _ in
+            DispatchQueue.global(qos: .userInitiated).async {
+                if !plugin.leavePreviewSessionFromShakeMenu() {
+                    DispatchQueue.main.async {
+                        self.showError(message: "Could not leave the test app.", plugin: plugin)
+                    }
+                }
+            }
+        })
+
+        alertShake.addAction(UIAlertAction(title: reloadButtonTitle, style: .default) { _ in
+            DispatchQueue.main.async {
+                if !plugin.reloadPreviewSessionFromShakeMenu() {
+                    self.showError(message: "Could not reload the test app.", plugin: plugin)
+                }
+            }
+        })
+
+        alertShake.addAction(UIAlertAction(title: cancelButtonTitle, style: .default))
+
+        DispatchQueue.main.async {
+            if let topVC = UIApplication.topViewController() {
+                topVC.present(alertShake, animated: true)
+            }
+        }
+    }
+
+    private func showConfiguredDefaultMenu(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) {
         let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "App"
         let title = "Preview \(appName) Menu"
         let message = "What would you like to do?"

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -550,6 +550,20 @@ export interface CapacitorUpdaterPlugin {
   set(options: BundleId): Promise<void>;
 
   /**
+   * Start a temporary preview/testing session.
+   *
+   * This stores the currently active bundle as the pending fallback, enables the
+   * native shake menu, and makes the next applied bundle show a native notice
+   * explaining that shaking the device can reload or leave the preview.
+   *
+   * Use this before calling {@link set} for Expo Go-style preview flows.
+   *
+   * @returns {Promise<void>} Resolves when preview session state is prepared.
+   * @since 8.47.0
+   */
+  startPreviewSession(): Promise<void>;
+
+  /**
    * Delete a bundle from local storage to free up disk space.
    *
    * You cannot delete:

--- a/src/web.ts
+++ b/src/web.ts
@@ -88,6 +88,11 @@ export class CapacitorUpdaterWeb extends WebPlugin implements CapacitorUpdaterPl
     return;
   }
 
+  async startPreviewSession(): Promise<void> {
+    console.warn('Cannot start preview session in web');
+    return;
+  }
+
   async getDeviceId(): Promise<DeviceId> {
     console.warn('Cannot get ID in web');
     return { deviceId: 'default' };


### PR DESCRIPTION
## What
- Add a native `startPreviewSession()` updater API for temporary preview/test sessions.
- Store the current bundle as the preview fallback, enable the shake menu, show a native preview-started notice, and make the shake menu reload or leave the test app.
- Fix iOS shake menu plugin lookup and route leave-preview through the same reset transition used by the plugin.

## Why
- Capgo channel preview links need an Expo Go-style flow where a tester can enter a preview bundle and leave it from the native shake menu.

## How
- Persist preview session state while active.
- Use the existing pending-bundle reset path to restore the original bundle.
- Clear local channel override when leaving preview and regenerate docs for the new API.

## Testing
- `bun run fmt`
- `bun run build`
- `bun run verify:web`
- `bun run verify` partially: iOS passed; Android stopped before compile because no Java runtime is installed on this machine.

## Not Tested
- Android local Gradle compile/runtime shake flow due missing Java runtime locally. CI should cover Android once available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startPreviewSession(): a persisted preview/testing mode that preserves the current bundle as a fallback, enables a native shake menu with “Reload” and “Leave test app”, shows a native “Preview started” notice after reloads, and restores prior state when leaving preview.
  * Preview fallback is respected (won’t be removed automatically) and can be staged for reload.
  * Web: starting a preview session logs a warning and no-ops.

* **Documentation**
  * README/API reference updated with startPreviewSession() usage (since 8.47.0).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->