### PR TITLE
[codex] Guard background runner before bundle switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,11 @@ The bundle must include an `index.html` file at the root level.
 For encrypted bundles, provide the `sessionKey` and `checksum` parameters.
 For multi-file delta updates, provide the `manifest` array.
 
+**Android Background Runner note:** `@capacitor/background-runner` loads its
+configured runner script from native APK assets. Live updates cannot replace
+that runner script. Keep it stable across OTA updates and ship a native app
+update when the runner code changes.
+
 | Param         | Type                                                        | Description                                                                                  |
 | ------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#downloadoptions">DownloadOptions</a></code> | The {@link <a href="#downloadoptions">DownloadOptions</a>} for downloading a new bundle zip. |

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -18,12 +18,15 @@ import androidx.work.WorkManager;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Date;
@@ -63,6 +66,8 @@ public class CapgoUpdater {
     private static final String PREVIEW_FALLBACK_VERSION = "previewFallbackVersion";
     private static final String bundleDirectory = "versions";
     private static final String TEMP_UNZIP_PREFIX = "capgo_unzip_";
+    private static final String CAPACITOR_CONFIG_ASSET = "capacitor.config.json";
+    private static final String BACKGROUND_RUNNER_CONFIG_KEY = "BackgroundRunner";
 
     public static final String TAG = "Capacitor-updater";
     public SharedPreferences.Editor editor;
@@ -763,6 +768,7 @@ public class CapgoUpdater {
     }
 
     private void setCurrentBundle(final File bundle) {
+        this.cancelBackgroundRunnerWorkBeforeBundleSwitch();
         this.editor.putString(this.CAP_SERVER_PATH, bundle.getPath());
         logger.info("Current bundle set to: " + bundle);
         this.editor.commit();
@@ -770,6 +776,73 @@ public class CapgoUpdater {
 
     static boolean shouldResetForForeignBundle(final String bundlePath, final boolean isBuiltin, final boolean hasStoredBundleInfo) {
         return bundlePath != null && !bundlePath.trim().isEmpty() && !isBuiltin && !hasStoredBundleInfo;
+    }
+
+    static String getBackgroundRunnerLabelFromConfig(final String configJson) {
+        if (configJson == null || configJson.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            final JSONObject config = new JSONObject(configJson);
+            final JSONObject plugins = config.optJSONObject("plugins");
+            if (plugins == null) {
+                return null;
+            }
+
+            final JSONObject backgroundRunner = plugins.optJSONObject(BACKGROUND_RUNNER_CONFIG_KEY);
+            if (backgroundRunner == null) {
+                return null;
+            }
+
+            final String label = backgroundRunner.optString("label", "").trim();
+            return label.isEmpty() ? null : label;
+        } catch (JSONException ignored) {
+            return null;
+        }
+    }
+
+    private String readAssetAsString(final String assetPath) throws IOException {
+        final StringBuilder buffer = new StringBuilder();
+        try (
+            final BufferedReader reader = new BufferedReader(
+                new InputStreamReader(this.activity.getAssets().open(assetPath), StandardCharsets.UTF_8)
+            )
+        ) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                buffer.append(line).append('\n');
+            }
+        }
+        return buffer.toString();
+    }
+
+    private void cancelBackgroundRunnerWorkBeforeBundleSwitch() {
+        if (this.activity == null) {
+            return;
+        }
+
+        final String label;
+        try {
+            label = getBackgroundRunnerLabelFromConfig(this.readAssetAsString(CAPACITOR_CONFIG_ASSET));
+        } catch (IOException ignored) {
+            return;
+        }
+
+        if (label == null) {
+            return;
+        }
+
+        try {
+            final WorkManager workManager = WorkManager.getInstance(this.activity.getApplicationContext());
+            workManager.cancelUniqueWork(label);
+            workManager.cancelAllWorkByTag(label);
+            logger.info("Cancelled Background Runner work before bundle switch.");
+            logger.debug("Background Runner label: " + label);
+        } catch (Exception e) {
+            logger.warn("Failed to cancel Background Runner work before bundle switch.");
+            logger.debug("Background Runner cancellation error: " + e.getMessage());
+        }
     }
 
     private boolean hasStoredBundleInfo(final String id) {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -1126,6 +1126,28 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void testGetBackgroundRunnerLabelFromConfigExtractsLabel() {
+        final String config =
+            "{\"plugins\":{\"BackgroundRunner\":{\"label\":\"com.example.runner\",\"src\":\"runner.js\",\"autoStart\":true}}}";
+
+        assertEquals("com.example.runner", CapgoUpdater.getBackgroundRunnerLabelFromConfig(config));
+    }
+
+    @Test
+    public void testGetBackgroundRunnerLabelFromConfigReturnsNullWhenMissing() {
+        final String config = "{\"plugins\":{\"CapacitorUpdater\":{\"autoUpdate\":true}}}";
+
+        assertNull(CapgoUpdater.getBackgroundRunnerLabelFromConfig(config));
+    }
+
+    @Test
+    public void testGetBackgroundRunnerLabelFromConfigReturnsNullForBlankLabel() {
+        final String config = "{\"plugins\":{\"BackgroundRunner\":{\"label\":\"  \",\"src\":\"runner.js\"}}}";
+
+        assertNull(CapgoUpdater.getBackgroundRunnerLabelFromConfig(config));
+    }
+
+    @Test
     public void testGetBundleInfoBuiltinReturnsVersionBuildWhenPresent() {
         CapgoUpdater updater = new CapgoUpdater(null);
         updater.versionBuild = "1.2.3";

--- a/api.md
+++ b/api.md
@@ -281,6 +281,11 @@ The bundle must include an `index.html` file at the root level.
 For encrypted bundles, provide the `sessionKey` and `checksum` parameters.
 For multi-file delta updates, provide the `manifest` array.
 
+**Android Background Runner note:** `@capacitor/background-runner` loads its
+configured runner script from native APK assets. Live updates cannot replace
+that runner script. Keep it stable across OTA updates and ship a native app
+update when the runner code changes.
+
 **Parameters**
 
 | Name | Type | Description |

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -501,6 +501,11 @@ export interface CapacitorUpdaterPlugin {
    * For encrypted bundles, provide the `sessionKey` and `checksum` parameters.
    * For multi-file delta updates, provide the `manifest` array.
    *
+   * **Android Background Runner note:** `@capacitor/background-runner` loads its
+   * configured runner script from native APK assets. Live updates cannot replace
+   * that runner script. Keep it stable across OTA updates and ship a native app
+   * update when the runner code changes.
+   *
    * @example
    * const bundle = await CapacitorUpdater.download({
    *   url: `https://example.com/versions/${version}/dist.zip`,


### PR DESCRIPTION
## What
- Cancel configured Android `@capacitor/background-runner` WorkManager jobs before changing the active bundle path.
- Add unit coverage for extracting the Background Runner label from `capacitor.config.json`.
- Document that Android Background Runner scripts are native APK assets and cannot be replaced by live updates.

## Why
- Issue #643 reports Background Runner failures after live updates when the runner script changes.
- Android Background Runner loads `capacitor.config.json` and the runner script from native assets, so OTA cannot safely replace that script.
- Cancelling queued runner work before bundle switches is the smallest safe mitigation on the updater side.

## How
- Read the packaged `capacitor.config.json` asset, parse `plugins.BackgroundRunner.label`, and cancel matching unique work and work tags before storing a new active bundle path.
- Keep cancellation best-effort so apps without Background Runner or without readable config continue unchanged.
- Add docs through `src/definitions.ts` and regenerate `README.md`/`api.md`.

## Testing
- `bun run build`
- `cd android && ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest`
- `bun run verify:android`
- `bun run verify:ios`

## Not Tested
- Manual reproduction with an app using `@capacitor/background-runner` on a physical Android device.

Generated by an AI agent, with local verification above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Background Runner job management during bundle updates

* **Documentation**
  * Clarified that Background Runner scripts from APK assets cannot be replaced via OTA updates; runner code must remain stable across updates

* **Tests**
  * Added unit tests to verify Background Runner configuration parsing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->