### PR TITLE
[codex] Prevent update path traversal

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -193,6 +193,30 @@ public class CapgoUpdater {
         this.cachedKeyId = CryptoCipher.calcKeyId(publicKey);
     }
 
+    static File resolvePathInsideDirectory(final File baseDirectory, final String relativePath) throws IOException {
+        if (relativePath == null || relativePath.isEmpty()) {
+            throw new IOException("Invalid empty path");
+        }
+        if (relativePath.contains("\\") || relativePath.indexOf('\0') >= 0) {
+            throw new IOException("Invalid path separator");
+        }
+        if (new File(relativePath).isAbsolute()) {
+            throw new IOException("Absolute paths are not allowed");
+        }
+
+        final File canonicalBase = baseDirectory.getCanonicalFile();
+        final File canonicalTarget = new File(canonicalBase, relativePath).getCanonicalFile();
+        final String basePath = canonicalBase.getPath();
+        final String targetPath = canonicalTarget.getPath();
+        final String normalizedBasePath = basePath.endsWith(File.separator) ? basePath : basePath + File.separator;
+
+        if (!targetPath.equals(basePath) && !targetPath.startsWith(normalizedBasePath)) {
+            throw new IOException("Path escapes base directory: " + relativePath);
+        }
+
+        return canonicalTarget;
+    }
+
     public String getKeyId() {
         return this.cachedKeyId;
     }
@@ -213,22 +237,20 @@ public class CapgoUpdater {
 
             ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
-                if (entry.getName().contains("\\")) {
-                    logger.error("Unzip failed: Windows path not supported");
-                    logger.debug("Invalid path: " + entry.getName());
-                    this.sendStats("windows_path_fail");
+                final File file;
+                try {
+                    file = resolvePathInsideDirectory(targetDirectory, entry.getName());
+                } catch (IOException e) {
+                    if (entry.getName().contains("\\")) {
+                        logger.error("Unzip failed: Windows path not supported");
+                        logger.debug("Invalid path: " + entry.getName());
+                        this.sendStats("windows_path_fail");
+                    } else {
+                        this.sendStats("canonical_path_fail");
+                    }
+                    throw e;
                 }
-                final File file = new File(targetDirectory, entry.getName());
-                final String canonicalPath = file.getCanonicalPath();
-                final String canonicalDir = targetDirectory.getCanonicalPath();
                 final File dir = entry.isDirectory() ? file : file.getParentFile();
-
-                if (!canonicalPath.startsWith(canonicalDir)) {
-                    this.sendStats("canonical_path_fail");
-                    throw new FileNotFoundException(
-                        "SecurityException, Failed to ensure directory is the start path : " + canonicalDir + " of " + canonicalPath
-                    );
-                }
 
                 assert dir != null;
                 if (!dir.isDirectory() && !dir.mkdirs()) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -355,6 +355,7 @@ public class DownloadService extends Worker {
                     builtinFile = resolveManifestBuiltinFile(builtinFolder, fileName);
                 } catch (IOException e) {
                     logger.error("Invalid manifest file path: " + fileName);
+                    sendStatsAsync("manifest_path_fail", version + ":" + fileName);
                     hasError.set(true);
                     continue;
                 }

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -168,6 +168,16 @@ public class DownloadService extends Worker {
         return Result.success(output);
     }
 
+    static File resolveManifestTargetFile(final File destFolder, final String fileName) throws IOException {
+        final boolean isBrotli = fileName.endsWith(".br");
+        final String targetFileName = isBrotli ? fileName.substring(0, fileName.length() - 3) : fileName;
+        return CapgoUpdater.resolvePathInsideDirectory(destFolder, targetFileName);
+    }
+
+    static File resolveManifestBuiltinFile(final File builtinFolder, final String fileName) throws IOException {
+        return CapgoUpdater.resolvePathInsideDirectory(builtinFolder, fileName);
+    }
+
     private String getInputString(String key, String fallback) {
         String value = getInputData().getString(key);
         return value != null ? value : fallback;
@@ -338,11 +348,19 @@ public class DownloadService extends Worker {
                 boolean isBrotli = fileName.endsWith(".br");
                 String targetFileName = isBrotli ? fileName.substring(0, fileName.length() - 3) : fileName;
 
-                File targetFile = new File(destFolder, targetFileName);
+                File targetFile;
+                File builtinFile;
+                try {
+                    targetFile = resolveManifestTargetFile(destFolder, fileName);
+                    builtinFile = resolveManifestBuiltinFile(builtinFolder, fileName);
+                } catch (IOException e) {
+                    logger.error("Invalid manifest file path: " + fileName);
+                    hasError.set(true);
+                    continue;
+                }
                 String cacheBaseName = new File(isBrotli ? targetFileName : fileName).getName();
                 File cacheFile = new File(cacheFolder, finalFileHash + "_" + cacheBaseName);
                 final File legacyCacheFile = isBrotli ? new File(cacheFolder, finalFileHash + "_" + new File(fileName).getName()) : null;
-                File builtinFile = new File(builtinFolder, fileName);
 
                 // Ensure parent directories of the target file exist
                 if (!Objects.requireNonNull(targetFile.getParentFile()).exists() && !targetFile.getParentFile().mkdirs()) {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -15,8 +15,12 @@ import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginHandle;
 import io.github.g00fy2.versioncompare.Version;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -26,6 +30,8 @@ import java.util.Map;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.json.JSONArray;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -221,6 +227,16 @@ public class CapacitorUpdaterUnitTest {
         public BundleInfo getNextBundle() {
             return null;
         }
+    }
+
+    private static final class StatsIgnoringCapgoUpdater extends CapgoUpdater {
+
+        StatsIgnoringCapgoUpdater() {
+            super(mock(Logger.class));
+        }
+
+        @Override
+        public void sendStats(final String action) {}
     }
 
     private static final class FreshDownloadCapgoUpdater extends CapgoUpdater {
@@ -712,6 +728,34 @@ public class CapacitorUpdaterUnitTest {
         Files.createFile(indexFile);
         indexFile.toFile().deleteOnExit();
         return tempDir;
+    }
+
+    private static Path createZipWithEntry(final String entryName) throws Exception {
+        final Path zipPath = Files.createTempFile("capgo-zip-path", ".zip");
+        zipPath.toFile().deleteOnExit();
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+            zip.putNextEntry(new ZipEntry(entryName));
+            zip.write("owned".getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return zipPath;
+    }
+
+    private static File invokeUnzip(final CapgoUpdater updater, final String id, final Path zipPath, final String dest) throws Exception {
+        final Method method = CapgoUpdater.class.getDeclaredMethod("unzip", String.class, File.class, String.class);
+        method.setAccessible(true);
+        try {
+            return (File) method.invoke(updater, id, zipPath.toFile(), dest);
+        } catch (InvocationTargetException e) {
+            final Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw e;
+        }
     }
 
     private static void invokeBackgroundDownload(final CapacitorUpdaterPlugin plugin) throws Exception {
@@ -2193,6 +2237,43 @@ public class CapacitorUpdaterUnitTest {
 
             verify(splashScreenPlugin, never()).invoke(eq("hide"), any(PluginCall.class));
         }
+    }
+
+    @Test
+    public void testZipEntryRejectsSiblingPrefixPathTraversal() throws Exception {
+        final Path documentsDir = Files.createTempDirectory("capgo-zip-path");
+        documentsDir.toFile().deleteOnExit();
+        final Path zipPath = createZipWithEntry("../bundle-evil/pwned.txt");
+        final Path escapedPath = documentsDir.resolve("bundle-evil").resolve("pwned.txt");
+
+        final CapgoUpdater updater = new StatsIgnoringCapgoUpdater();
+        updater.documentsDir = documentsDir.toFile();
+
+        assertThrows(IOException.class, () -> invokeUnzip(updater, "bundle-id", zipPath, "bundle"));
+        assertFalse(Files.exists(escapedPath));
+    }
+
+    @Test
+    public void testManifestTargetRejectsPathTraversalAfterBrotliSuffixIsRemoved() throws Exception {
+        final Path documentsDir = Files.createTempDirectory("capgo-manifest-path");
+        documentsDir.toFile().deleteOnExit();
+        final Path destFolder = documentsDir.resolve("bundle");
+        Files.createDirectories(destFolder);
+
+        assertThrows(IOException.class, () -> DownloadService.resolveManifestTargetFile(destFolder.toFile(), "../bundle-evil/app.js.br"));
+        assertFalse(Files.exists(documentsDir.resolve("bundle-evil")));
+    }
+
+    @Test
+    public void testManifestTargetAllowsNestedBrotliFileInsideBundle() throws Exception {
+        final Path documentsDir = Files.createTempDirectory("capgo-manifest-valid");
+        documentsDir.toFile().deleteOnExit();
+        final Path destFolder = documentsDir.resolve("bundle");
+        Files.createDirectories(destFolder);
+
+        final File resolved = DownloadService.resolveManifestTargetFile(destFolder.toFile(), "assets/app.js.br");
+
+        assertEquals(destFolder.resolve("assets").resolve("app.js").toFile().getCanonicalFile(), resolved);
     }
 
     @Test

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -1009,6 +1009,7 @@ import UIKit
                 builtinFilePath = try Self.resolvePathInsideDirectory(baseDirectory: builtinFolder, relativePath: fileName)
             } catch {
                 logger.error("Invalid manifest file path: \(fileName)")
+                self.sendStats(action: "manifest_path_fail", versionName: "\(version):\(fileName)")
                 errorLock.lock()
                 if downloadError == nil {
                     downloadError = error

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -97,6 +97,43 @@ import UIKit
         let timedOut: Bool
     }
 
+    enum SecurePathError: Error {
+        case emptyPath
+        case windowsPath
+        case absolutePath
+        case pathTraversal
+    }
+
+    static func resolvePathInsideDirectory(baseDirectory: URL, relativePath: String) throws -> URL {
+        if relativePath.isEmpty {
+            throw SecurePathError.emptyPath
+        }
+        if relativePath.contains("\\") || relativePath.contains("\0") {
+            throw SecurePathError.windowsPath
+        }
+        if (relativePath as NSString).isAbsolutePath {
+            throw SecurePathError.absolutePath
+        }
+
+        let canonicalBase = baseDirectory.standardizedFileURL
+        let canonicalBasePath = canonicalBase.path
+        let normalizedBasePath = canonicalBasePath.hasSuffix("/") ? canonicalBasePath : "\(canonicalBasePath)/"
+        let canonicalTarget = canonicalBase.appendingPathComponent(relativePath).standardizedFileURL
+        let canonicalTargetPath = canonicalTarget.path
+
+        if canonicalTargetPath != canonicalBasePath && !canonicalTargetPath.hasPrefix(normalizedBasePath) {
+            throw SecurePathError.pathTraversal
+        }
+
+        return canonicalTarget
+    }
+
+    static func resolveManifestTargetPath(baseDirectory: URL, fileName: String) throws -> URL {
+        let isBrotli = fileName.hasSuffix(".br")
+        let targetFileName = isBrotli ? String(fileName.dropLast(3)) : fileName
+        return try resolvePathInsideDirectory(baseDirectory: baseDirectory, relativePath: targetFileName)
+    }
+
     private func isTimedOutError(_ error: Error?) -> Bool {
         guard let nsError = error as NSError? else {
             return false
@@ -491,21 +528,15 @@ import UIKit
         }
     }
 
-    private func validateZipEntry(path: String, destUnZip: URL) throws {
-        // Check for Windows paths
-        if path.contains("\\") {
+    private func resolveZipEntry(path: String, destUnZip: URL) throws -> URL {
+        do {
+            return try Self.resolvePathInsideDirectory(baseDirectory: destUnZip, relativePath: path)
+        } catch SecurePathError.windowsPath {
             logger.error("Unzip failed: Windows path not supported")
             logger.debug("Invalid path: \(path)")
             self.sendStats(action: "windows_path_fail")
             throw CustomError.cannotUnzip
-        }
-
-        // Check for path traversal
-        let fileURL = destUnZip.appendingPathComponent(path)
-        let canonicalPath = fileURL.standardizedFileURL.path
-        let canonicalDir = destUnZip.standardizedFileURL.path
-
-        if !canonicalPath.hasPrefix(canonicalDir) {
+        } catch {
             self.sendStats(action: "canonical_path_fail")
             throw CustomError.cannotUnzip
         }
@@ -596,10 +627,7 @@ import UIKit
 
         do {
             for entry in archive {
-                // Validate entry path for security
-                try validateZipEntry(path: entry.path, destUnZip: destUnZip)
-
-                let destPath = destUnZip.appendingPathComponent(entry.path)
+                let destPath = try resolveZipEntry(path: entry.path, destUnZip: destUnZip)
 
                 if entry.type == .directory {
                     try FileManager.default.createDirectory(at: destPath, withIntermediateDirectories: true, attributes: nil)
@@ -974,8 +1002,21 @@ import UIKit
             let legacyCacheFilePath: URL? = isBrotli ? cacheFolder.appendingPathComponent("\(finalFileHash)_\(fileNameWithoutPath)") : nil
 
             let destFileName = isBrotli ? String(fileName.dropLast(3)) : fileName
-            let destFilePath = destFolder.appendingPathComponent(destFileName)
-            let builtinFilePath = builtinFolder.appendingPathComponent(fileName)
+            let destFilePath: URL
+            let builtinFilePath: URL
+            do {
+                destFilePath = try Self.resolveManifestTargetPath(baseDirectory: destFolder, fileName: fileName)
+                builtinFilePath = try Self.resolvePathInsideDirectory(baseDirectory: builtinFolder, relativePath: fileName)
+            } catch {
+                logger.error("Invalid manifest file path: \(fileName)")
+                errorLock.lock()
+                if downloadError == nil {
+                    downloadError = error
+                }
+                errorLock.unlock()
+                hasError.value = true
+                continue
+            }
 
             // Create parent directories synchronously (before operations start)
             try? FileManager.default.createDirectory(at: destFilePath.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -1651,6 +1651,53 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertNotNil(updater)
     }
 
+    func testZipEntryPathRejectsSiblingPrefixPathTraversal() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let base = root.appendingPathComponent("bundle")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        XCTAssertThrowsError(
+            try CapgoUpdater.resolvePathInsideDirectory(
+                baseDirectory: base,
+                relativePath: "../bundle-evil/pwned.txt"
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("bundle-evil/pwned.txt").path))
+    }
+
+    func testManifestTargetPathRejectsPathTraversalAfterBrotliSuffixIsRemoved() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let base = root.appendingPathComponent("bundle")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        XCTAssertThrowsError(
+            try CapgoUpdater.resolveManifestTargetPath(
+                baseDirectory: base,
+                fileName: "../bundle-evil/app.js.br"
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("bundle-evil/app.js").path))
+    }
+
+    func testManifestTargetPathAllowsNestedBrotliFileInsideBundle() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let base = root.appendingPathComponent("bundle")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = try CapgoUpdater.resolveManifestTargetPath(
+            baseDirectory: base,
+            fileName: "assets/app.js.br"
+        )
+
+        XCTAssertEqual(
+            resolved.standardizedFileURL.path,
+            base.appendingPathComponent("assets/app.js").standardizedFileURL.path
+        )
+    }
+
     // MARK: - Performance Tests
 
     func testPerformanceStringTrim() {


### PR DESCRIPTION
## What
- Harden Android and iOS update file path handling for zip extraction and manifest downloads.
- Add regression tests for malicious zip entries and manifest file names, including Brotli manifest targets.

## Why
- API-provided update metadata and downloaded archives must not be able to write outside the intended bundle directory via path traversal or sibling-prefix paths.

## How
- Resolve update paths against the canonical destination directory and require the resolved target to remain inside that directory.
- Reject empty, absolute, Windows-style, and null-containing paths before writing files.
- Reuse the secure resolver for manifest target files, manifest bundled-file lookups, and zip entries.

## Testing
- `bun run fmt`
- `bun run verify`
- Focused Android path traversal tests via `./gradlew testDebugUnitTest --tests ...`
- Focused iOS path traversal tests via `./scripts/test-ios.sh -only-testing:...`
- `bun run lint` was also run; it still fails on existing repo-wide SwiftLint/ESLint issues unrelated to this change.

## Not Tested
- Device-level end-to-end update installation beyond the existing native build/test verification.

Generated with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened protections against path traversal during app extraction and manifest processing on Android and iOS.
  * Improved handling and validation of compressed/manifest filenames to prevent invalid destination paths; invalid entries are now logged and skipped.
  * Enhanced error reporting and metrics for path-resolution failures.

* **Tests**
  * Added cross-platform regression tests covering path traversal, compressed-filename edge cases, and valid nested bundle paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->