### PR TITLE
fix: refresh previews from payload url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2200,9 +2200,10 @@ If you don't use backend, you need to provide the URL and version of the bundle.
 
 ##### StartPreviewSessionOptions
 
-| Prop        | Type                | Description                                                                                                                                                                                     | Default                | Since  |
-| ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------ |
-| **`appId`** | <code>string</code> | App id to use while the preview session is active. The previous app id is restored when leaving the preview session. Requires {@link PluginsConfig.CapacitorUpdater.allowPreview} to be `true`. | <code>undefined</code> | 8.47.0 |
+| Prop             | Type                | Description                                                                                                                                                                                                                                                               | Default                | Since  |
+| ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------ |
+| **`appId`**      | <code>string</code> | App id to use while the preview session is active. The previous app id is restored when leaving the preview session. Requires {@link PluginsConfig.CapacitorUpdater.allowPreview} to be `true`.                                                                           | <code>undefined</code> | 8.47.0 |
+| **`payloadUrl`** | <code>string</code> | HTTP(S) URL returning a preview download payload. When provided, the native shake reload action fetches this payload again before reloading so channel previews can move to the latest bundle. Requires {@link PluginsConfig.CapacitorUpdater.allowPreview} to be `true`. | <code>undefined</code> | 8.48.0 |
 
 
 ##### BundleListResult

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -49,9 +49,13 @@ import com.google.android.play.core.install.model.AppUpdateType;
 import com.google.android.play.core.install.model.InstallStatus;
 import com.google.android.play.core.install.model.UpdateAvailability;
 import io.github.g00fy2.versioncompare.Version;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -98,7 +102,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private static final String PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY = "CapacitorUpdater.previewPreviousShakeChannelSelector";
     private static final String PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY = "CapacitorUpdater.previewPreviousNextBundle";
     private static final String PREVIEW_PREVIOUS_APP_ID_PREF_KEY = "CapacitorUpdater.previewPreviousAppId";
+    private static final String PREVIEW_PREVIOUS_DEFAULT_CHANNEL_PREF_KEY = "CapacitorUpdater.previewPreviousDefaultChannel";
+    private static final String PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY = "CapacitorUpdater.previewPreviousDefaultChannelWasSet";
     private static final String PREVIEW_APP_ID_PREF_KEY = "CapacitorUpdater.previewAppId";
+    private static final String PREVIEW_PAYLOAD_URL_PREF_KEY = "CapacitorUpdater.previewPayloadUrl";
     private static final String[] BREAKING_EVENT_NAMES = { "breakingAvailable", "majorAvailable" };
     private static final String LAST_FAILED_BUNDLE_PREF_KEY = "CapacitorUpdater.lastFailedBundle";
     private static final String LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY = "CapacitorUpdater.lastReportedAppExitTimestamp";
@@ -1930,6 +1937,20 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
     }
 
+    private BundleInfo downloadBundle(
+        final String url,
+        final String version,
+        final String sessionKey,
+        final String checksum,
+        final JSONArray manifest
+    ) throws IOException {
+        if (manifest != null) {
+            return this.implementation.downloadManifest(url, version, sessionKey, checksum, manifest);
+        }
+
+        return this.implementation.download(url, version, sessionKey, checksum);
+    }
+
     @PluginMethod
     public void download(final PluginCall call) {
         final String url = call.getString("url");
@@ -1951,20 +1972,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             logger.info("Downloading " + url);
             startNewThread(() -> {
                 try {
-                    final BundleInfo downloaded;
-                    if (manifest != null) {
-                        // For manifest downloads, we need to handle this asynchronously
-                        // to avoid automatically scheduling/applying the downloaded bundle.
-                        // Manual download must not schedule/apply the bundle automatically.
-                        CapacitorUpdaterPlugin.this.implementation.downloadBackground(url, version, sessionKey, checksum, manifest, false);
-                        // Return immediately with a pending status - the actual result will come via listeners
-                        final String id = CapacitorUpdaterPlugin.this.implementation.randomString();
-                        downloaded = new BundleInfo(id, version, BundleStatus.DOWNLOADING, new Date(System.currentTimeMillis()), "");
-                        call.resolve(InternalUtils.mapToJSObject(downloaded.toJSONMap()));
-                        return;
-                    } else {
-                        downloaded = CapacitorUpdaterPlugin.this.implementation.download(url, version, sessionKey, checksum);
-                    }
+                    final BundleInfo downloaded = this.downloadBundle(url, version, sessionKey, checksum, manifest);
                     if (downloaded.isErrorStatus()) {
                         throw new RuntimeException("Download failed: " + downloaded.getStatus());
                     } else {
@@ -2231,6 +2239,13 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return;
         }
         final String previewAppId = this.normalizePreviewAppId(call.getString("appId"));
+        final String rawPayloadUrl = call.getString("payloadUrl");
+        final String previewPayloadUrl = this.normalizePreviewPayloadUrl(rawPayloadUrl);
+        if (this.hasPreviewPayloadUrl(rawPayloadUrl) && previewPayloadUrl == null) {
+            logger.error("startPreviewSession called with invalid payloadUrl");
+            call.reject("Invalid preview payloadUrl");
+            return;
+        }
         startNewThread(() -> {
             try {
                 if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
@@ -2249,6 +2264,16 @@ public class CapacitorUpdaterPlugin extends Plugin {
                     }
 
                     this.editor.putString(PREVIEW_PREVIOUS_APP_ID_PREF_KEY, this.implementation.appId);
+                    if (this.prefs.contains(DEFAULT_CHANNEL_PREF_KEY)) {
+                        this.editor.putString(
+                            PREVIEW_PREVIOUS_DEFAULT_CHANNEL_PREF_KEY,
+                            this.prefs.getString(DEFAULT_CHANNEL_PREF_KEY, "")
+                        );
+                        this.editor.putBoolean(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY, true);
+                    } else {
+                        this.editor.remove(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_PREF_KEY);
+                        this.editor.putBoolean(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY, false);
+                    }
                     this.editor.putBoolean(PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY, Boolean.TRUE.equals(this.shakeMenuEnabled));
                     this.editor.putBoolean(
                         PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY,
@@ -2261,6 +2286,13 @@ public class CapacitorUpdaterPlugin extends Plugin {
                     this.setActiveAppId(previewAppId);
                     this.editor.putString(PREVIEW_APP_ID_PREF_KEY, previewAppId);
                     logger.info("Preview session using appId: " + previewAppId);
+                }
+
+                if (previewPayloadUrl != null) {
+                    this.editor.putString(PREVIEW_PAYLOAD_URL_PREF_KEY, previewPayloadUrl);
+                    logger.info("Preview session using payload URL");
+                } else {
+                    this.editor.remove(PREVIEW_PAYLOAD_URL_PREF_KEY);
                 }
 
                 this.previewSessionEnabled = true;
@@ -2287,9 +2319,6 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return false;
         }
 
-        if (!this.clearPreviewChannelOverride()) {
-            return false;
-        }
         final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
         this.endPreviewSession();
         final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
@@ -2308,6 +2337,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     public boolean reloadPreviewSessionFromShakeMenu() {
+        final String payloadUrl = this.storedPreviewPayloadUrl();
+        if (payloadUrl != null) {
+            return this.refreshPreviewSessionFromPayloadUrl(payloadUrl);
+        }
+
         return this._reload();
     }
 
@@ -2350,6 +2384,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         );
         this.restorePreviewPreviousNextBundle();
         this.restorePreviewPreviousAppId();
+        this.restorePreviewPreviousDefaultChannel();
 
         this.previewSessionEnabled = false;
         this.previewSessionAlertPending = false;
@@ -2376,6 +2411,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
         this.restorePreviewPreviousNextBundle();
         this.restorePreviewPreviousAppId();
+        this.restorePreviewPreviousDefaultChannel();
         this.previewSessionEnabled = false;
         this.previewSessionAlertPending = false;
         this.implementation.previewSession = false;
@@ -2393,7 +2429,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.editor.remove(PREVIEW_PREVIOUS_SHAKE_CHANNEL_SELECTOR_PREF_KEY);
         this.editor.remove(PREVIEW_PREVIOUS_NEXT_BUNDLE_PREF_KEY);
         this.editor.remove(PREVIEW_PREVIOUS_APP_ID_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_PREF_KEY);
+        this.editor.remove(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY);
         this.editor.remove(PREVIEW_APP_ID_PREF_KEY);
+        this.editor.remove(PREVIEW_PAYLOAD_URL_PREF_KEY);
         this.editor.apply();
     }
 
@@ -2411,6 +2450,23 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
         this.setActiveAppId(previousAppId);
         logger.info("Restored appId after preview: " + previousAppId);
+    }
+
+    private void restorePreviewPreviousDefaultChannel() {
+        final String configDefaultChannel = this.getConfig().getString("defaultChannel", "");
+        if (this.prefs.getBoolean(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY, false)) {
+            final String previousDefaultChannel = this.prefs.getString(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_PREF_KEY, "");
+            this.editor.putString(DEFAULT_CHANNEL_PREF_KEY, previousDefaultChannel);
+            this.implementation.defaultChannel = previousDefaultChannel;
+            this.editor.apply();
+            logger.info("Restored defaultChannel after preview");
+            return;
+        }
+
+        this.editor.remove(DEFAULT_CHANNEL_PREF_KEY);
+        this.implementation.defaultChannel = configDefaultChannel;
+        this.editor.apply();
+        logger.info("Restored defaultChannel after preview to config value");
     }
 
     private String normalizePreviewAppId(final String rawAppId) {
@@ -2431,6 +2487,131 @@ public class CapacitorUpdaterPlugin extends Plugin {
         return appId;
     }
 
+    private boolean hasPreviewPayloadUrl(final String rawPayloadUrl) {
+        if (rawPayloadUrl == null) {
+            return false;
+        }
+
+        final String payloadUrl = rawPayloadUrl.trim();
+        if (payloadUrl.isEmpty()) {
+            return false;
+        }
+
+        final String lowercasedPayloadUrl = payloadUrl.toLowerCase(java.util.Locale.ROOT);
+        return !"undefined".equals(lowercasedPayloadUrl) && !"null".equals(lowercasedPayloadUrl);
+    }
+
+    private String normalizePreviewPayloadUrl(final String rawPayloadUrl) {
+        if (!this.hasPreviewPayloadUrl(rawPayloadUrl)) {
+            return null;
+        }
+
+        final String payloadUrl = rawPayloadUrl.trim();
+        try {
+            final URL parsedUrl = new URL(payloadUrl);
+            final String protocol = parsedUrl.getProtocol();
+            if (!"https".equals(protocol) && !"http".equals(protocol)) {
+                return null;
+            }
+            return parsedUrl.toString();
+        } catch (final MalformedURLException ignored) {
+            return null;
+        }
+    }
+
+    private String storedPreviewPayloadUrl() {
+        return this.normalizePreviewPayloadUrl(this.prefs.getString(PREVIEW_PAYLOAD_URL_PREF_KEY, null));
+    }
+
+    private String readResponseBody(final InputStream stream) throws IOException {
+        if (stream == null) {
+            return "";
+        }
+
+        try (InputStream input = stream; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            final byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private JSONObject fetchPreviewPayload(final String payloadUrl) throws IOException, JSONException {
+        final HttpURLConnection connection = (HttpURLConnection) new URL(payloadUrl).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setConnectTimeout(30000);
+        connection.setReadTimeout(60000);
+
+        try {
+            final int statusCode = connection.getResponseCode();
+            final String body = this.readResponseBody(
+                statusCode >= 200 && statusCode < 300 ? connection.getInputStream() : connection.getErrorStream()
+            );
+            final JSONObject payload = new JSONObject(body);
+            if (statusCode < 200 || statusCode >= 300) {
+                throw new IOException(
+                    payload.optString("message", payload.optString("error", "Preview payload request failed with HTTP " + statusCode))
+                );
+            }
+            return payload;
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private BundleInfo downloadPreviewPayloadBundle(final JSONObject payload) throws IOException, JSONException {
+        final String version = payload.optString("version", "").trim();
+        if (version.isEmpty()) {
+            throw new IOException("Preview payload is missing a version");
+        }
+
+        final JSONArray manifest = payload.optJSONArray("manifest");
+        final String url = payload.optString("url", "");
+        if ((url == null || url.isEmpty()) && (manifest == null || manifest.length() == 0)) {
+            throw new IOException("Preview payload is missing download information");
+        }
+
+        return this.downloadBundle(
+            url == null || url.isEmpty() ? "https://404.capgo.app/no.zip" : url,
+            version,
+            payload.optString("sessionKey", ""),
+            payload.optString("checksum", ""),
+            manifest
+        );
+    }
+
+    private boolean refreshPreviewSessionFromPayloadUrl(final String payloadUrl) {
+        try {
+            final JSONObject payload = this.fetchPreviewPayload(payloadUrl);
+            final String version = payload.optString("version", "").trim();
+            if (version.isEmpty()) {
+                throw new IOException("Preview payload is missing a version");
+            }
+
+            if (version.equals(this.implementation.getCurrentBundle().getVersionName())) {
+                logger.info("Preview payload unchanged, reloading current bundle");
+                return this._reload();
+            }
+
+            final BundleInfo next = this.downloadPreviewPayloadBundle(payload);
+            if (next.isErrorStatus()) {
+                throw new IOException("Download failed: " + next.getStatus());
+            }
+            if (!this.implementation.set(next.getId())) {
+                throw new IOException("Downloaded preview bundle cannot be applied");
+            }
+
+            this.notifyBundleSet(next);
+            return this._reload();
+        } catch (final Exception err) {
+            logger.error("Could not refresh preview session: " + err.getMessage());
+            return false;
+        }
+    }
+
     private void clearPreviewSessionForNativeBuildChange() {
         if (!Boolean.TRUE.equals(this.previewSessionEnabled) && this.implementation.getPreviewFallbackBundle() == null) {
             return;
@@ -2442,33 +2623,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
         this.restorePreviewPreviousAppId();
+        this.restorePreviewPreviousDefaultChannel();
         this.implementation.setPreviewFallbackBundle(null);
         this.implementation.setNextBundle(null);
-        this.clearPreviewChannelOverride();
         this.clearPreviewSessionPreferences();
-    }
-
-    private boolean clearPreviewChannelOverride() {
-        final String configDefaultChannel = this.getConfig().getString("defaultChannel", "");
-        final AtomicReference<Map<String, Object>> unsetChannelResult = new AtomicReference<>();
-        try {
-            this.implementation.unsetChannel(this.editor, DEFAULT_CHANNEL_PREF_KEY, configDefaultChannel, unsetChannelResult::set);
-        } catch (final Exception err) {
-            logger.error("Could not clear preview channel override: " + err.getMessage());
-            return false;
-        }
-
-        final Map<String, Object> result = unsetChannelResult.get();
-        if (result == null) {
-            logger.error("Could not clear preview channel override: no result");
-            return false;
-        }
-        if (result.containsKey("error")) {
-            final Object message = result.getOrDefault("message", result.get("error"));
-            logger.error("Could not clear preview channel override: " + message);
-            return false;
-        }
-        return true;
     }
 
     private void restorePreviewPreviousNextBundle() {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -101,7 +101,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private let previewPreviousShakeChannelSelectorDefaultsKey = "CapacitorUpdater.previewPreviousShakeChannelSelector"
     private let previewPreviousNextBundleDefaultsKey = "CapacitorUpdater.previewPreviousNextBundle"
     private let previewPreviousAppIdDefaultsKey = "CapacitorUpdater.previewPreviousAppId"
+    private let previewPreviousDefaultChannelDefaultsKey = "CapacitorUpdater.previewPreviousDefaultChannel"
+    private let previewPreviousDefaultChannelWasSetDefaultsKey = "CapacitorUpdater.previewPreviousDefaultChannelWasSet"
     private let previewAppIdDefaultsKey = "CapacitorUpdater.previewAppId"
+    private let previewPayloadUrlDefaultsKey = "CapacitorUpdater.previewPayloadUrl"
     // Note: DELAY_CONDITION_PREFERENCES is now defined in DelayUpdateUtils.DELAY_CONDITION_PREFERENCES
     private var updateUrl = ""
     private var backgroundTaskID: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
@@ -749,6 +752,62 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         return manifestEntries
     }
 
+    private struct PreviewPayload: Decodable {
+        let version: String?
+        let url: String?
+        let checksum: String?
+        let sessionKey: String?
+        let manifest: [ManifestEntry]?
+        let message: String?
+        let error: String?
+    }
+
+    private func makePreviewError(_ message: String) -> NSError {
+        NSError(domain: "CapacitorUpdaterPreview", code: 0, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    private func downloadBundle(urlString: String, version: String, sessionKey: String, checksum rawChecksum: String, manifestEntries: [ManifestEntry]?) throws -> BundleInfo {
+        guard let url = URL(string: urlString) else {
+            throw makePreviewError("Invalid download URL")
+        }
+
+        var checksum = rawChecksum
+        let next: BundleInfo
+        if let manifestEntries = manifestEntries {
+            next = try self.implementation.downloadManifest(manifest: manifestEntries, version: version, sessionKey: sessionKey)
+        } else {
+            next = try self.implementation.download(url: url, version: version, sessionKey: sessionKey)
+        }
+
+        if self.implementation.publicKey != "" && checksum == "" {
+            self.logger.error("Public key present but no checksum provided")
+            self.implementation.sendStats(action: "checksum_required", versionName: next.getVersionName())
+            let id = next.getId()
+            let resDel = self.implementation.delete(id: id)
+            if !resDel {
+                self.logger.error("Delete failed, id \(id) doesn't exist")
+            }
+            throw ObjectSavableError.checksum
+        }
+
+        checksum = try CryptoCipher.decryptChecksum(checksum: checksum, publicKey: self.implementation.publicKey)
+        CryptoCipher.logChecksumInfo(label: "Bundle checksum", hexChecksum: next.getChecksum())
+        CryptoCipher.logChecksumInfo(label: "Expected checksum", hexChecksum: checksum)
+        if (checksum != "" || self.implementation.publicKey != "") && next.getChecksum() != checksum {
+            self.logger.error("Error checksum \(next.getChecksum()) \(checksum)")
+            self.implementation.sendStats(action: "checksum_fail", versionName: next.getVersionName())
+            let id = next.getId()
+            let resDel = self.implementation.delete(id: id)
+            if !resDel {
+                self.logger.error("Delete failed, id \(id) doesn't exist")
+            }
+            throw ObjectSavableError.checksum
+        }
+
+        self.logger.info("Good checksum \(next.getChecksum()) \(checksum)")
+        return next
+    }
+
     @objc func download(_ call: CAPPluginCall) {
         guard let urlString = call.getString("url") else {
             logger.error("Download called without url")
@@ -762,57 +821,30 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         let sessionKey = call.getString("sessionKey", "")
-        var checksum = call.getString("checksum", "")
+        let checksum = call.getString("checksum", "")
         let manifestArray = call.getArray("manifest")
-        let url = URL(string: urlString)
-        logger.info("Downloading \(String(describing: url))")
+        logger.info("Downloading \(urlString)")
         self.saveCallForAsyncHandling(call)
         self.runBackgroundDownloadWork {
             do {
-                let next: BundleInfo
-                if let manifestEntries = self.manifestEntries(from: manifestArray) {
-                    next = try self.implementation.downloadManifest(manifest: manifestEntries, version: version, sessionKey: sessionKey)
-                } else {
-                    next = try self.implementation.download(url: url!, version: version, sessionKey: sessionKey)
-                }
-                // If public key is present but no checksum provided, refuse installation
-                if self.implementation.publicKey != "" && checksum == "" {
-                    self.logger.error("Public key present but no checksum provided")
-                    self.implementation.sendStats(action: "checksum_required", versionName: next.getVersionName())
-                    let id = next.getId()
-                    let resDel = self.implementation.delete(id: id)
-                    if !resDel {
-                        self.logger.error("Delete failed, id \(id) doesn't exist")
-                    }
-                    throw ObjectSavableError.checksum
-                }
-
-                checksum = try CryptoCipher.decryptChecksum(checksum: checksum, publicKey: self.implementation.publicKey)
-                CryptoCipher.logChecksumInfo(label: "Bundle checksum", hexChecksum: next.getChecksum())
-                CryptoCipher.logChecksumInfo(label: "Expected checksum", hexChecksum: checksum)
-                if (checksum != "" || self.implementation.publicKey != "") && next.getChecksum() != checksum {
-                    self.logger.error("Error checksum \(next.getChecksum()) \(checksum)")
-                    self.implementation.sendStats(action: "checksum_fail", versionName: next.getVersionName())
-                    let id = next.getId()
-                    let resDel = self.implementation.delete(id: id)
-                    if !resDel {
-                        self.logger.error("Delete failed, id \(id) doesn't exist")
-                    }
-                    throw ObjectSavableError.checksum
-                } else {
-                    self.logger.info("Good checksum \(next.getChecksum()) \(checksum)")
-                }
+                let next = try self.downloadBundle(
+                    urlString: urlString,
+                    version: version,
+                    sessionKey: sessionKey,
+                    checksum: checksum,
+                    manifestEntries: self.manifestEntries(from: manifestArray)
+                )
                 var updateAvailablePayload: JSObject = [:]
                 updateAvailablePayload["bundle"] = self.bundlePayload(next)
                 self.notifyListenersOnMain("updateAvailable", data: updateAvailablePayload)
                 self.resolveCall(call, data: next.toJSON())
             } catch {
-                self.logger.error("Failed to download from: \(String(describing: url)) \(error.localizedDescription)")
+                self.logger.error("Failed to download from: \(urlString) \(error.localizedDescription)")
                 var downloadFailedPayload: JSObject = [:]
                 downloadFailedPayload["version"] = version
                 self.notifyListenersOnMain("downloadFailed", data: downloadFailedPayload)
                 self.implementation.sendStats(action: "download_fail")
-                self.rejectCall(call, message: "Failed to download from: \(url!) - \(error.localizedDescription)")
+                self.rejectCall(call, message: "Failed to download from: \(urlString) - \(error.localizedDescription)")
             }
         }
     }
@@ -989,6 +1021,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         let previewAppId = self.normalizedPreviewAppId(call.getString("appId"))
+        let rawPayloadUrl = call.getString("payloadUrl")
+        let previewPayloadUrl = self.normalizedPreviewPayloadUrl(rawPayloadUrl)
+        if let rawPayloadUrl = rawPayloadUrl, !rawPayloadUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, previewPayloadUrl == nil {
+            logger.error("startPreviewSession called with invalid payloadUrl")
+            call.reject("Invalid preview payloadUrl")
+            return
+        }
 
         if !self.previewSessionEnabled {
             let current = self.implementation.getCurrentBundle()
@@ -1007,6 +1046,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             UserDefaults.standard.set(self.implementation.appId, forKey: self.previewPreviousAppIdDefaultsKey)
+            if let previousDefaultChannel = UserDefaults.standard.object(forKey: self.defaultChannelDefaultsKey) as? String {
+                UserDefaults.standard.set(previousDefaultChannel, forKey: self.previewPreviousDefaultChannelDefaultsKey)
+                UserDefaults.standard.set(true, forKey: self.previewPreviousDefaultChannelWasSetDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: self.previewPreviousDefaultChannelDefaultsKey)
+                UserDefaults.standard.set(false, forKey: self.previewPreviousDefaultChannelWasSetDefaultsKey)
+            }
             UserDefaults.standard.set(self.shakeMenuEnabled, forKey: self.previewPreviousShakeMenuDefaultsKey)
             UserDefaults.standard.set(self.shakeChannelSelectorEnabled, forKey: self.previewPreviousShakeChannelSelectorDefaultsKey)
             logger.info("Preview session started with fallback bundle: \(current.toString())")
@@ -1016,6 +1062,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             self.implementation.appId = previewAppId
             UserDefaults.standard.set(previewAppId, forKey: self.previewAppIdDefaultsKey)
             logger.info("Preview session using appId: \(previewAppId)")
+        }
+
+        if let previewPayloadUrl = previewPayloadUrl {
+            UserDefaults.standard.set(previewPayloadUrl.absoluteString, forKey: self.previewPayloadUrlDefaultsKey)
+            logger.info("Preview session using payload URL")
+        } else {
+            UserDefaults.standard.removeObject(forKey: self.previewPayloadUrlDefaultsKey)
         }
 
         self.previewSessionEnabled = true
@@ -1030,14 +1083,12 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     func leavePreviewSessionFromShakeMenu() -> Bool {
         let previewBundle = self.implementation.getCurrentBundle()
-        let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
 
         let didReset = self.resetToPreviewFallbackBundle()
         guard didReset else {
             return false
         }
 
-        _ = self.implementation.unsetChannel(defaultChannelKey: self.defaultChannelDefaultsKey, configDefaultChannel: configDefaultChannel)
         let previewFallbackBundle = self.implementation.getPreviewFallbackBundle()
         self.endPreviewSession()
         let restoredNextBundle = self.implementation.getNextBundle()
@@ -1050,7 +1101,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     func reloadPreviewSessionFromShakeMenu() -> Bool {
-        self._reload()
+        if let payloadUrl = self.storedPreviewPayloadUrl() {
+            return self.refreshPreviewSessionFromPayloadUrl(payloadUrl)
+        }
+
+        return self._reload()
     }
 
     func hasActivePreviewSession() -> Bool {
@@ -1088,6 +1143,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             ?? getConfig().getBoolean("allowShakeChannelSelector", false)
         self.restorePreviewPreviousNextBundle()
         self.restorePreviewPreviousAppId()
+        self.restorePreviewPreviousDefaultChannel()
 
         self.previewSessionEnabled = false
         self.previewSessionAlertPending = false
@@ -1117,6 +1173,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.restorePreviewPreviousNextBundle()
         self.restorePreviewPreviousAppId()
+        self.restorePreviewPreviousDefaultChannel()
         self.previewSessionEnabled = false
         self.previewSessionAlertPending = false
         self.implementation.previewSession = false
@@ -1132,7 +1189,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         UserDefaults.standard.removeObject(forKey: self.previewPreviousShakeChannelSelectorDefaultsKey)
         UserDefaults.standard.removeObject(forKey: self.previewPreviousNextBundleDefaultsKey)
         UserDefaults.standard.removeObject(forKey: self.previewPreviousAppIdDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousDefaultChannelDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPreviousDefaultChannelWasSetDefaultsKey)
         UserDefaults.standard.removeObject(forKey: self.previewAppIdDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewPayloadUrlDefaultsKey)
         UserDefaults.standard.synchronize()
     }
 
@@ -1143,6 +1203,23 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         self.implementation.appId = previousAppId
         logger.info("Restored appId after preview: \(previousAppId)")
+    }
+
+    private func restorePreviewPreviousDefaultChannel() {
+        let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
+        let hadPreviousDefaultChannel = UserDefaults.standard.object(forKey: self.previewPreviousDefaultChannelWasSetDefaultsKey) as? Bool ?? false
+
+        guard hadPreviousDefaultChannel,
+              let previousDefaultChannel = UserDefaults.standard.string(forKey: self.previewPreviousDefaultChannelDefaultsKey) else {
+            UserDefaults.standard.removeObject(forKey: self.defaultChannelDefaultsKey)
+            self.implementation.defaultChannel = configDefaultChannel
+            logger.info("Restored defaultChannel after preview to config value")
+            return
+        }
+
+        UserDefaults.standard.set(previousDefaultChannel, forKey: self.defaultChannelDefaultsKey)
+        self.implementation.defaultChannel = previousDefaultChannel
+        logger.info("Restored defaultChannel after preview")
     }
 
     private func normalizedPreviewAppId(_ rawAppId: String?) -> String? {
@@ -1163,6 +1240,97 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         return appId
     }
 
+    private func normalizedPreviewPayloadUrl(_ rawPayloadUrl: String?) -> URL? {
+        guard let rawPayloadUrl else {
+            return nil
+        }
+
+        let payloadUrl = rawPayloadUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !payloadUrl.isEmpty,
+              let url = URL(string: payloadUrl),
+              url.scheme == "https" || url.scheme == "http" else {
+            return nil
+        }
+
+        return url
+    }
+
+    private func storedPreviewPayloadUrl() -> URL? {
+        normalizedPreviewPayloadUrl(UserDefaults.standard.string(forKey: self.previewPayloadUrlDefaultsKey))
+    }
+
+    private func fetchPreviewPayload(_ payloadUrl: URL) throws -> PreviewPayload {
+        var request = URLRequest(url: payloadUrl)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var responseData: Data?
+        var response: URLResponse?
+        var responseError: Error?
+
+        URLSession.shared.dataTask(with: request) { data, urlResponse, error in
+            responseData = data
+            response = urlResponse
+            responseError = error
+            semaphore.signal()
+        }.resume()
+
+        if semaphore.wait(timeout: .now() + 60) == .timedOut {
+            throw makePreviewError("Preview payload request timed out")
+        }
+
+        if let responseError = responseError {
+            throw responseError
+        }
+
+        let data = responseData ?? Data()
+        if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
+            if let payload = try? JSONDecoder().decode(PreviewPayload.self, from: data) {
+                throw makePreviewError(payload.message ?? payload.error ?? "Preview payload request failed with HTTP \(httpResponse.statusCode)")
+            }
+            let message = String(data: data, encoding: .utf8) ?? "Preview payload request failed with HTTP \(httpResponse.statusCode)"
+            throw makePreviewError(message)
+        }
+
+        return try JSONDecoder().decode(PreviewPayload.self, from: data)
+    }
+
+    private func refreshPreviewSessionFromPayloadUrl(_ payloadUrl: URL) -> Bool {
+        do {
+            let payload = try self.fetchPreviewPayload(payloadUrl)
+            guard let version = payload.version, !version.isEmpty else {
+                throw makePreviewError("Preview payload is missing a version")
+            }
+            guard payload.url != nil || payload.manifest?.isEmpty == false else {
+                throw makePreviewError("Preview payload is missing download information")
+            }
+
+            let current = self.implementation.getCurrentBundle()
+            if current.getVersionName() == version {
+                self.logger.info("Preview payload unchanged, reloading current bundle")
+                return self._reload()
+            }
+
+            let next = try self.downloadBundle(
+                urlString: payload.url ?? "https://404.capgo.app/no.zip",
+                version: version,
+                sessionKey: payload.sessionKey ?? "",
+                checksum: payload.checksum ?? "",
+                manifestEntries: payload.manifest
+            )
+
+            guard self.implementation.set(id: next.getId()) else {
+                throw makePreviewError("Downloaded preview bundle cannot be applied")
+            }
+
+            self.notifyBundleSet(next)
+            return self._reload()
+        } catch {
+            self.logger.error("Could not refresh preview session: \(error.localizedDescription)")
+            return false
+        }
+    }
+
     private func clearPreviewSessionForNativeBuildChange() {
         guard self.previewSessionEnabled || self.implementation.getPreviewFallbackBundle() != nil else {
             return
@@ -1174,10 +1342,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
         self.shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
         self.restorePreviewPreviousAppId()
+        self.restorePreviewPreviousDefaultChannel()
         _ = self.implementation.setPreviewFallbackBundle(fallback: nil)
         _ = self.implementation.setNextBundle(next: Optional<String>.none)
-        let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
-        _ = self.implementation.unsetChannel(defaultChannelKey: self.defaultChannelDefaultsKey, configDefaultChannel: configDefaultChannel)
         self.clearPreviewSessionPreferences()
     }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1312,7 +1312,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             let next = try self.downloadBundle(
-                // Used only when payload.url exists; manifestEntries routes through downloadManifest instead.
+                // Fallback URL is only provided when payload.url is missing; when manifestEntries is present,
+                // downloadBundle routes through downloadManifest and ignores urlString.
                 urlString: payload.url ?? "https://404.capgo.app/no.zip",
                 version: version,
                 sessionKey: payload.sessionKey ?? "",

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1312,6 +1312,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             let next = try self.downloadBundle(
+                // Used only when payload.url exists; manifestEntries routes through downloadManifest instead.
                 urlString: payload.url ?? "https://404.capgo.app/no.zip",
                 version: version,
                 sessionKey: payload.sessionKey ?? "",

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -81,9 +81,11 @@ extension UIWindow {
         })
 
         alertShake.addAction(UIAlertAction(title: reloadButtonTitle, style: .default) { _ in
-            DispatchQueue.main.async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 if !plugin.reloadPreviewSessionFromShakeMenu() {
-                    self.showError(message: "Could not reload the test app.", plugin: plugin)
+                    DispatchQueue.main.async {
+                        self.showError(message: "Could not reload the test app.", plugin: plugin)
+                    }
                 }
             }
         })

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -2139,6 +2139,15 @@ export interface StartPreviewSessionOptions {
    * @default undefined
    */
   appId?: string;
+  /**
+   * HTTP(S) URL returning a preview download payload.
+   * When provided, the native shake reload action fetches this payload again
+   * before reloading so channel previews can move to the latest bundle.
+   * Requires {@link PluginsConfig.CapacitorUpdater.allowPreview} to be `true`.
+   * @since 8.48.0
+   * @default undefined
+   */
+  payloadUrl?: string;
 }
 
 export interface AppReadyResult {


### PR DESCRIPTION
## What
- Add an optional `payloadUrl` to preview sessions.
- Make shake reload refetch that payload before reloading, so channel previews can move to the latest bundle without using normal channel update rules.
- Restore the previous default channel locally when leaving/clearing preview sessions.
- Make Android manifest `download()` resolve with the real downloaded bundle instead of a temporary downloading bundle.

## Why
- Preview should download and set an explicit payload, not depend on channel assignment/update eligibility.
- Channel preview needs a safe way to refresh from the same preview payload URL.
- Leaving preview should not clear or mutate the user's previous channel state.

## How
- Persist the preview payload URL during `startPreviewSession`.
- On native shake reload, fetch the payload, download the bundle or manifest, set it, and reload.
- Keep existing reload behavior when no payload URL is stored.
- Snapshot and restore the previous default channel around preview sessions.

## Testing
- `bun run fmt`
- `bun run build`
- `bun run test`
- `bun run verify`

## Not Tested
- Manual device test against a live Capgo preview channel after this package is released and the Capgo app passes `payloadUrl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional payloadUrl for preview sessions (since 8.48.0). The native shake reload will re-fetch and apply a remote preview payload from an HTTP(S) URL before reloading.
  * Preview start now validates and normalizes the provided payload URL.

* **Behavior Changes**
  * Exiting preview restores the previous default channel/state.
  * Shake-triggered reloads refresh from the stored payload URL when present and run reload work off the main UI thread where applicable.

* **Documentation**
  * Docs updated to describe payloadUrl in StartPreviewSessionOptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-updater/pull/789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->