### PR TITLE
fix: restore host app during preview exit

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -106,6 +106,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private static final String PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY = "CapacitorUpdater.previewPreviousDefaultChannelWasSet";
     private static final String PREVIEW_APP_ID_PREF_KEY = "CapacitorUpdater.previewAppId";
     private static final String PREVIEW_PAYLOAD_URL_PREF_KEY = "CapacitorUpdater.previewPayloadUrl";
+    private static final String PREVIEW_SESSION_ALERT_PENDING_PREF_KEY = "CapacitorUpdater.previewSessionAlertPending";
     private static final String[] BREAKING_EVENT_NAMES = { "breakingAvailable", "majorAvailable" };
     private static final String LAST_FAILED_BUNDLE_PREF_KEY = "CapacitorUpdater.lastFailedBundle";
     private static final String LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY = "CapacitorUpdater.lastReportedAppExitTimestamp";
@@ -160,6 +161,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     Boolean shakeChannelSelectorEnabled = false;
     Boolean previewSessionEnabled = false;
     private Boolean previewSessionAlertPending = false;
+    private Boolean isLeavingPreviewForIncomingLink = false;
     private Boolean allowManualBundleError = false;
     private Boolean allowPreview = false;
     Boolean allowSetDefaultChannel = true;
@@ -502,6 +504,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
         this.implementation.previewSession = Boolean.TRUE.equals(this.previewSessionEnabled);
         if (Boolean.TRUE.equals(this.previewSessionEnabled)) {
+            this.previewSessionAlertPending = this.prefs.contains(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY)
+                ? this.prefs.getBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, false)
+                : true;
             final String previewAppId = this.prefs.getString(PREVIEW_APP_ID_PREF_KEY, "");
             if (previewAppId != null && !previewAppId.isEmpty()) {
                 this.setActiveAppId(previewAppId);
@@ -520,6 +525,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         if (nativeBuildVersionChanged) {
             this.clearPreviewSessionForNativeBuildChange();
         }
+        this.leavePreviewSessionForLaunchIntentIfNeeded();
         this.reportPreviousAppExitReasons();
         this.reportPreviousWebViewRenderProcessGone();
         this.installWebViewStatsReporter();
@@ -534,6 +540,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.delayUpdateUtils.checkCancelDelay(DelayUpdateUtils.CancelDelaySource.KILLED);
 
         this.checkForUpdateAfterDelay();
+        this.showPreviewSessionNoticeIfNeeded();
 
         // On Android 14+ (API 34+), topActivity in RecentTaskInfo returns null due to
         // security restrictions (StrandHogg task hijacking mitigations). Use ProcessLifecycleOwner
@@ -2301,6 +2308,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 this.shakeMenuEnabled = true;
                 this.shakeChannelSelectorEnabled = false;
                 this.editor.putBoolean(PREVIEW_SESSION_PREF_KEY, true);
+                this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
                 this.editor.apply();
                 this.ensureShakeMenuStarted();
                 call.resolve();
@@ -2322,6 +2330,58 @@ public class CapacitorUpdaterPlugin extends Plugin {
         final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
         this.endPreviewSession();
         final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
+        this.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle, restoredNextBundle);
+        return true;
+    }
+
+    private void leavePreviewSessionForLaunchIntentIfNeeded() {
+        final Intent intent = getActivity() == null ? null : getActivity().getIntent();
+        if (
+            intent == null ||
+            !Intent.ACTION_VIEW.equals(intent.getAction()) ||
+            intent.getData() == null ||
+            !Boolean.TRUE.equals(this.previewSessionEnabled) ||
+            !isPreviewDeepLink(intent.getData()) ||
+            Boolean.TRUE.equals(this.isLeavingPreviewForIncomingLink)
+        ) {
+            return;
+        }
+
+        this.isLeavingPreviewForIncomingLink = true;
+        logger.info("Preview deeplink launch detected while preview session is active; restoring fallback before initial load");
+        if (!this.leavePreviewSessionWithoutReload()) {
+            logger.error("Could not leave preview session before initial preview deeplink routing");
+            this.isLeavingPreviewForIncomingLink = false;
+        }
+    }
+
+    private boolean leavePreviewSessionWithoutReload() {
+        final BundleInfo previewBundle = this.implementation.getCurrentBundle();
+        final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
+        if (previewFallbackBundle == null || previewFallbackBundle.isErrorStatus()) {
+            logger.error("No preview fallback bundle available");
+            return false;
+        }
+        if (!this.implementation.canSet(previewFallbackBundle)) {
+            logger.error("Preview fallback bundle is not installable");
+            return false;
+        }
+        if (!this.implementation.stagePreviewFallbackReload(previewFallbackBundle)) {
+            logger.error("Could not stage preview fallback bundle");
+            return false;
+        }
+
+        this.endPreviewSession();
+        final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
+        this.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle, restoredNextBundle);
+        return true;
+    }
+
+    private void deletePreviewBundleIfUnused(
+        final BundleInfo previewBundle,
+        final BundleInfo previewFallbackBundle,
+        final BundleInfo restoredNextBundle
+    ) {
         if (
             !previewBundle.isBuiltin() &&
             (previewFallbackBundle == null || !previewBundle.getId().equals(previewFallbackBundle.getId())) &&
@@ -2333,7 +2393,6 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 logger.warn("Cannot delete preview bundle " + previewBundle.getId() + ": " + err.getMessage());
             }
         }
-        return true;
     }
 
     public boolean reloadPreviewSessionFromShakeMenu() {
@@ -2388,6 +2447,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
         this.previewSessionEnabled = false;
         this.previewSessionAlertPending = false;
+        this.isLeavingPreviewForIncomingLink = false;
         this.implementation.previewSession = false;
         this.shakeMenuEnabled = previousShakeMenuEnabled;
         this.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled;
@@ -2414,6 +2474,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.restorePreviewPreviousDefaultChannel();
         this.previewSessionEnabled = false;
         this.previewSessionAlertPending = false;
+        this.isLeavingPreviewForIncomingLink = false;
         this.implementation.previewSession = false;
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
@@ -2433,6 +2494,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.editor.remove(PREVIEW_PREVIOUS_DEFAULT_CHANNEL_WAS_SET_PREF_KEY);
         this.editor.remove(PREVIEW_APP_ID_PREF_KEY);
         this.editor.remove(PREVIEW_PAYLOAD_URL_PREF_KEY);
+        this.editor.remove(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY);
         this.editor.apply();
     }
 
@@ -2521,6 +2583,21 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private String storedPreviewPayloadUrl() {
         return this.normalizePreviewPayloadUrl(this.prefs.getString(PREVIEW_PAYLOAD_URL_PREF_KEY, null));
+    }
+
+    private String previewPathFromUri(final Uri uri) {
+        if ("capgo".equals(uri.getScheme())) {
+            final String host = uri.getHost();
+            final String path = uri.getPath();
+            return ("/" + (host == null ? "" : host) + (path == null ? "" : path)).replaceAll("/+", "/");
+        }
+
+        return uri.getPath();
+    }
+
+    private boolean isPreviewDeepLink(final Uri uri) {
+        final String path = this.previewPathFromUri(uri);
+        return "/preview/channel".equals(path) || "/preview/bundle".equals(path);
     }
 
     private String readResponseBody(final InputStream stream) throws IOException {
@@ -2619,6 +2696,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         logger.info("Native build changed; clearing preview session state");
         this.previewSessionEnabled = false;
         this.previewSessionAlertPending = false;
+        this.isLeavingPreviewForIncomingLink = false;
         this.implementation.previewSession = false;
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
@@ -2657,6 +2735,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return;
         }
         this.previewSessionAlertPending = false;
+        this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, false);
+        this.editor.apply();
 
         new Handler(Looper.getMainLooper()).postDelayed(
             () -> {
@@ -2666,6 +2746,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
                     }
                     if (getActivity() == null || getActivity().isFinishing()) {
                         this.previewSessionAlertPending = true;
+                        this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
+                        this.editor.apply();
                         return;
                     }
 
@@ -2676,6 +2758,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
                         .show();
                 } catch (final Exception e) {
                     this.previewSessionAlertPending = true;
+                    this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
+                    this.editor.apply();
                     logger.warn("Could not show preview session notice: " + e.getMessage());
                 }
             },
@@ -3918,6 +4002,34 @@ public class CapacitorUpdaterPlugin extends Plugin {
         } catch (NullPointerException e) {
             return false;
         }
+    }
+
+    @Override
+    protected void handleOnNewIntent(Intent intent) {
+        super.handleOnNewIntent(intent);
+        if (
+            intent == null ||
+            !Intent.ACTION_VIEW.equals(intent.getAction()) ||
+            intent.getData() == null ||
+            !Boolean.TRUE.equals(this.previewSessionEnabled) ||
+            !isPreviewDeepLink(intent.getData()) ||
+            Boolean.TRUE.equals(this.isLeavingPreviewForIncomingLink)
+        ) {
+            return;
+        }
+
+        this.isLeavingPreviewForIncomingLink = true;
+        if (getActivity() != null) {
+            getActivity().setIntent(intent);
+        }
+        logger.info("Preview deeplink received while preview session is active; restoring fallback before routing");
+        startNewThread(() -> {
+            final boolean didLeave = this.leavePreviewSessionFromShakeMenu();
+            if (!didLeave) {
+                logger.error("Could not leave preview session before routing incoming preview deeplink");
+                this.isLeavingPreviewForIncomingLink = false;
+            }
+        });
     }
 
     @Override

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -105,6 +105,12 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private let previewPreviousDefaultChannelWasSetDefaultsKey = "CapacitorUpdater.previewPreviousDefaultChannelWasSet"
     private let previewAppIdDefaultsKey = "CapacitorUpdater.previewAppId"
     private let previewPayloadUrlDefaultsKey = "CapacitorUpdater.previewPayloadUrl"
+    private let previewSessionAlertPendingDefaultsKey = "CapacitorUpdater.previewSessionAlertPending"
+    private let previewDeepLinkScheme = "capgo"
+    private let previewDeepLinkRootComponent = "preview"
+    private let previewDeepLinkChannelComponent = "channel"
+    private let previewDeepLinkBundleComponent = "bundle"
+    private let previewPathSeparator = Character(UnicodeScalar(UInt8(47)))
     // Note: DELAY_CONDITION_PREFERENCES is now defined in DelayUpdateUtils.DELAY_CONDITION_PREFERENCES
     private var updateUrl = ""
     private var backgroundTaskID: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
@@ -158,6 +164,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     public var shakeChannelSelectorEnabled = false
     public var previewSessionEnabled = false
     private var previewSessionAlertPending = false
+    private var isLeavingPreviewForIncomingLink = false
     let semaphoreReady = DispatchSemaphore(value: 0)
 
     private var delayUpdateUtils: DelayUpdateUtils!
@@ -233,6 +240,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         previewSessionEnabled = allowPreview && storedPreviewSessionEnabled
         implementation.previewSession = previewSessionEnabled
         if previewSessionEnabled {
+            previewSessionAlertPending = UserDefaults.standard.object(forKey: previewSessionAlertPendingDefaultsKey) as? Bool ?? true
             shakeMenuEnabled = true
             shakeChannelSelectorEnabled = false
         }
@@ -315,6 +323,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         if nativeBuildVersionChanged {
             self.clearPreviewSessionForNativeBuildChange()
         }
+        self.leavePreviewSessionForLaunchURLIfNeeded()
 
         if resetWhenUpdate {
             let didResetCurrentBundle = self.resetCurrentBundleForNativeBuildChangeIfNeeded()
@@ -332,11 +341,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             logger.error("unable to force reload, the plugin might fallback to the builtin version")
         }
 
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(appMovedToBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
-        nc.addObserver(self, selector: #selector(appMovedToForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
-        nc.addObserver(self, selector: #selector(appWillTerminate), name: UIApplication.willTerminateNotification, object: nil)
-        nc.addObserver(self, selector: #selector(appDidReceiveMemoryWarning), name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        self.registerNotificationObservers()
 
         // Check for 'kill' delay condition on app launch
         // This handles cases where the app was killed (willTerminateNotification is not reliable for system kills)
@@ -344,6 +349,47 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.appMovedToForeground()
         self.checkForUpdateAfterDelay()
+        self.showPreviewSessionNoticeIfNeeded()
+    }
+
+    private func registerNotificationObservers() {
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appMovedToBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appMovedToForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appWillTerminate),
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appDidReceiveMemoryWarning),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handleOpenURLForPreviewSession(notification:)),
+            name: Notification.Name.capacitorOpenURL,
+            object: nil
+        )
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handleOpenURLForPreviewSession(notification:)),
+            name: Notification.Name.capacitorOpenUniversalLink,
+            object: nil
+        )
     }
 
     private func syncKeepUrlPathFlag(enabled: Bool) {
@@ -1077,6 +1123,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.shakeMenuEnabled = true
         self.shakeChannelSelectorEnabled = false
         UserDefaults.standard.set(true, forKey: self.previewSessionDefaultsKey)
+        UserDefaults.standard.set(true, forKey: self.previewSessionAlertPendingDefaultsKey)
         UserDefaults.standard.synchronize()
         call.resolve()
     }
@@ -1092,12 +1139,57 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let previewFallbackBundle = self.implementation.getPreviewFallbackBundle()
         self.endPreviewSession()
         let restoredNextBundle = self.implementation.getNextBundle()
+        self.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle: previewFallbackBundle, restoredNextBundle: restoredNextBundle)
+        return true
+    }
+
+    private func leavePreviewSessionForLaunchURLIfNeeded() {
+        guard self.previewSessionEnabled,
+              !self.isLeavingPreviewForIncomingLink,
+              let launchUrl = ApplicationDelegateProxy.shared.lastURL,
+              self.isPreviewDeepLink(launchUrl) else {
+            return
+        }
+
+        self.isLeavingPreviewForIncomingLink = true
+        logger.info("Preview deeplink launch detected while preview session is active; restoring fallback before initial load")
+        if !self.leavePreviewSessionWithoutReload() {
+            logger.error("Could not leave preview session before initial preview deeplink routing")
+            self.isLeavingPreviewForIncomingLink = false
+        }
+    }
+
+    private func leavePreviewSessionWithoutReload() -> Bool {
+        let previewBundle = self.implementation.getCurrentBundle()
+        guard let previewFallbackBundle = self.implementation.getPreviewFallbackBundle(), !previewFallbackBundle.isErrorStatus() else {
+            logger.error("No preview fallback bundle available")
+            return false
+        }
+        guard self.implementation.canSet(bundle: previewFallbackBundle) else {
+            logger.error("Preview fallback bundle is not installable")
+            return false
+        }
+        guard self.implementation.stagePreviewFallbackReload(bundle: previewFallbackBundle) else {
+            logger.error("Could not stage preview fallback bundle")
+            return false
+        }
+
+        self.endPreviewSession()
+        let restoredNextBundle = self.implementation.getNextBundle()
+        self.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle: previewFallbackBundle, restoredNextBundle: restoredNextBundle)
+        return true
+    }
+
+    private func deletePreviewBundleIfUnused(
+        _ previewBundle: BundleInfo,
+        previewFallbackBundle: BundleInfo?,
+        restoredNextBundle: BundleInfo?
+    ) {
         if !previewBundle.isBuiltin() &&
             previewFallbackBundle?.getId() != previewBundle.getId() &&
             restoredNextBundle?.getId() != previewBundle.getId() {
             _ = self.implementation.delete(id: previewBundle.getId(), removeInfo: false)
         }
-        return true
     }
 
     func reloadPreviewSessionFromShakeMenu() -> Bool {
@@ -1147,6 +1239,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.previewSessionEnabled = false
         self.previewSessionAlertPending = false
+        self.isLeavingPreviewForIncomingLink = false
         self.implementation.previewSession = false
         self.shakeMenuEnabled = previousShakeMenuEnabled
         self.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled
@@ -1176,6 +1269,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.restorePreviewPreviousDefaultChannel()
         self.previewSessionEnabled = false
         self.previewSessionAlertPending = false
+        self.isLeavingPreviewForIncomingLink = false
         self.implementation.previewSession = false
         self.shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
         self.shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
@@ -1193,6 +1287,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         UserDefaults.standard.removeObject(forKey: self.previewPreviousDefaultChannelWasSetDefaultsKey)
         UserDefaults.standard.removeObject(forKey: self.previewAppIdDefaultsKey)
         UserDefaults.standard.removeObject(forKey: self.previewPayloadUrlDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: self.previewSessionAlertPendingDefaultsKey)
         UserDefaults.standard.synchronize()
     }
 
@@ -1257,6 +1352,55 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func storedPreviewPayloadUrl() -> URL? {
         normalizedPreviewPayloadUrl(UserDefaults.standard.string(forKey: self.previewPayloadUrlDefaultsKey))
+    }
+
+    private func previewPath(from url: URL) -> String {
+        if url.scheme == self.previewDeepLinkScheme {
+            var components: [String] = []
+            if let host = url.host, !host.isEmpty {
+                components.append(host)
+            }
+            components.append(contentsOf: url.path.split(separator: self.previewPathSeparator).map(String.init))
+            return self.normalizedPreviewPath(components)
+        }
+
+        return url.path
+    }
+
+    private func normalizedPreviewPath(_ components: [String]) -> String {
+        let separator = String(self.previewPathSeparator)
+        return separator + components.filter { !$0.isEmpty }.joined(separator: separator)
+    }
+
+    private func previewDeepLinkPath(_ leafComponent: String) -> String {
+        self.normalizedPreviewPath([self.previewDeepLinkRootComponent, leafComponent])
+    }
+
+    private func isPreviewDeepLink(_ url: URL) -> Bool {
+        let path = self.previewPath(from: url)
+        return path == self.previewDeepLinkPath(self.previewDeepLinkChannelComponent) ||
+            path == self.previewDeepLinkPath(self.previewDeepLinkBundleComponent)
+    }
+
+    @objc private func handleOpenURLForPreviewSession(notification: NSNotification) {
+        let rawUrl = (notification.object as? [String: Any])?["url"]
+        let url = rawUrl as? URL ?? (rawUrl as? NSURL).map { $0 as URL }
+        guard self.previewSessionEnabled,
+              !self.isLeavingPreviewForIncomingLink,
+              let url,
+              self.isPreviewDeepLink(url) else {
+            return
+        }
+
+        self.isLeavingPreviewForIncomingLink = true
+        logger.info("Preview deeplink received while preview session is active; restoring fallback before routing")
+        DispatchQueue.global(qos: .userInitiated).async {
+            let didLeave = self.leavePreviewSessionFromShakeMenu()
+            if !didLeave {
+                self.logger.error("Could not leave preview session before routing incoming preview deeplink")
+                self.isLeavingPreviewForIncomingLink = false
+            }
+        }
     }
 
     private func fetchPreviewPayload(_ payloadUrl: URL) throws -> PreviewPayload {
@@ -1340,6 +1484,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         logger.info("Native build changed; clearing preview session state")
         self.previewSessionEnabled = false
         self.previewSessionAlertPending = false
+        self.isLeavingPreviewForIncomingLink = false
         self.implementation.previewSession = false
         self.shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
         self.shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
@@ -1367,6 +1512,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
         self.previewSessionAlertPending = false
+        UserDefaults.standard.set(false, forKey: self.previewSessionAlertPendingDefaultsKey)
+        UserDefaults.standard.synchronize()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(600)) {
             guard self.previewSessionEnabled else {
@@ -1375,6 +1522,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             if let topVC = UIApplication.topViewController(),
                topVC.isKind(of: UIAlertController.self) {
                 self.previewSessionAlertPending = true
+                UserDefaults.standard.set(true, forKey: self.previewSessionAlertPendingDefaultsKey)
+                UserDefaults.standard.synchronize()
                 return
             }
 
@@ -1386,6 +1535,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             alert.addAction(UIAlertAction(title: "Got it", style: .default))
             if let topVC = UIApplication.topViewController() {
                 topVC.present(alert, animated: true)
+            } else {
+                self.previewSessionAlertPending = true
+                UserDefaults.standard.set(true, forKey: self.previewSessionAlertPendingDefaultsKey)
+                UserDefaults.standard.synchronize()
             }
         }
     }

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -29,7 +29,7 @@ extension UIWindow {
             // Find the CapacitorUpdaterPlugin instance
             guard let bridgeViewController = rootViewController as? CAPBridgeViewController,
                   let bridge = bridgeViewController.bridge,
-                  let plugin = bridge.plugin(withName: "CapacitorUpdaterPlugin") as? CapacitorUpdaterPlugin else {
+                  let plugin = bridge.plugin(withName: "CapacitorUpdater") as? CapacitorUpdaterPlugin else {
                 return
             }
 


### PR DESCRIPTION
## What
- Fix iOS preview shake menu lookup so the updater plugin is found under its Capacitor JS name.
- Persist the preview help modal pending state so it still appears after reload or restart.
- Restore the preview fallback before routing a new preview deeplink when a preview session is already active, including cold launches from a preview link.

## Why
- Users could enter a preview and then be stuck because the iOS shake menu silently failed to find the plugin.
- The explanation modal could be lost across the preview reload.
- A new preview link opened while inside another preview could be handled by the preview app JavaScript instead of the Capgo host app.

## How
- Use the registered Capacitor plugin key `CapacitorUpdater` in the iOS shake handler.
- Store `previewSessionAlertPending` in native preferences and retry the modal if native UI is not ready.
- Detect preview links natively on iOS and Android, restore the fallback bundle, clear preview session state, and then let the host app process the retained deeplink.

## Testing
- `bun run verify:ios`
- `bun run verify:android`
- `bun run verify:web`
- `bun run prettier -- --check android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java`
- `bun run eslint` (passes with existing warnings in `src/web.ts`)

## Not Tested
- Manual device validation of shaking out of a live Capgo preview still needs to be done with the next app build that consumes this plugin change.

Generated with Codex.
