### PR TITLE
[codex] Cap GitHub Actions job timeouts at 10 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Tests already passed before tag was created, so just build and deploy
   deploy:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     name: "Build code and npm release"
     permissions:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,7 +19,7 @@ jobs:
   # Only bump version and create tag if all tests pass
   bump-version:
     needs: [test]
-    timeout-minutes: 30
+    timeout-minutes: 10
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     name: "Bump version and create tag"

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   github-releases-to-discord:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && contains(github.event.comment.body, '/publish-beta')) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: Resolve PR and access checks
         id: pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   guard_swiftpm_version:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
   build_android:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js
@@ -69,7 +69,7 @@ jobs:
         id: test_android
         run: bun run native:test:android
   build_ios:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: macOS-latest
     steps:
       - name: Setup Node.js
@@ -101,7 +101,7 @@ jobs:
         id: test_ios
         run: bun run native:test:ios
   maestro_android_example_app:
-    timeout-minutes: 60
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
     strategy:
@@ -157,7 +157,7 @@ jobs:
           name: maestro-results-android-${{ matrix.scenario }}
           path: maestro-results
   maestro_ios_example_app:
-    timeout-minutes: 45
+    timeout-minutes: 10
     runs-on: macOS-latest
     name: iOS example app Maestro smoke / ${{ matrix.scenario }}
     strategy:
@@ -194,7 +194,7 @@ jobs:
           name: maestro-results-ios-${{ matrix.scenario }}
           path: maestro-results-ios
   maestro_ios_live_update:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: macOS-latest
     name: iOS example app Maestro live update / ${{ matrix.scenario }}
     strategy:
@@ -238,7 +238,7 @@ jobs:
           name: maestro-results-ios-live-update-${{ matrix.scenario }}
           path: maestro-results-ios-live-update/${{ matrix.scenario }}
   web:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     name: 'Build code and test'
     steps:
@@ -271,7 +271,7 @@ jobs:
         id: verify_code
         run: bun run verify:web
   maestro_android_scenarios:
-    timeout-minutes: 60
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     name: maestro_android / ${{ matrix.scenario }}
     strategy:
@@ -327,7 +327,7 @@ jobs:
     if: always()
     needs:
       - maestro_android_scenarios
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js


### PR DESCRIPTION
## What
- Set every GitHub Actions job timeout to 10 minutes.
- Updated the remaining 30, 45, and 60 minute `timeout-minutes` values across CI, release, beta publish, and Discord release workflows.

## Why
- Keep GitHub Actions jobs bounded to a consistent 10 minute maximum.

## How
- Changed only existing `timeout-minutes` values in `.github/workflows/*.yml`.
- Left workflow steps, matrices, permissions, and triggers unchanged.
- This PR was prepared by an AI agent.

## Testing
- `bun run verify`
- Direct scan confirmed no `.github/workflows` timeout remains above 10 minutes.
- `git diff --check`

## Not Tested
- `bunx prettier --check .github/workflows/*.yml` reports formatting differences in existing workflow files, so I did not apply broad formatting churn for this timeout-only change.