### PR TITLE
[codex] Enable KVM for Android Maestro jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Install Maestro
         env:
           GH_TOKEN: ${{ github.token }}
@@ -303,6 +308,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Install Maestro
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What
- Enable KVM permissions before Android emulator-based Maestro jobs run.

## Why
- PR #792 capped all GitHub Actions job timeouts at 10 minutes.
- The first Android Maestro run hit that cap because the emulator booted without KVM and spent about seven minutes starting before Gradle finished building.

## How
- Added the standard KVM udev rule setup before `reactivecircus/android-emulator-runner` in both Android Maestro jobs.
- Left the 10-minute job timeouts intact.
- This PR was prepared by an AI agent.

## Testing
- Direct scan confirmed no `.github/workflows` timeout remains above 10 minutes.
- `git diff --check origin/main..HEAD`
- Earlier on the timeout branch: `bun run verify`

## Not Tested
- Waiting on this PR’s GitHub Actions run to confirm the hosted runner now boots the Android emulator fast enough under the 10-minute cap.