### PR TITLE
[codex] ci: use Node 24 action tags

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -20,11 +20,11 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      uses: actions/setup-node@v6
       with:
         node-version: 24.x
     - name: Cache Bun runtime
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache@v5
       with:
         path: ~/.bun
         key: ${{ runner.os }}-bun-${{ inputs.bun-version }}
@@ -36,7 +36,7 @@ runs:
       run: ./scripts/ci/install-bun.sh
     - name: Cache Bun dependencies
       if: inputs.dependency-cache-key != '' && inputs.dependency-cache-path != ''
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache@v5
       with:
         path: ${{ inputs.dependency-cache-path }}
         key: ${{ inputs.dependency-cache-key }}

--- a/.github/actions/setup-maestro/action.yml
+++ b/.github/actions/setup-maestro/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Cache Maestro runtime
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache@v5
       with:
         path: ~/.maestro
         key: ${{ runner.os }}-maestro-${{ inputs.maestro-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Enforce capacitor-swift-pm version
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -60,7 +60,7 @@ jobs:
       - name: Check plugin wiring
         run: bun run check:wiring
       - name: Setup java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -80,7 +80,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -109,7 +109,7 @@ jobs:
     name: Build Maestro web assets
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -124,7 +124,7 @@ jobs:
       - name: Build reusable Maestro web assets
         run: bun scripts/maestro/build-bundles.mjs all
       - name: Upload reusable Maestro web assets
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-web-assets
           path: |
@@ -155,7 +155,7 @@ jobs:
           - manual-manifest
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -168,20 +168,20 @@ jobs:
             example-app/node_modules
           install-example: 'true'
       - name: Setup java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
       - name: Download reusable Maestro web assets
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-web-assets
           path: .
       - name: Build Android app
         run: bun scripts/maestro/prepare-android-scenario.mjs "${{ matrix.scenario }}"
       - name: Upload Android app
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug/app-debug.apk
@@ -196,7 +196,7 @@ jobs:
     name: Build iOS Maestro apps
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -209,7 +209,7 @@ jobs:
             example-app/node_modules
           install-example: 'true'
       - name: Download reusable Maestro web assets
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-web-assets
           path: .
@@ -247,7 +247,7 @@ jobs:
             ditto "$derived_data_path/Build/Products/Debug-iphonesimulator/App.app" "$app_artifact_path/App.app"
           done
       - name: Upload iOS apps
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-ios-apps
           path: ${{ runner.temp }}/maestro-ios-apps
@@ -271,7 +271,7 @@ jobs:
           - manual-zip-config-guards
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -284,7 +284,7 @@ jobs:
             example-app/node_modules
           install-example: 'true'
       - name: Setup java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -294,12 +294,12 @@ jobs:
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
       - name: Download reusable Maestro web assets
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-web-assets
           path: .
       - name: Download Android app
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
@@ -309,7 +309,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: Run Maestro smoke tests
-        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
+        uses: reactivecircus/android-emulator-runner@v2.37.0 # NOSONAR version tag required by repo policy
         with:
           api-level: 30
           arch: x86_64
@@ -328,7 +328,7 @@ jobs:
             bun run test:maestro:android
       - name: Upload Maestro artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-results-android-${{ matrix.scenario }}
           path: maestro-results
@@ -351,7 +351,7 @@ jobs:
           - manual-zip-config-guards
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Boot iOS simulator early
@@ -378,12 +378,12 @@ jobs:
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
       - name: Download reusable Maestro web assets
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-web-assets
           path: .
       - name: Download iOS app
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-ios-apps
           path: maestro-ios-apps
@@ -400,7 +400,7 @@ jobs:
           bun run test:maestro:ios:smoke
       - name: Upload Maestro artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-results-ios-${{ matrix.scenario }}
           path: maestro-results-ios
@@ -423,7 +423,7 @@ jobs:
           - on-launch
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Boot iOS simulator early
@@ -450,12 +450,12 @@ jobs:
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
       - name: Download reusable Maestro web assets
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-web-assets
           path: .
       - name: Download iOS app
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-ios-apps
           path: maestro-ios-apps
@@ -473,7 +473,7 @@ jobs:
           ./scripts/maestro/run-ios-live-update.sh "${{ matrix.scenario }}"
       - name: Upload live update Maestro artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: maestro-results-ios-live-update-${{ matrix.scenario }}
           path: maestro-results-ios-live-update/${{ matrix.scenario }}
@@ -487,7 +487,7 @@ jobs:
     name: Build code and test
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -530,7 +530,7 @@ jobs:
           - manual-manifest
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Bun
@@ -543,7 +543,7 @@ jobs:
             example-app/node_modules
           install-example: 'true'
       - name: Setup java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -553,12 +553,12 @@ jobs:
         with:
           maestro-version: ${{ env.MAESTRO_VERSION }}
       - name: Download reusable Maestro web assets
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-web-assets
           path: .
       - name: Download Android app
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v7
         with:
           name: maestro-android-app-${{ matrix.scenario }}
           path: example-app/android/app/build/outputs/apk/debug
@@ -568,7 +568,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: Run live update Maestro flow
-        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
+        uses: reactivecircus/android-emulator-runner@v2.37.0 # NOSONAR version tag required by repo policy
         with:
           api-level: 30
           arch: x86_64


### PR DESCRIPTION
## What
- Update the local setup-bun and setup-maestro composite actions to use `actions/cache@v5`.
- Convert CI Action SHA pins in `test.yml` to version tags only.
- Keep existing major versions where the pinned SHA already matched a Node 24 tag (`checkout@v6`, `setup-java@v5`, `upload-artifact@v7`, `download-artifact@v7`, `reactivecircus/android-emulator-runner@v2.37.0`).
- Add targeted Sonar suppressions for the two emulator-runner version-tag lines because this repo intentionally requires version tags instead of full SHAs.

## Why
- `actions/cache@v4` declares the Node 20 action runtime, which triggers GitHub Actions Node 20 deprecation warnings even when the job installs Node 24.
- The repo convention is to use version tags instead of raw Action SHAs.

## How
- Replaced cache v4 SHA pins with `actions/cache@v5`, which declares Node 24.
- Replaced existing SHA-pinned Actions in the test workflow with their version tag equivalents.
- Verified there are no remaining 40-character Action SHA pins under `.github`.

## Testing
- `bun run fmt`
- `bun run verify`
- `git diff --check`
- Scanned `.github` for remaining Action SHA pins.
- Checked external Action runtimes; the changed CI Actions now resolve to Node 24, composite, or docker runtimes.

## Not Tested
- `bun run lint` does not pass on current `main` because SwiftLint reports existing iOS violations unrelated to this workflow-only change.
