### PR TITLE
fix: stabilize preview deeplink reentry

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1562,6 +1562,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             this.implementation.directUpdate = false;
         }
         if (this.applyDownloadedBundleForDirectUpdate(latest)) {
+            this.implementation.setNextBundle(null);
             this.notifyBundleSet(latest);
             sendReadyToJs(latest, "update installed", true);
         } else {
@@ -2418,12 +2419,35 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private boolean leavePreviewSessionForIncomingPreviewLink() {
-        if (!this.leavePreviewSessionWithoutReload(true)) {
-            return false;
-        }
+        final BundleInfo previewBundle = this.implementation.getCurrentBundle();
+        final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
 
         try {
-            return this._reload();
+            if (previewFallbackBundle == null || previewFallbackBundle.isErrorStatus()) {
+                logger.error("No preview fallback bundle available");
+                return false;
+            }
+            if (!this.implementation.canSet(previewFallbackBundle)) {
+                logger.error("Preview fallback bundle is not installable");
+                return false;
+            }
+
+            final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
+            if (!this.implementation.stagePreviewFallbackReload(previewFallbackBundle)) {
+                logger.error("Could not stage preview fallback bundle");
+                return false;
+            }
+
+            if (!this._reload()) {
+                this.implementation.restoreResetState(previousState);
+                this.restoreLiveBundleStateAfterFailedReload();
+                return false;
+            }
+
+            this.endPreviewSession(true);
+            final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
+            this.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle, restoredNextBundle);
+            return true;
         } finally {
             this.clearIncomingPreviewTransition();
         }

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -159,15 +159,39 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private volatile boolean onLaunchDirectUpdateUsed = false;
     Boolean shakeMenuEnabled = false;
     Boolean shakeChannelSelectorEnabled = false;
-    Boolean previewSessionEnabled = false;
+    volatile Boolean previewSessionEnabled = false;
     private Boolean previewSessionAlertPending = false;
-    private Boolean isLeavingPreviewForIncomingLink = false;
+    private volatile Boolean isLeavingPreviewForIncomingLink = false;
     private Boolean allowManualBundleError = false;
     private Boolean allowPreview = false;
     Boolean allowSetDefaultChannel = true;
 
     String getUpdateUrl() {
         return this.updateUrl;
+    }
+
+    private boolean isPreviewSessionStateActive() {
+        return (
+            Boolean.TRUE.equals(this.previewSessionEnabled) ||
+            Boolean.TRUE.equals(this.isLeavingPreviewForIncomingLink) ||
+            (this.implementation != null && this.implementation.previewSession)
+        );
+    }
+
+    private boolean shouldBlockAutoUpdateForPreviewSession() {
+        if (!this.isPreviewSessionStateActive()) {
+            return false;
+        }
+
+        logger.info("Preview session is active. Skipping normal auto-update work.");
+        return true;
+    }
+
+    private void clearIncomingPreviewTransition() {
+        this.isLeavingPreviewForIncomingLink = false;
+        if (!Boolean.TRUE.equals(this.previewSessionEnabled) && this.implementation != null) {
+            this.implementation.previewSession = false;
+        }
     }
 
     // Used for activity-based foreground/background detection on Android < 14
@@ -1507,6 +1531,12 @@ public class CapacitorUpdaterPlugin extends Plugin {
     void scheduleDirectUpdateFinish(final BundleInfo latest) {
         startNewThread(() -> {
             try {
+                if (this.shouldBlockAutoUpdateForPreviewSession()) {
+                    logger.info("Skipping direct update install while preview session state is active");
+                    this.implementation.directUpdate = false;
+                    this.clearBackgroundDownloadState();
+                    return;
+                }
                 Activity currentActivity = this.getActivity();
                 if (currentActivity != null) {
                     this.implementation.activity = currentActivity;
@@ -1521,14 +1551,51 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private void directUpdateFinish(final BundleInfo latest) {
+        if (this.shouldBlockAutoUpdateForPreviewSession()) {
+            logger.info("Skipping direct update finish while preview session state is active");
+            this.implementation.directUpdate = false;
+            this.clearBackgroundDownloadState();
+            return;
+        }
         if ("onLaunch".equals(this.directUpdateMode)) {
             this.onLaunchDirectUpdateUsed = true;
             this.implementation.directUpdate = false;
         }
-        if (CapacitorUpdaterPlugin.this.implementation.set(latest) && CapacitorUpdaterPlugin.this._reload()) {
+        if (this.applyDownloadedBundleForDirectUpdate(latest)) {
             this.notifyBundleSet(latest);
             sendReadyToJs(latest, "update installed", true);
+        } else {
+            this.implementation.setNextBundle(latest.getId());
+            final JSObject ret = new JSObject();
+            ret.put("bundle", InternalUtils.mapToJSObject(latest.toJSONMap()));
+            this.notifyListeners("updateAvailable", ret);
+            sendReadyToJs(
+                this.implementation.getCurrentBundle(),
+                "Direct update reload failed, update will install next background",
+                false
+            );
         }
+    }
+
+    private boolean applyDownloadedBundleForDirectUpdate(final BundleInfo latest) {
+        final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
+        final String previousBundleName = this.implementation.getCurrentBundle().getVersionName();
+
+        if (!this.implementation.stagePendingReload(latest)) {
+            this.implementation.restoreResetState(previousState);
+            logger.error("Direct update failed to stage downloaded bundle: " + latest.toString());
+            return false;
+        }
+
+        if (this._reload()) {
+            this.implementation.finalizePendingReload(latest, previousBundleName);
+            return true;
+        }
+
+        this.implementation.restoreResetState(previousState);
+        this.restoreLiveBundleStateAfterFailedReload();
+        logger.error("Direct update reload failed after staging bundle: " + latest.toString());
+        return false;
     }
 
     private void cleanupObsoleteVersions() {
@@ -2136,6 +2203,15 @@ public class CapacitorUpdaterPlugin extends Plugin {
         return this.semaphoreWait(phase, waitTimeMs);
     }
 
+    protected boolean reloadWithoutWaitingForAppReady() {
+        this.applyCurrentBundleToBridge();
+
+        final long waitTimeMs = this.resolveAppReadyCheckTimeoutMs();
+        this.checkAppReady(waitTimeMs);
+        this.notifyListeners("appReloaded", new JSObject());
+        return true;
+    }
+
     @PluginMethod
     public void reload(final PluginCall call) {
         startNewThread(() -> {
@@ -2143,7 +2219,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 final BundleInfo current = this.implementation.getCurrentBundle();
                 final BundleInfo next = this.implementation.getNextBundle();
 
-                if (next != null && !next.isErrorStatus() && !next.getId().equals(current.getId())) {
+                if (!this.isPreviewSessionStateActive() && next != null && !next.isErrorStatus() && !next.getId().equals(current.getId())) {
                     final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
                     final String previousBundleName = this.implementation.getCurrentBundle().getVersionName();
                     logger.info("Applying pending bundle before reload: " + next.getVersionName());
@@ -2223,6 +2299,12 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 if (!this.implementation.set(id)) {
                     logger.info("No such bundle " + id);
                     call.reject("Update failed, id " + id + " does not exist.");
+                } else if (Boolean.TRUE.equals(this.previewSessionEnabled)) {
+                    logger.info("Preview session set active bundle " + id + " without waiting for preview app readiness");
+                    this.reloadWithoutWaitingForAppReady();
+                    this.notifyBundleSet(this.implementation.getBundleInfo(id));
+                    this.showPreviewSessionNoticeIfNeeded();
+                    call.resolve();
                 } else if (!this._reload()) {
                     logger.error("Reload failed after setting bundle " + id);
                     call.reject("Reload failed after setting bundle " + id);
@@ -2335,6 +2417,18 @@ public class CapacitorUpdaterPlugin extends Plugin {
         return true;
     }
 
+    private boolean leavePreviewSessionForIncomingPreviewLink() {
+        if (!this.leavePreviewSessionWithoutReload(true)) {
+            return false;
+        }
+
+        try {
+            return this._reload();
+        } finally {
+            this.clearIncomingPreviewTransition();
+        }
+    }
+
     private void leavePreviewSessionForLaunchIntentIfNeeded() {
         final Intent intent = getActivity() == null ? null : getActivity().getIntent();
         if (
@@ -2357,6 +2451,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private boolean leavePreviewSessionWithoutReload() {
+        return this.leavePreviewSessionWithoutReload(false);
+    }
+
+    private boolean leavePreviewSessionWithoutReload(final boolean keepPreviewGuard) {
         final BundleInfo previewBundle = this.implementation.getCurrentBundle();
         final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
         if (previewFallbackBundle == null || previewFallbackBundle.isErrorStatus()) {
@@ -2372,7 +2470,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return false;
         }
 
-        this.endPreviewSession();
+        this.endPreviewSession(keepPreviewGuard);
         final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
         this.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle, restoredNextBundle);
         return true;
@@ -2402,7 +2500,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return this.refreshPreviewSessionFromPayloadUrl(payloadUrl);
         }
 
-        return this._reload();
+        return this.reloadWithoutWaitingForAppReady();
     }
 
     public boolean hasActivePreviewSession() {
@@ -2434,6 +2532,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private void endPreviewSession() {
+        this.endPreviewSession(false);
+    }
+
+    private void endPreviewSession(final boolean keepPreviewGuard) {
         final boolean previousShakeMenuEnabled = this.prefs.getBoolean(
             PREVIEW_PREVIOUS_SHAKE_MENU_PREF_KEY,
             this.getConfig().getBoolean("shakeMenu", false)
@@ -2448,8 +2550,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
         this.previewSessionEnabled = false;
         this.previewSessionAlertPending = false;
-        this.isLeavingPreviewForIncomingLink = false;
-        this.implementation.previewSession = false;
+        if (keepPreviewGuard) {
+            this.implementation.previewSession = true;
+        } else {
+            this.clearIncomingPreviewTransition();
+        }
         this.shakeMenuEnabled = previousShakeMenuEnabled;
         this.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled;
         this.implementation.setPreviewFallbackBundle(null);
@@ -2670,7 +2775,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
             if (version.equals(this.implementation.getCurrentBundle().getVersionName())) {
                 logger.info("Preview payload unchanged, reloading current bundle");
-                return this._reload();
+                return this.reloadWithoutWaitingForAppReady();
             }
 
             final BundleInfo next = this.downloadPreviewPayloadBundle(payload);
@@ -2682,7 +2787,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             }
 
             this.notifyBundleSet(next);
-            return this._reload();
+            return this.reloadWithoutWaitingForAppReady();
         } catch (final Exception err) {
             logger.error("Could not refresh preview session: " + err.getMessage());
             return false;
@@ -2967,6 +3072,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
             logger.error("Error no url or wrong format");
             return "unavailable";
         }
+        if (this.shouldBlockAutoUpdateForPreviewSession()) {
+            return "preview_session";
+        }
         if (this.isDownloadStuckOrTimedOut()) {
             logger.info("Download already in progress, skipping duplicate download request");
             return "already_running";
@@ -3135,7 +3243,13 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 @Override
                 public void run() {
                     try {
+                        if (CapacitorUpdaterPlugin.this.shouldBlockAutoUpdateForPreviewSession()) {
+                            return;
+                        }
                         CapacitorUpdaterPlugin.this.implementation.getLatest(CapacitorUpdaterPlugin.this.updateUrl, null, (res) -> {
+                            if (CapacitorUpdaterPlugin.this.shouldBlockAutoUpdateForPreviewSession()) {
+                                return;
+                            }
                             JSObject jsRes = InternalUtils.mapToJSObject(res);
                             if (jsRes.has("error") || jsRes.has("kind")) {
                                 final BundleInfo current = CapacitorUpdaterPlugin.this.implementation.getCurrentBundle();
@@ -3198,6 +3312,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             logger.info("semaphoreReady countDown");
             this.semaphoreDown();
             logger.info("semaphoreReady countDown done");
+            this.clearIncomingPreviewTransition();
             final JSObject ret = new JSObject();
             ret.put("bundle", InternalUtils.mapToJSObject(bundle.toJSONMap()));
             call.resolve(ret);
@@ -3245,6 +3360,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private Boolean _isAutoUpdateEnabled() {
+        if (this.isPreviewSessionStateActive()) {
+            return false;
+        }
         final CapConfig config = CapConfig.loadDefault(this.getActivity());
         String serverUrl = config.getServerUrl();
         if (serverUrl != null && !serverUrl.isEmpty()) {
@@ -3443,6 +3561,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
         logger.info("endBackGroundTaskWithNotif " + msg);
     }
 
+    private void clearBackgroundDownloadState() {
+        this.backgroundDownloadTask = null;
+        this.downloadStartTimeMs = 0;
+    }
+
     private boolean isDownloadStuckOrTimedOut() {
         if (this.backgroundDownloadTask == null || !this.backgroundDownloadTask.isAlive()) {
             return false;
@@ -3469,6 +3592,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private Thread backgroundDownload() {
+        if (this.shouldBlockAutoUpdateForPreviewSession()) {
+            return null;
+        }
         final boolean plannedDirectUpdate = this.shouldUseDirectUpdate();
         final boolean initialDirectUpdateAllowed = this.isDirectUpdateCurrentlyAllowed(plannedDirectUpdate);
         final String messageUpdate = initialDirectUpdateAllowed
@@ -3479,9 +3605,17 @@ public class CapacitorUpdaterPlugin extends Plugin {
         Thread newTask = startNewThread(() -> {
             // Wait for cleanup to complete before starting download
             waitForCleanupIfNeeded();
+            if (CapacitorUpdaterPlugin.this.shouldBlockAutoUpdateForPreviewSession()) {
+                CapacitorUpdaterPlugin.this.clearBackgroundDownloadState();
+                return;
+            }
             logger.info("Check for update via: " + CapacitorUpdaterPlugin.this.updateUrl);
             try {
                 CapacitorUpdaterPlugin.this.implementation.getLatest(CapacitorUpdaterPlugin.this.updateUrl, null, (res) -> {
+                    if (CapacitorUpdaterPlugin.this.shouldBlockAutoUpdateForPreviewSession()) {
+                        CapacitorUpdaterPlugin.this.clearBackgroundDownloadState();
+                        return;
+                    }
                     JSObject jsRes = InternalUtils.mapToJSObject(res);
                     final BundleInfo current = CapacitorUpdaterPlugin.this.implementation.getCurrentBundle();
 
@@ -3706,6 +3840,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
                                 : initialDirectUpdateAllowed;
                             startNewThread(() -> {
                                 try {
+                                    if (CapacitorUpdaterPlugin.this.shouldBlockAutoUpdateForPreviewSession()) {
+                                        CapacitorUpdaterPlugin.this.clearBackgroundDownloadState();
+                                        return;
+                                    }
                                     logger.info(
                                         "New bundle: " +
                                             latestVersionName +
@@ -3792,6 +3930,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private void installNext() {
         try {
+            if (this.shouldBlockAutoUpdateForPreviewSession()) {
+                return;
+            }
             String delayUpdatePreferences = prefs.getString(DelayUpdateUtils.DELAY_CONDITION_PREFERENCES, "[]");
             ArrayList<DelayCondition> delayConditionList = delayUpdateUtils.parseDelayConditions(delayUpdatePreferences);
             if (!delayConditionList.isEmpty()) {
@@ -3825,6 +3966,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
         if (current.isBuiltin()) {
             logger.info("Built-in bundle is active. We skip the check for notifyAppReady.");
+            return;
+        }
+        if (this.isPreviewSessionStateActive()) {
+            logger.info("Preview session is active. We skip the check for notifyAppReady.");
             return;
         }
         logger.debug("Current bundle is: " + current);
@@ -4021,7 +4166,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
         logger.info("Preview deeplink received while preview session is active; restoring fallback before routing");
         startNewThread(() -> {
-            final boolean didLeave = this.leavePreviewSessionFromShakeMenu();
+            final boolean didLeave = this.leavePreviewSessionForIncomingPreviewLink();
             if (!didLeave) {
                 logger.error("Could not leave preview session before routing incoming preview deeplink");
                 this.isLeavingPreviewForIncomingLink = false;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -82,7 +82,7 @@ public class CapgoUpdater {
     public String channelUrl = "";
     public String defaultChannel = "";
     public String appId = "";
-    public boolean previewSession = false;
+    public volatile boolean previewSession = false;
     public String publicKey = "";
     public String deviceID = "";
     public int timeout = 20000;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -742,11 +742,15 @@ public class CapgoUpdater {
             CapgoUpdater.this.notifyListeners("updateAvailable", ret);
             logger.info("setNext: " + setNext);
             if (setNext) {
-                logger.info("directUpdate: " + this.directUpdate);
-                if (this.directUpdate) {
+                if (this.previewSession) {
+                    logger.info("Preview session is active, skipping automatic install of downloaded bundle");
+                    this.directUpdate = false;
+                } else if (this.directUpdate) {
+                    logger.info("directUpdate: " + this.directUpdate);
                     CapgoUpdater.this.directUpdateFinish(next);
                     this.directUpdate = false;
                 } else {
+                    logger.info("directUpdate: " + this.directUpdate);
                     this.setNextBundle(next.getId());
                 }
             }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -1423,6 +1423,70 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void testCheckRevertSkipsRollbackDuringPreviewSession() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final ResetTrackingCapgoUpdater updater = new ResetTrackingCapgoUpdater();
+            updater.currentBundle = new BundleInfo("preview-id", "preview", BundleStatus.PENDING, new Date(), "preview");
+
+            plugin.implementation = updater;
+            plugin.previewSessionEnabled = true;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            invokePrivateVoidMethod(plugin, "checkRevert");
+
+            assertFalse(updater.resetCalled);
+            assertFalse(plugin.hasNotifiedEvent("updateFailed"));
+        }
+    }
+
+    @Test
+    public void testCheckRevertSkipsRollbackDuringPreviewTransition() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final ResetTrackingCapgoUpdater updater = new ResetTrackingCapgoUpdater();
+            updater.currentBundle = new BundleInfo("preview-id", "preview", BundleStatus.PENDING, new Date(), "preview");
+            updater.previewSession = true;
+
+            plugin.implementation = updater;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            invokePrivateVoidMethod(plugin, "checkRevert");
+
+            assertFalse(updater.resetCalled);
+            assertFalse(plugin.hasNotifiedEvent("updateFailed"));
+        }
+    }
+
+    @Test
+    public void testTriggerUpdateCheckSkipsDuringPreviewSession() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            plugin.implementation = new ResetTrackingCapgoUpdater();
+            plugin.previewSessionEnabled = true;
+            plugin.setLoggerForTesting(mock(Logger.class));
+            setPrivateField(plugin, "updateUrl", "https://example.com/updates");
+
+            assertEquals("preview_session", plugin.triggerBackgroundUpdateCheck());
+        }
+    }
+
+    @Test
     public void testResetToPendingWithoutPendingBundleDoesNotResetState() throws Exception {
         try (
             MockedStatic<Looper> looperMock = mockStatic(Looper.class);
@@ -2361,7 +2425,10 @@ public class CapacitorUpdaterUnitTest {
 
             assertTrue(plugin.startNewThreadCalled);
             assertTrue(plugin.reloadCalled);
-            assertEquals(1, updater.setCalls);
+            assertEquals(0, updater.setCalls);
+            assertEquals(1, updater.stagePendingReloadCalls);
+            assertEquals(1, updater.finalizePendingReloadCalls);
+            assertSame(latest, updater.finalizedPendingReloadBundle);
             assertSame(plugin.activity, updater.activity);
         }
     }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -165,6 +165,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     public var previewSessionEnabled = false
     private var previewSessionAlertPending = false
     private var isLeavingPreviewForIncomingLink = false
+    private var previewTransitionClearWorkItem: DispatchWorkItem?
     let semaphoreReady = DispatchSemaphore(value: 0)
 
     private var delayUpdateUtils: DelayUpdateUtils!
@@ -986,7 +987,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let current: BundleInfo = self.implementation.getCurrentBundle()
         let next: BundleInfo? = self.implementation.getNextBundle()
 
-        if let next = next, !next.isErrorStatus(), next.getId() != current.getId() {
+        if !self.isPreviewSessionStateActive(),
+           let next = next,
+           !next.isErrorStatus(),
+           next.getId() != current.getId() {
             let previousState = self.implementation.captureResetState()
             let previousBundleName = self.implementation.getCurrentBundle().getVersionName()
             logger.info("Applying pending bundle before reload: \(next.toString())")
@@ -1025,6 +1029,27 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    private func applyDownloadedBundleForDirectUpdate(_ next: BundleInfo) -> Bool {
+        let previousState = self.implementation.captureResetState()
+        let previousBundleName = self.implementation.getCurrentBundle().getVersionName()
+
+        guard self.implementation.stagePendingReload(bundle: next) else {
+            self.implementation.restoreResetState(previousState)
+            logger.error("Direct update failed to stage downloaded bundle: \(next.toString())")
+            return false
+        }
+
+        if self._reload() {
+            self.implementation.finalizePendingReload(bundle: next, previousBundleName: previousBundleName)
+            return true
+        }
+
+        self.implementation.restoreResetState(previousState)
+        self.restoreLiveBundleStateAfterFailedReload()
+        logger.error("Direct update reload failed after staging bundle: \(next.toString())")
+        return false
+    }
+
     @objc func next(_ call: CAPPluginCall) {
         guard let id = call.getString("id") else {
             logger.error("Next called without id")
@@ -1058,6 +1083,37 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             self.showPreviewSessionNoticeIfNeeded()
             call.resolve()
         }
+    }
+
+    private func isPreviewSessionStateActive() -> Bool {
+        self.previewSessionEnabled || self.isLeavingPreviewForIncomingLink || self.implementation.previewSession
+    }
+
+    private func shouldBlockAutoUpdateForPreviewSession() -> Bool {
+        guard self.isPreviewSessionStateActive() else {
+            return false
+        }
+
+        logger.info("Preview session is active. Skipping normal auto-update work.")
+        return true
+    }
+
+    private func clearIncomingPreviewTransition() {
+        self.previewTransitionClearWorkItem?.cancel()
+        self.previewTransitionClearWorkItem = nil
+        self.isLeavingPreviewForIncomingLink = false
+        if !self.previewSessionEnabled {
+            self.implementation.previewSession = false
+        }
+    }
+
+    private func scheduleIncomingPreviewTransitionFallbackClear() {
+        self.previewTransitionClearWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.clearIncomingPreviewTransition()
+        }
+        self.previewTransitionClearWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.appReadyTimeout), execute: workItem)
     }
 
     @objc func startPreviewSession(_ call: CAPPluginCall) {
@@ -1117,6 +1173,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             UserDefaults.standard.removeObject(forKey: self.previewPayloadUrlDefaultsKey)
         }
 
+        self.clearIncomingPreviewTransition()
         self.previewSessionEnabled = true
         self.previewSessionAlertPending = true
         self.implementation.previewSession = true
@@ -1159,7 +1216,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    private func leavePreviewSessionWithoutReload() -> Bool {
+    private func leavePreviewSessionWithoutReload(keepPreviewGuard: Bool = false) -> Bool {
         let previewBundle = self.implementation.getCurrentBundle()
         guard let previewFallbackBundle = self.implementation.getPreviewFallbackBundle(), !previewFallbackBundle.isErrorStatus() else {
             logger.error("No preview fallback bundle available")
@@ -1174,10 +1231,24 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             return false
         }
 
-        self.endPreviewSession()
+        self.endPreviewSession(keepPreviewGuard: keepPreviewGuard)
         let restoredNextBundle = self.implementation.getNextBundle()
         self.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle: previewFallbackBundle, restoredNextBundle: restoredNextBundle)
         return true
+    }
+
+    private func leavePreviewSessionForIncomingPreviewLink() -> Bool {
+        guard self.leavePreviewSessionWithoutReload(keepPreviewGuard: true) else {
+            return false
+        }
+
+        let didReload = self._reload()
+        if didReload {
+            self.scheduleIncomingPreviewTransitionFallbackClear()
+        } else {
+            self.clearIncomingPreviewTransition()
+        }
+        return didReload
     }
 
     private func deletePreviewBundleIfUnused(
@@ -1228,7 +1299,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         return false
     }
 
-    private func endPreviewSession() {
+    private func endPreviewSession(keepPreviewGuard: Bool = false) {
         let previousShakeMenuEnabled = UserDefaults.standard.object(forKey: self.previewPreviousShakeMenuDefaultsKey) as? Bool
             ?? getConfig().getBoolean("shakeMenu", false)
         let previousShakeChannelSelectorEnabled = UserDefaults.standard.object(forKey: self.previewPreviousShakeChannelSelectorDefaultsKey) as? Bool
@@ -1239,8 +1310,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         self.previewSessionEnabled = false
         self.previewSessionAlertPending = false
-        self.isLeavingPreviewForIncomingLink = false
-        self.implementation.previewSession = false
+        if keepPreviewGuard {
+            self.implementation.previewSession = true
+        } else {
+            self.clearIncomingPreviewTransition()
+        }
         self.shakeMenuEnabled = previousShakeMenuEnabled
         self.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled
         _ = self.implementation.setPreviewFallbackBundle(fallback: nil)
@@ -1395,7 +1469,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.isLeavingPreviewForIncomingLink = true
         logger.info("Preview deeplink received while preview session is active; restoring fallback before routing")
         DispatchQueue.global(qos: .userInitiated).async {
-            let didLeave = self.leavePreviewSessionFromShakeMenu()
+            let didLeave = self.leavePreviewSessionForIncomingPreviewLink()
             if !didLeave {
                 self.logger.error("Could not leave preview session before routing incoming preview deeplink")
                 self.isLeavingPreviewForIncomingLink = false
@@ -1701,6 +1775,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             logger.error("Error no url or wrong format")
             return "unavailable"
         }
+        if self.shouldBlockAutoUpdateForPreviewSession() {
+            return "preview_session"
+        }
         if self.isDownloadStuckOrTimedOut() {
             logger.info("Download already in progress, skipping duplicate download request")
             return "already_running"
@@ -1937,6 +2014,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let bundle = self.implementation.getCurrentBundle()
         self.implementation.setSuccess(bundle: bundle, autoDeletePrevious: self.autoDeletePrevious)
         logger.info("Current bundle loaded successfully. [notifyAppReady was called] \(bundle.toString())")
+        self.clearIncomingPreviewTransition()
 
         call.resolve(["bundle": bundle.toJSON()])
     }
@@ -1987,6 +2065,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     // Note: _checkCancelDelay method has been moved to DelayUpdateUtils class
 
     private func _isAutoUpdateEnabled() -> Bool {
+        if self.isPreviewSessionStateActive() {
+            return false
+        }
         let instanceDescriptor = (self.bridge?.viewController as? CAPBridgeViewController)?.instanceDescriptor()
         if instanceDescriptor?.serverURL != nil {
             logger.warn("AutoUpdate is automatic disabled when serverUrl is set.")
@@ -2022,6 +2103,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let current: BundleInfo = self.implementation.getCurrentBundle()
         if current.isBuiltin() {
             logger.info("Built-in bundle is active. We skip the check for notifyAppReady.")
+            return
+        }
+        if self.isPreviewSessionStateActive() {
+            logger.info("Preview session is active. We skip the check for notifyAppReady.")
             return
         }
 
@@ -2693,6 +2778,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         return true
     }
 
+    private func clearDownloadInProgressState() {
+        downloadLock.lock()
+        defer { downloadLock.unlock() }
+        downloadInProgress = false
+        downloadStartTime = nil
+    }
+
     func runBackgroundDownloadWork(_ work: @escaping () -> Void) {
         // Live update checks/downloads are user-visible work. Using `.background`
         // lets the scheduler starve them for minutes while the app is active.
@@ -2718,6 +2810,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     func backgroundDownload() {
+        if self.shouldBlockAutoUpdateForPreviewSession() {
+            return
+        }
         // Set download in progress flag (thread-safe)
         downloadLock.lock()
         downloadInProgress = true
@@ -2746,10 +2841,19 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.runBackgroundDownloadWork {
             // Wait for cleanup to complete before starting download
             self.waitForCleanupIfNeeded()
+            if self.shouldBlockAutoUpdateForPreviewSession() {
+                self.clearDownloadInProgressState()
+                return
+            }
             self.beginDownloadBackgroundTask()
             self.logger.info("Check for update via \(self.updateUrl)")
             let res = self.implementation.getLatest(url: url, channel: nil)
             let current = self.implementation.getCurrentBundle()
+            if self.shouldBlockAutoUpdateForPreviewSession() {
+                self.clearDownloadInProgressState()
+                self.endBackGroundTask()
+                return
+            }
 
             // Handle network errors and other failures first
             let backendError = res.error ?? ""
@@ -2861,6 +2965,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                         )
                         return
                     }
+                    if self.shouldBlockAutoUpdateForPreviewSession() {
+                        self.clearDownloadInProgressState()
+                        self.endBackGroundTask()
+                        return
+                    }
                     res.checksum = try CryptoCipher.decryptChecksum(checksum: res.checksum, publicKey: self.implementation.publicKey)
                     CryptoCipher.logChecksumInfo(label: "Bundle checksum", hexChecksum: next.getChecksum())
                     CryptoCipher.logChecksumInfo(label: "Expected checksum", hexChecksum: res.checksum)
@@ -2878,6 +2987,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                             current: current,
                             plannedDirectUpdate: plannedDirectUpdate
                         )
+                        return
+                    }
+                    if self.shouldBlockAutoUpdateForPreviewSession() {
+                        self.clearDownloadInProgressState()
+                        self.endBackGroundTask()
                         return
                     }
                     let directUpdateAllowed = plannedDirectUpdate && !self.autoSplashscreenTimedOut
@@ -2899,7 +3013,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                             )
                             return
                         }
-                        if self.implementation.set(bundle: next) && self._reload() {
+                        if self.applyDownloadedBundleForDirectUpdate(next) {
                             self.notifyBundleSet(next)
                             self.endBackGroundTaskWithNotif(
                                 msg: "update installed",
@@ -2909,10 +3023,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                                 plannedDirectUpdate: plannedDirectUpdate
                             )
                         } else {
+                            _ = self.implementation.setNextBundle(next: next.getId())
+                            self.notifyListeners("updateAvailable", data: ["bundle": next.toJSON()])
                             self.endBackGroundTaskWithNotif(
-                                msg: "Update install failed",
+                                msg: "Direct update reload failed, update will install next background",
                                 latestVersionName: latestVersionName,
-                                current: next,
+                                current: self.implementation.getCurrentBundle(),
+                                error: false,
                                 plannedDirectUpdate: plannedDirectUpdate
                             )
                         }
@@ -2968,6 +3085,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func installNext() {
+        if self.shouldBlockAutoUpdateForPreviewSession() {
+            return
+        }
         let delayUpdatePreferences = UserDefaults.standard.string(forKey: DelayUpdateUtils.DELAY_CONDITION_PREFERENCES) ?? "[]"
         let delayConditionList: [DelayCondition] = fromJsonArr(json: delayUpdatePreferences).map { obj -> DelayCondition in
             let kind: String = obj.value(forKey: "kind") as! String
@@ -3059,8 +3179,14 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             }
             DispatchQueue.global(qos: .utility).async {
+                if self.shouldBlockAutoUpdateForPreviewSession() {
+                    return
+                }
                 let res = self.implementation.getLatest(url: url, channel: nil)
                 let current = self.implementation.getCurrentBundle()
+                if self.shouldBlockAutoUpdateForPreviewSession() {
+                    return
+                }
 
                 if res.version != current.getVersionName() {
                     self.logger.info("New version found: \(res.version)")

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1041,6 +1041,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         if self._reload() {
             self.implementation.finalizePendingReload(bundle: next, previousBundleName: previousBundleName)
+            _ = self.implementation.setNextBundle(next: Optional<String>.none)
             return true
         }
 
@@ -1238,14 +1239,38 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func leavePreviewSessionForIncomingPreviewLink() -> Bool {
-        guard self.leavePreviewSessionWithoutReload(keepPreviewGuard: true) else {
+        let previewBundle = self.implementation.getCurrentBundle()
+        guard let previewFallbackBundle = self.implementation.getPreviewFallbackBundle(), !previewFallbackBundle.isErrorStatus() else {
+            logger.error("No preview fallback bundle available")
+            self.clearIncomingPreviewTransition()
+            return false
+        }
+        guard self.implementation.canSet(bundle: previewFallbackBundle) else {
+            logger.error("Preview fallback bundle is not installable")
+            self.clearIncomingPreviewTransition()
+            return false
+        }
+
+        let previousState = self.implementation.captureResetState()
+        guard self.implementation.stagePreviewFallbackReload(bundle: previewFallbackBundle) else {
+            logger.error("Could not stage preview fallback bundle")
+            self.clearIncomingPreviewTransition()
             return false
         }
 
         let didReload = self._reload()
         if didReload {
+            self.endPreviewSession(keepPreviewGuard: true)
+            let restoredNextBundle = self.implementation.getNextBundle()
+            self.deletePreviewBundleIfUnused(
+                previewBundle,
+                previewFallbackBundle: previewFallbackBundle,
+                restoredNextBundle: restoredNextBundle
+            )
             self.scheduleIncomingPreviewTransitionFallbackClear()
         } else {
+            self.implementation.restoreResetState(previousState)
+            self.restoreLiveBundleStateAfterFailedReload()
             self.clearIncomingPreviewTransition()
         }
         return didReload

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -821,6 +821,46 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertEqual(CapacitorUpdaterPlugin.normalizedPeriodCheckDelaySeconds(3600), 3600)
     }
 
+    func testCheckRevertSkipsRollbackDuringPreviewSession() {
+        let previewPlugin = TestableCapacitorUpdaterPlugin()
+        let previewImplementation = ResetTrackingCapgoUpdater()
+        previewImplementation.currentBundleValue = BundleInfo(
+            id: "preview-id",
+            version: "preview",
+            status: .PENDING,
+            downloaded: Date(),
+            checksum: "preview"
+        )
+
+        previewPlugin.implementation = previewImplementation
+        previewPlugin.previewSessionEnabled = true
+
+        previewPlugin.checkRevert()
+
+        XCTAssertFalse(previewImplementation.resetCalled)
+        XCTAssertFalse(previewPlugin.notifiedEventNames.contains("updateFailed"))
+    }
+
+    func testCheckRevertSkipsRollbackDuringPreviewTransition() {
+        let previewPlugin = TestableCapacitorUpdaterPlugin()
+        let previewImplementation = ResetTrackingCapgoUpdater()
+        previewImplementation.currentBundleValue = BundleInfo(
+            id: "preview-id",
+            version: "preview",
+            status: .PENDING,
+            downloaded: Date(),
+            checksum: "preview"
+        )
+        previewImplementation.previewSession = true
+
+        previewPlugin.implementation = previewImplementation
+
+        previewPlugin.checkRevert()
+
+        XCTAssertFalse(previewImplementation.resetCalled)
+        XCTAssertFalse(previewPlugin.notifiedEventNames.contains("updateFailed"))
+    }
+
     func testResetToPendingWithoutInstallablePendingBundleDoesNotResetState() {
         let resetPlugin = ResetTestableCapacitorUpdaterPlugin()
         let resetImplementation = ResetTrackingCapgoUpdater()

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -861,6 +861,30 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertFalse(previewPlugin.notifiedEventNames.contains("updateFailed"))
     }
 
+    func testTriggerUpdateCheckSkipsDuringPreviewSession() {
+        let previewPlugin = TestableCapacitorUpdaterPlugin()
+        let previewImplementation = ResetTrackingCapgoUpdater()
+        previewImplementation.currentBundleValue = BundleInfo(
+            id: "preview-id",
+            version: "preview",
+            status: .PENDING,
+            downloaded: Date(),
+            checksum: "preview"
+        )
+
+        previewPlugin.implementation = previewImplementation
+        previewPlugin.previewSessionEnabled = true
+        previewPlugin.setUpdateUrlForTesting("https://example.com/update")
+
+        let status = previewPlugin.triggerBackgroundUpdateCheck()
+
+        XCTAssertEqual(status, "preview_session")
+        XCTAssertFalse(previewImplementation.resetCalled)
+        XCTAssertFalse(previewPlugin.notifiedEventNames.contains("updateAvailable"))
+        XCTAssertFalse(previewPlugin.notifiedEventNames.contains("downloadFailed"))
+        XCTAssertFalse(previewPlugin.notifiedEventNames.contains("updateCheckResult"))
+    }
+
     func testResetToPendingWithoutInstallablePendingBundleDoesNotResetState() {
         let resetPlugin = ResetTestableCapacitorUpdaterPlugin()
         let resetImplementation = ResetTrackingCapgoUpdater()


### PR DESCRIPTION
## What
- Restore the host bundle before routing a new preview deeplink when another preview session is active.
- Keep a native preview-transition guard alive while the host is reloading for an incoming preview deeplink.
- Block normal auto-update checks, direct installs, pending-bundle installs, and Android download-completion `setNext` while preview or preview reentry is active.
- Make direct update installs transactional: stage the downloaded bundle, reload, finalize only on success, and restore/queue the bundle if reload fails.
- Let Android preview-session reloads proceed without waiting for arbitrary preview apps to call `notifyAppReady()`.
- Skip app-ready rollback while a preview session or preview reentry transition is active.

## Why
- External camera deeplinks can arrive while a third-party preview bundle is still active. The previous flow could leave the preview JS in control or block the reset path, making repeated scans flaky and leaving the app stuck in preview.
- Preview temporarily changes `appId`, so a scheduled/background update check racing the deeplink reset could download or apply a bundle for the wrong app.
- Preview bundles can be any app from any user, so they cannot be required to include updater JS or call `notifyAppReady()`.
- A normal direct update reload can race native navigation/reload work; it should not leave updater state half-applied if reload cannot be performed.

## How
- Added a shared native guard for active preview state and incoming-preview transitions.
- Incoming preview deeplinks now leave the old session with the guard preserved, reload the restored host bundle, then clear the guard after host readiness or timeout.
- Auto-update entry points and completion paths now no-op while the guard is active; preview refresh/download remains separate.
- Direct update completion now uses existing staged reload helpers and restores previous state on failure before queueing the downloaded bundle for a later install.
- Android download completion skips automatic install/set-next when `CapgoUpdater.previewSession` is active.

## Testing
- `bun run build`
- `bun run swiftlint -- --fix --format`
- `git diff --check`
- CI run pending for full Android/iOS verification after latest push.

## Not Tested
- `bun run test:ios` locally: xcodebuild compiled the plugin, then the only installed local iOS 26.4 simulator runtime aborted before XCTest bootstrapped with a private-framework signature/load error.
- Android tests locally: this environment does not have a Java runtime (`/usr/libexec/java_home -V` cannot locate a JVM).
- Full `bun run lint`: local SwiftLint reports existing violations in files outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview sessions now comprehensively gate all update operations: direct updates, auto-update checks, and background downloads are blocked during active preview state
  * Preview reload enhanced to bypass app-ready signal waiting during preview transitions

* **Bug Fixes**
  * Rollback behavior is now properly skipped when preview sessions are active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->