### PR TITLE
fix: keep channel ids numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -2377,7 +2377,7 @@ Result returned after requesting an immediate native auto-update check.
 
 | Prop                 | Type                 | Description                                     | Since |
 | -------------------- | -------------------- | ----------------------------------------------- | ----- |
-| **`id`**             | <code>string</code>  | The channel ID                                  | 7.5.0 |
+| **`id`**             | <code>number</code>  | The channel ID                                  | 7.5.0 |
 | **`name`**           | <code>string</code>  | The channel name                                | 7.5.0 |
 | **`public`**         | <code>boolean</code> | Whether this is a public channel                | 7.5.0 |
 | **`allow_self_set`** | <code>boolean</code> | Whether devices can self-assign to this channel | 7.5.0 |

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1903,64 +1903,66 @@ public class CapgoUpdater {
                         String data = responseBody.string();
 
                         try {
-                            Map<String, Object> ret = new HashMap<>();
+                            Map<String, Object> ret = parseListChannelsResponse(data);
 
+                            logger.info("Channels listed successfully");
+                            callback.callback(ret);
+                        } catch (JSONException arrayException) {
+                            // If not an array, try to parse as error object
                             try {
-                                // Try to parse as direct array first
-                                JSONArray channelsJson = new JSONArray(data);
-                                List<Map<String, Object>> channelsList = new ArrayList<>();
-
-                                for (int i = 0; i < channelsJson.length(); i++) {
-                                    JSONObject channelJson = channelsJson.getJSONObject(i);
-                                    Map<String, Object> channel = new HashMap<>();
-                                    channel.put("id", channelJson.optString("id", ""));
-                                    channel.put("name", channelJson.optString("name", ""));
-                                    channel.put("public", channelJson.optBoolean("public", false));
-                                    channel.put("allow_self_set", channelJson.optBoolean("allow_self_set", false));
-                                    channelsList.add(channel);
-                                }
-
-                                // Wrap in channels object for JS API
-                                ret.put("channels", channelsList);
-
-                                logger.info("Channels listed successfully");
-                                callback.callback(ret);
-                            } catch (JSONException arrayException) {
-                                // If not an array, try to parse as error object
-                                try {
-                                    JSONObject json = new JSONObject(data);
-                                    if (json.has("error")) {
-                                        Map<String, Object> retError = new HashMap<>();
-                                        retError.put("error", json.getString("error"));
-                                        if (json.has("message")) {
-                                            retError.put("message", json.getString("message"));
-                                        } else {
-                                            retError.put("message", "server did not provide a message");
-                                        }
-                                        callback.callback(retError);
-                                        return;
-                                    }
+                                JSONObject json = new JSONObject(data);
+                                if (json.has("error")) {
                                     Map<String, Object> retError = new HashMap<>();
-                                    retError.put("message", "Unexpected channels response format");
-                                    retError.put("error", "parse_error");
+                                    retError.put("error", json.getString("error"));
+                                    if (json.has("message")) {
+                                        retError.put("message", json.getString("message"));
+                                    } else {
+                                        retError.put("message", "server did not provide a message");
+                                    }
                                     callback.callback(retError);
                                     return;
-                                } catch (JSONException objException) {
-                                    // If neither array nor object, throw parse error
-                                    arrayException.addSuppressed(objException);
-                                    throw arrayException;
                                 }
+                                Map<String, Object> retError = new HashMap<>();
+                                retError.put("message", "Unexpected channels response format");
+                                retError.put("error", "parse_error");
+                                callback.callback(retError);
+                                return;
+                            } catch (JSONException objException) {
+                                // If neither array nor object, throw parse error
+                                arrayException.addSuppressed(objException);
+                                Map<String, Object> retError = new HashMap<>();
+                                retError.put("message", "JSON parse error: " + arrayException.getMessage());
+                                retError.put("error", "parse_error");
+                                callback.callback(retError);
                             }
-                        } catch (JSONException e) {
-                            Map<String, Object> retError = new HashMap<>();
-                            retError.put("message", "JSON parse error: " + e.getMessage());
-                            retError.put("error", "parse_error");
-                            callback.callback(retError);
                         }
                     }
                 }
             }
         );
+    }
+
+    static Map<String, Object> parseListChannelsResponse(final String data) throws JSONException {
+        JSONArray channelsJson = new JSONArray(data);
+        List<Map<String, Object>> channelsList = new ArrayList<>();
+
+        for (int i = 0; i < channelsJson.length(); i++) {
+            JSONObject channelJson = channelsJson.getJSONObject(i);
+            Object channelId = channelJson.get("id");
+            if (!(channelId instanceof Number)) {
+                throw new JSONException("Channel id must be a number");
+            }
+            Map<String, Object> channel = new HashMap<>();
+            channel.put("id", channelId);
+            channel.put("name", channelJson.optString("name", ""));
+            channel.put("public", channelJson.optBoolean("public", false));
+            channel.put("allow_self_set", channelJson.optBoolean("allow_self_set", false));
+            channelsList.add(channel);
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+        ret.put("channels", channelsList);
+        return ret;
     }
 
     public void sendStats(final String action) {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +34,7 @@ import java.util.function.BooleanSupplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -969,6 +971,28 @@ public class CapacitorUpdaterUnitTest {
             currentType = currentType.getComponentType();
         }
         return applicationExitInfoClassName.equals(currentType.getName());
+    }
+
+    @Test
+    public void listChannelsResponseKeepsNumericChannelIds() throws Exception {
+        final Map<String, Object> result = CapgoUpdater.parseListChannelsResponse(
+            "[{\"id\":123,\"name\":\"Production\",\"public\":true,\"allow_self_set\":true}]"
+        );
+
+        final Object channelsValue = result.get("channels");
+        assertTrue(channelsValue instanceof List<?>);
+        final Object channelValue = ((List<?>) channelsValue).get(0);
+        assertTrue(channelValue instanceof Map<?, ?>);
+        final Object id = ((Map<?, ?>) channelValue).get("id");
+        assertTrue(id instanceof Number);
+        assertEquals(123, ((Number) id).intValue());
+    }
+
+    @Test
+    public void listChannelsResponseRejectsStringChannelIds() {
+        assertThrows(JSONException.class, () ->
+            CapgoUpdater.parseListChannelsResponse("[{\"id\":\"123\",\"name\":\"Production\",\"public\":true,\"allow_self_set\":true}]")
+        );
     }
 
     @Test

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -2431,7 +2431,7 @@ import UIKit
         if let channels = responseValue.channels {
             listChannels.channels = channels.map { channel in
                 var channelDict: [String: Any] = [:]
-                channelDict["id"] = channel.id ?? ""
+                channelDict["id"] = channel.id
                 channelDict["name"] = channel.name ?? ""
                 channelDict["public"] = channel.public ?? false
                 channelDict["allow_self_set"] = channel.allow_self_set ?? false

--- a/ios/Sources/CapacitorUpdaterPlugin/InternalUtils.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/InternalUtils.swift
@@ -70,7 +70,7 @@ extension GetChannel {
 }
 // swiftlint:disable identifier_name
 struct ChannelInfo: Codable {
-    let id: String?
+    let id: Int
     let name: String?
     let `public`: Bool?
     let allow_self_set: Bool?

--- a/ios/Tests/CapacitorUpdaterPluginTests/ListChannelsTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/ListChannelsTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+@testable import CapacitorUpdaterPlugin
+
+private final class ListChannelsRequestCapgoUpdater: CapgoUpdater {
+    private let requestResult: CapgoUpdater.RequestResult
+
+    init(requestResult: CapgoUpdater.RequestResult) {
+        self.requestResult = requestResult
+        super.init()
+    }
+
+    override func performRequest(_ request: URLRequest, label: String) -> CapgoUpdater.RequestResult {
+        requestResult
+    }
+}
+
+final class ListChannelsTests: XCTestCase {
+    func testListChannelsDecodesNumericChannelIdsAsNumbers() throws {
+        let channelURL = try XCTUnwrap(URL(string: "https://example.com/channel"))
+        let response = try XCTUnwrap(HTTPURLResponse(url: channelURL, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let responseData = Data("""
+        [
+          {"id":123,"name":"Production","public":true,"allow_self_set":true},
+          {"id":456,"name":"Beta","public":false,"allow_self_set":true}
+        ]
+        """.utf8)
+        let requestResult = CapgoUpdater.RequestResult(data: responseData, response: response, error: nil, timedOut: false)
+        let updater = ListChannelsRequestCapgoUpdater(requestResult: requestResult)
+        updater.setLogger(Logger(withTag: "TestLogger"))
+        updater.channelUrl = "https://example.com/channel"
+
+        let result = updater.listChannels()
+
+        XCTAssertEqual(result.error, "")
+        XCTAssertEqual(result.channels.count, 2)
+        XCTAssertEqual(result.channels[0]["id"] as? Int, 123)
+        XCTAssertEqual(result.channels[0]["name"] as? String, "Production")
+        XCTAssertEqual(result.channels[0]["public"] as? Bool, true)
+        XCTAssertEqual(result.channels[0]["allow_self_set"] as? Bool, true)
+        XCTAssertEqual(result.channels[1]["id"] as? Int, 456)
+    }
+
+    func testListChannelsRejectsStringChannelIds() throws {
+        let channelURL = try XCTUnwrap(URL(string: "https://example.com/channel"))
+        let response = try XCTUnwrap(HTTPURLResponse(url: channelURL, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let responseData = Data("""
+        [
+          {"id":"123","name":"Production","public":true,"allow_self_set":true}
+        ]
+        """.utf8)
+        let requestResult = CapgoUpdater.RequestResult(data: responseData, response: response, error: nil, timedOut: false)
+        let updater = ListChannelsRequestCapgoUpdater(requestResult: requestResult)
+        updater.setLogger(Logger(withTag: "TestLogger"))
+        updater.channelUrl = "https://example.com/channel"
+
+        let result = updater.listChannels()
+
+        XCTAssertEqual(result.error, "decode_error")
+        XCTAssertEqual(result.channels.count, 0)
+    }
+}

--- a/scripts/maestro/fake-capgo-server.mjs
+++ b/scripts/maestro/fake-capgo-server.mjs
@@ -22,19 +22,19 @@ const baseHeaders = {
 
 const channelCatalog = [
   {
-    id: 'beta',
+    id: 1,
     name: 'beta',
     public: false,
     allow_self_set: true,
   },
   {
-    id: 'public-preview',
+    id: 2,
     name: 'public-preview',
     public: true,
     allow_self_set: true,
   },
   {
-    id: 'private-alpha',
+    id: 3,
     name: 'private-alpha',
     public: false,
     allow_self_set: false,

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1717,7 +1717,7 @@ export interface ChannelInfo {
    *
    * @since 7.5.0
    */
-  id: string;
+  id: number;
   /**
    * The channel name
    *


### PR DESCRIPTION
## What
- Treat `listChannels()` channel `id` as a numeric field across TypeScript, iOS, and Android.
- Return native channel IDs to JavaScript as numbers instead of stringifying them.
- Add iOS and Android regression tests for numeric IDs and string-ID rejection.
- Update the Maestro fake Capgo server channel fixture to return numeric ids.

## Why
- The backend returns numeric channel IDs. iOS modeled them as `String?`, so `JSONDecoder` failed before channels could be returned.
- Android and the CI fake server also needed to preserve the same numeric contract.
- Fixes #706.

## How
- Changed `ChannelInfo.id` to `number` in TypeScript and required `Int` on iOS.
- Added a strict Android list-channel parser that keeps JSON numbers and rejects non-numeric IDs.
- Kept the existing server error-object fallback for non-array responses.
- Changed fake Maestro channel fixtures from string ids to numeric ids.

## Testing
- `bun run fmt`
- `bun run test:ios -- -only-testing:CapacitorUpdaterPluginTests/ListChannelsTests`
- `cd android && ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.listChannelsResponseKeepsNumericChannelIds --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.listChannelsResponseRejectsStringChannelIds`
- `CAPGO_MAESTRO_PORT=4192 ... curl http://127.0.0.1:4192/api/channel?scenario=manual-zip` confirmed numeric ids in the fake server response
- `bun run verify`

## Not Tested
- Did not call the live Capgo channel API; regression tests and the Maestro fake server use representative native response fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Channel IDs are now `number` type instead of `string` in the `ChannelInfo` interface across all platforms.

* **Tests**
  * Added test coverage validating numeric channel ID parsing and ensuring string-formatted IDs are properly rejected.

* **Documentation**
  * Updated API documentation to reflect the channel ID type change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->