### PR TITLE
fix: address list channel test sonar comments

### DIFF
--- a/ios/Tests/CapacitorUpdaterPluginTests/ListChannelsTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/ListChannelsTests.swift
@@ -10,14 +10,18 @@ private final class ListChannelsRequestCapgoUpdater: CapgoUpdater {
         super.init()
     }
 
-    override func performRequest(_ request: URLRequest, label: String) -> CapgoUpdater.RequestResult {
+    override func performRequest(_: URLRequest, label _: String) -> CapgoUpdater.RequestResult {
         requestResult
     }
 }
 
 final class ListChannelsTests: XCTestCase {
+    private let channelScheme = "https"
+    private let channelHost = "example.com"
+    private let channelPathComponent = "channel"
+
     func testListChannelsDecodesNumericChannelIdsAsNumbers() throws {
-        let channelURL = try XCTUnwrap(URL(string: "https://example.com/channel"))
+        let channelURL = try makeChannelURL()
         let response = try XCTUnwrap(HTTPURLResponse(url: channelURL, statusCode: 200, httpVersion: nil, headerFields: nil))
         let responseData = Data("""
         [
@@ -28,7 +32,7 @@ final class ListChannelsTests: XCTestCase {
         let requestResult = CapgoUpdater.RequestResult(data: responseData, response: response, error: nil, timedOut: false)
         let updater = ListChannelsRequestCapgoUpdater(requestResult: requestResult)
         updater.setLogger(Logger(withTag: "TestLogger"))
-        updater.channelUrl = "https://example.com/channel"
+        updater.channelUrl = channelURL.absoluteString
 
         let result = updater.listChannels()
 
@@ -42,7 +46,7 @@ final class ListChannelsTests: XCTestCase {
     }
 
     func testListChannelsRejectsStringChannelIds() throws {
-        let channelURL = try XCTUnwrap(URL(string: "https://example.com/channel"))
+        let channelURL = try makeChannelURL()
         let response = try XCTUnwrap(HTTPURLResponse(url: channelURL, statusCode: 200, httpVersion: nil, headerFields: nil))
         let responseData = Data("""
         [
@@ -52,11 +56,19 @@ final class ListChannelsTests: XCTestCase {
         let requestResult = CapgoUpdater.RequestResult(data: responseData, response: response, error: nil, timedOut: false)
         let updater = ListChannelsRequestCapgoUpdater(requestResult: requestResult)
         updater.setLogger(Logger(withTag: "TestLogger"))
-        updater.channelUrl = "https://example.com/channel"
+        updater.channelUrl = channelURL.absoluteString
 
         let result = updater.listChannels()
 
         XCTAssertEqual(result.error, "decode_error")
         XCTAssertEqual(result.channels.count, 0)
+    }
+
+    private func makeChannelURL() throws -> URL {
+        var components = URLComponents()
+        components.scheme = channelScheme
+        components.host = channelHost
+        components.path = "/" + channelPathComponent
+        return try XCTUnwrap(components.url)
     }
 }


### PR DESCRIPTION
## What
- Clean up the `ListChannelsTests` helpers added for numeric channel id coverage.
- Remove unused override parameter names and avoid hardcoded full URI literals in the tests.

## Why
- Follow-up to #801 after reviewing comments: SonarQube reported these issues on the merged PR.

## How
- Mark unused override parameters with `_`.
- Build the test channel URL from `URLComponents` and reuse the resulting absolute string.

## Testing
- `bun run fmt`
- `bun run verify`

## Not Tested
- Local `bun run test:ios -- -only-testing:CapacitorUpdaterPluginTests/ListChannelsTests` could not complete because the local simulator boot/test runner hung and then timed out before executing tests. CI will run the iOS test jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test maintainability by refactoring URL construction logic to reduce code duplication and enhance test clarity.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->