### PR TITLE
[codex] sync channel default from lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,6 +1188,9 @@ Use this to:
 - Check if a device is on a specific channel before showing features
 - Verify channel assignment after calling {@link setChannel}
 
+On native platforms, a successful response also refreshes the locally persisted
+default channel used by update checks.
+
 **Returns:** <code>Promise&lt;<a href="#getchannelres">GetChannelRes</a>&gt;</code>
 
 **Since:** 4.8.0

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1995,6 +1995,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                     CapacitorUpdaterPlugin.this.editor,
                     DEFAULT_CHANNEL_PREF_KEY,
                     CapacitorUpdaterPlugin.this.allowSetDefaultChannel,
+                    CapacitorUpdaterPlugin.this.getConfig().getString("defaultChannel", ""),
                     (res) -> {
                         JSObject jsRes = InternalUtils.mapToJSObject(res);
                         if (jsRes.has("error")) {
@@ -2043,21 +2044,25 @@ public class CapacitorUpdaterPlugin extends Plugin {
         try {
             logger.info("getChannel");
             startNewThread(() ->
-                CapacitorUpdaterPlugin.this.implementation.getChannel((res) -> {
-                    JSObject jsRes = InternalUtils.mapToJSObject(res);
-                    if (jsRes.has("error")) {
-                        String errorMessage = jsRes.has("message") ? jsRes.getString("message") : jsRes.getString("error");
-                        String errorCode = jsRes.getString("error");
+                CapacitorUpdaterPlugin.this.implementation.getChannel(
+                    (res) -> {
+                        JSObject jsRes = InternalUtils.mapToJSObject(res);
+                        if (jsRes.has("error")) {
+                            String errorMessage = jsRes.has("message") ? jsRes.getString("message") : jsRes.getString("error");
+                            String errorCode = jsRes.getString("error");
 
-                        JSObject errorObj = new JSObject();
-                        errorObj.put("message", errorMessage);
-                        errorObj.put("error", errorCode);
+                            JSObject errorObj = new JSObject();
+                            errorObj.put("message", errorMessage);
+                            errorObj.put("error", errorCode);
 
-                        call.reject(errorMessage, "GETCHANNEL_FAILED", null, errorObj);
-                    } else {
-                        call.resolve(jsRes);
-                    }
-                })
+                            call.reject(errorMessage, "GETCHANNEL_FAILED", null, errorObj);
+                        } else {
+                            call.resolve(jsRes);
+                        }
+                    },
+                    CapacitorUpdaterPlugin.this.editor,
+                    DEFAULT_CHANNEL_PREF_KEY
+                )
             );
         } catch (final Exception e) {
             logger.error("Failed to getChannel " + e.getMessage());

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1615,6 +1615,17 @@ public class CapgoUpdater {
         final boolean allowSetDefaultChannel,
         final Callback callback
     ) {
+        this.setChannel(channel, editor, defaultChannelKey, allowSetDefaultChannel, "", callback);
+    }
+
+    public void setChannel(
+        final String channel,
+        final SharedPreferences.Editor editor,
+        final String defaultChannelKey,
+        final boolean allowSetDefaultChannel,
+        final String configDefaultChannel,
+        final Callback callback
+    ) {
         // Check if setting defaultChannel is allowed
         if (!allowSetDefaultChannel) {
             logger.error("setChannel is disabled by allowSetDefaultChannel config");
@@ -1666,6 +1677,7 @@ public class CapgoUpdater {
                 // Clear persisted defaultChannel and revert to config value
                 editor.remove(defaultChannelKey);
                 editor.apply();
+                this.defaultChannel = configDefaultChannel;
                 logger.info("Public channel requested, channel override removed");
                 callback.callback(res);
             } else {
@@ -1680,6 +1692,10 @@ public class CapgoUpdater {
     }
 
     public void getChannel(final Callback callback) {
+        this.getChannel(callback, null, null);
+    }
+
+    public void getChannel(final Callback callback, final SharedPreferences.Editor editor, final String defaultChannelKey) {
         // Check if rate limit was exceeded
         if (rateLimitExceeded) {
             logger.debug("Skipping getChannel due to rate limit (429). Requests will resume after app restart.");
@@ -1798,6 +1814,7 @@ public class CapgoUpdater {
                                 ret.put(key, jsonResponse.get(key));
                             }
                         }
+                        persistDefaultChannelFromResponse(ret.get("channel"), editor, defaultChannelKey);
                         logger.info("Channel get to \"" + ret);
                         callback.callback(ret);
                     } catch (JSONException e) {
@@ -1809,6 +1826,24 @@ public class CapgoUpdater {
                 }
             }
         );
+    }
+
+    void persistDefaultChannelFromResponse(final Object channel, final SharedPreferences.Editor editor, final String defaultChannelKey) {
+        if (!(channel instanceof String)) {
+            return;
+        }
+
+        final String channelName = ((String) channel).trim();
+        if (channelName.isEmpty() || BundleInfo.ID_BUILTIN.equals(channelName)) {
+            return;
+        }
+
+        this.defaultChannel = channelName;
+        if (editor != null && defaultChannelKey != null && !defaultChannelKey.isEmpty()) {
+            editor.putString(defaultChannelKey, channelName);
+            editor.apply();
+        }
+        logger.info("defaultChannel synchronized from getChannel(): " + channelName);
     }
 
     public void listChannels(final Callback callback) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
@@ -542,6 +542,7 @@ public class ShakeMenu implements ShakeDetector.Listener {
                 new Thread(() -> {
                     final CapgoUpdater updater = plugin.implementation;
                     final Bridge bridge = activity.getBridge();
+                    final String configDefaultChannel = plugin.getConfig().getString("defaultChannel", "");
 
                     // Set the channel - respect plugin's allowSetDefaultChannel config
                     updater.setChannel(
@@ -549,6 +550,7 @@ public class ShakeMenu implements ShakeDetector.Listener {
                         updater.editor,
                         "CapacitorUpdater.defaultChannel",
                         plugin.allowSetDefaultChannel,
+                        configDefaultChannel,
                         (setRes) -> {
                             if (setRes == null) {
                                 activity.runOnUiThread(() -> {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -2586,6 +2586,32 @@ public class CapacitorUpdaterUnitTest {
         assertEquals("CapacitorUpdater/unknown (unknown) android/unknown", ua);
     }
 
+    @Test
+    public void persistDefaultChannelFromResponseStoresServerChannel() {
+        final CapgoUpdater updater = new CapgoUpdater(mock(Logger.class));
+        final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+        when(editor.putString("CapacitorUpdater.defaultChannel", "company-a")).thenReturn(editor);
+
+        updater.persistDefaultChannelFromResponse(" company-a ", editor, "CapacitorUpdater.defaultChannel");
+
+        assertEquals("company-a", updater.defaultChannel);
+        verify(editor).putString("CapacitorUpdater.defaultChannel", "company-a");
+        verify(editor).apply();
+    }
+
+    @Test
+    public void persistDefaultChannelFromResponseIgnoresBuiltinVersionName() {
+        final CapgoUpdater updater = new CapgoUpdater(mock(Logger.class));
+        final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+        updater.defaultChannel = "stable";
+
+        updater.persistDefaultChannelFromResponse("builtin", editor, "CapacitorUpdater.defaultChannel");
+
+        assertEquals("stable", updater.defaultChannel);
+        verify(editor, never()).putString(anyString(), anyString());
+        verify(editor, never()).apply();
+    }
+
     /**
      * Regression test for: NoSuchMethodError crash on Android 8.0/8.1 (API 26/27).
      * getLongVersionCode() was introduced in API 28; the plugin must use

--- a/api.md
+++ b/api.md
@@ -1009,6 +1009,9 @@ Use this to:
 - Check if a device is on a specific channel before showing features
 - Verify channel assignment after calling {@link setChannel}
 
+On native platforms, a successful response also refreshes the locally persisted
+default channel used by update checks.
+
 **Returns**
 
 `Promise<GetChannelRes>` — The current channel information.

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1885,7 +1885,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let triggerAutoUpdate = call.getBool("triggerAutoUpdate") ?? false
         self.saveCallForAsyncHandling(call)
         DispatchQueue.global(qos: .utility).async {
-            let res = self.implementation.setChannel(channel: channel, defaultChannelKey: self.defaultChannelDefaultsKey, allowSetDefaultChannel: self.allowSetDefaultChannel)
+            let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
+            let res = self.implementation.setChannel(
+                channel: channel,
+                defaultChannelKey: self.defaultChannelDefaultsKey,
+                allowSetDefaultChannel: self.allowSetDefaultChannel,
+                configDefaultChannel: configDefaultChannel
+            )
             if res.error != "" {
                 // Fire channelPrivate event if channel doesn't allow self-assignment
                 if res.error.contains("cannot_update_via_private_channel") || res.error.contains("channel_self_set_not_allowed") {
@@ -1916,7 +1922,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func getChannel(_ call: CAPPluginCall) {
         self.saveCallForAsyncHandling(call)
         DispatchQueue.global(qos: .utility).async {
-            let res = self.implementation.getChannel()
+            let res = self.implementation.getChannel(defaultChannelKey: self.defaultChannelDefaultsKey)
             if res.error != "" {
                 self.rejectCall(call, message: res.error, code: "GETCHANNEL_FAILED", data: [
                     "message": res.error,

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -2151,7 +2151,12 @@ import UIKit
         return setChannel
     }
 
-    func setChannel(channel: String, defaultChannelKey: String, allowSetDefaultChannel: Bool) -> SetChannel {
+    func setChannel(
+        channel: String,
+        defaultChannelKey: String,
+        allowSetDefaultChannel: Bool,
+        configDefaultChannel: String = ""
+    ) -> SetChannel {
         let setChannel: SetChannel = SetChannel()
 
         // Check if setting defaultChannel is allowed
@@ -2231,6 +2236,7 @@ import UIKit
         } else if responseValue.unset == true {
             UserDefaults.standard.removeObject(forKey: defaultChannelKey)
             UserDefaults.standard.synchronize()
+            self.defaultChannel = configDefaultChannel
             self.logger.info("Public channel requested, channel override removed")
 
             setChannel.status = responseValue.status ?? "ok"
@@ -2247,7 +2253,7 @@ import UIKit
         return setChannel
     }
 
-    func getChannel() -> GetChannel {
+    func getChannel(defaultChannelKey: String? = nil) -> GetChannel {
         let getChannel: GetChannel = GetChannel()
 
         // Check if rate limit was exceeded
@@ -2334,8 +2340,24 @@ import UIKit
             getChannel.message = responseValue.message ?? ""
             getChannel.channel = responseValue.channel ?? ""
             getChannel.allowSet = responseValue.allowSet ?? true
+            persistDefaultChannelFromResponse(channel: responseValue.channel, defaultChannelKey: defaultChannelKey)
         }
         return getChannel
+    }
+
+    func persistDefaultChannelFromResponse(channel: String?, defaultChannelKey: String?) {
+        guard let channelName = channel?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !channelName.isEmpty,
+              channelName != BundleInfo.ID_BUILTIN else {
+            return
+        }
+
+        self.defaultChannel = channelName
+        if let defaultChannelKey, !defaultChannelKey.isEmpty {
+            UserDefaults.standard.set(channelName, forKey: defaultChannelKey)
+            UserDefaults.standard.synchronize()
+        }
+        logger.info("defaultChannel synchronized from getChannel(): \(channelName)")
     }
 
     func listChannels() -> ListChannels {

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -338,7 +338,8 @@ extension UIWindow {
                         let setResult = updater.setChannel(
                             channel: name,
                             defaultChannelKey: "CapacitorUpdater.defaultChannel",
-                            allowSetDefaultChannel: plugin.allowSetDefaultChannel
+                            allowSetDefaultChannel: plugin.allowSetDefaultChannel,
+                            configDefaultChannel: plugin.getConfig().getString("defaultChannel", "") ?? ""
                         )
 
                         if !setResult.error.isEmpty {

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -753,6 +753,46 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertNil(UserDefaults.standard.string(forKey: defaultsKey))
     }
 
+    func testGetChannelPersistsServerChannelAsDefaultChannel() throws {
+        let updater = ChannelRequestCapgoUpdater()
+        updater.setLogger(Logger(withTag: "TestLogger"))
+        updater.channelUrl = "https://example.com/channel"
+
+        let channelURL = try XCTUnwrap(URL(string: "https://example.com/channel"))
+        let response = try XCTUnwrap(HTTPURLResponse(url: channelURL, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let responseData = try XCTUnwrap("""
+        {"channel":"company-a","status":"ok","allowSet":true}
+        """.data(using: .utf8))
+        updater.requestResult = CapgoUpdater.RequestResult(data: responseData, response: response, error: nil, timedOut: false)
+
+        let defaultsKey = "CapacitorUpdaterTests.defaultChannel.\(UUID().uuidString)"
+        defer {
+            UserDefaults.standard.removeObject(forKey: defaultsKey)
+        }
+
+        let result = updater.getChannel(defaultChannelKey: defaultsKey)
+
+        XCTAssertEqual(result.channel, "company-a")
+        XCTAssertEqual(updater.defaultChannel, "company-a")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: defaultsKey), "company-a")
+    }
+
+    func testGetChannelDoesNotPersistBuiltinVersionNameAsDefaultChannel() {
+        let updater = ChannelRequestCapgoUpdater()
+        updater.setLogger(Logger(withTag: "TestLogger"))
+        updater.defaultChannel = "stable"
+
+        let defaultsKey = "CapacitorUpdaterTests.defaultChannel.\(UUID().uuidString)"
+        defer {
+            UserDefaults.standard.removeObject(forKey: defaultsKey)
+        }
+
+        updater.persistDefaultChannelFromResponse(channel: "builtin", defaultChannelKey: defaultsKey)
+
+        XCTAssertEqual(updater.defaultChannel, "stable")
+        XCTAssertNil(UserDefaults.standard.string(forKey: defaultsKey))
+    }
+
     // MARK: - DelayCondition Tests
 
     func testDelayConditionInitialization() {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -974,6 +974,9 @@ export interface CapacitorUpdaterPlugin {
    * - Check if a device is on a specific channel before showing features
    * - Verify channel assignment after calling {@link setChannel}
    *
+   * On native platforms, a successful response also refreshes the locally persisted
+   * default channel used by update checks.
+   *
    * @returns {Promise<GetChannelRes>} The current channel information.
    * @throws {Error} If the operation fails.
    * @since 4.8.0


### PR DESCRIPTION
## What
- Sync the native `defaultChannel` from successful `getChannel()` responses on iOS and Android.
- Ignore `builtin` values when syncing channel state so bundle version names are not persisted as channel names.
- Restore the in-memory default channel to the configured default when a public-channel response unsets the local override.
- Add native regression tests and regenerate API docs.

## Why
- After login/custom ID changes, an app can observe a server-side channel assignment while the native plugin still has no local `defaultChannel`. Since channel selection is now local-first, later update checks can fall back to builtin even though the device is assigned to a company channel.

## How
- Android now has a `getChannel()` overload that receives the preferences editor/key and persists a valid returned channel.
- iOS `getChannel(defaultChannelKey:)` mirrors the same behavior through `UserDefaults`.
- Both platforms skip empty and `builtin` channel values to avoid confusing bundle version names with channel names.

## Testing
- `bun install`
- `bun run fmt`
- `bun run verify`
- `bun run check:wiring`
- `cd android && ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.persistDefaultChannelFromResponseStoresServerChannel --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest.persistDefaultChannelFromResponseIgnoresBuiltinVersionName`

## Not Tested
- Local iOS simulator test execution: attempted targeted tests and `bun run native:test:ios`, but CoreSimulator repeatedly interrupted the xcodebuild test runner after successful compilation. CI should run the macOS simulator job in a clean environment.

Generated with Codex.