### PR TITLE
fix: make preview fallback escape resilient

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -2523,16 +2523,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private boolean leavePreviewSessionForIncomingPreviewLink() {
         this.showPreviewTransitionLoader("incoming-preview-deeplink");
         final BundleInfo previewBundle = this.implementation.getCurrentBundle();
-        final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
+        final BundleInfo previewFallbackBundle = this.resolvePreviewFallbackBundle("incoming preview deeplink");
         boolean didReload = false;
 
         try {
-            if (previewFallbackBundle == null || previewFallbackBundle.isErrorStatus()) {
-                logger.error("No preview fallback bundle available");
-                return false;
-            }
-            if (!this.implementation.canSet(previewFallbackBundle)) {
-                logger.error("Preview fallback bundle is not installable");
+            if (previewFallbackBundle == null) {
                 return false;
             }
 
@@ -2542,7 +2537,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 return false;
             }
 
-            if (!this._reload()) {
+            if (!this.reloadWithoutWaitingForAppReady()) {
                 this.implementation.restoreResetState(previousState);
                 this.restoreLiveBundleStateAfterFailedReload();
                 return false;
@@ -2590,13 +2585,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private boolean leavePreviewSessionWithoutReload(final boolean keepPreviewGuard) {
         final BundleInfo previewBundle = this.implementation.getCurrentBundle();
-        final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
-        if (previewFallbackBundle == null || previewFallbackBundle.isErrorStatus()) {
-            logger.error("No preview fallback bundle available");
-            return false;
-        }
-        if (!this.implementation.canSet(previewFallbackBundle)) {
-            logger.error("Preview fallback bundle is not installable");
+        final BundleInfo previewFallbackBundle = this.resolvePreviewFallbackBundle("preview deeplink launch");
+        if (previewFallbackBundle == null) {
             return false;
         }
         if (!this.implementation.stagePreviewFallbackReload(previewFallbackBundle)) {
@@ -2649,20 +2639,15 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private boolean resetToPreviewFallbackBundle() {
-        final BundleInfo fallback = this.implementation.getPreviewFallbackBundle();
-        if (fallback == null || fallback.isErrorStatus()) {
-            logger.error("No preview fallback bundle available");
-            return false;
-        }
-        if (!this.implementation.canSet(fallback)) {
-            logger.error("Preview fallback bundle is not installable");
+        final BundleInfo fallback = this.resolvePreviewFallbackBundle("leave preview");
+        if (fallback == null) {
             return false;
         }
 
         final CapgoUpdater.ResetState previousState = this.implementation.captureResetState();
         final String previousBundleName = this.implementation.getCurrentBundle().getVersionName();
         logger.info("Resetting to preview fallback bundle: " + fallback.getVersionName());
-        if (this.implementation.stagePreviewFallbackReload(fallback) && this._reload()) {
+        if (this.implementation.stagePreviewFallbackReload(fallback) && this.reloadWithoutWaitingForAppReady()) {
             this.implementation.finalizeResetTransition(previousBundleName, false);
             this.notifyBundleSet(fallback);
             return true;
@@ -2670,6 +2655,29 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.implementation.restoreResetState(previousState);
         this.restoreLiveBundleStateAfterFailedReload();
         return false;
+    }
+
+    private BundleInfo resolvePreviewFallbackBundle(final String reason) {
+        final BundleInfo fallback = this.implementation.getPreviewFallbackBundle();
+        if (fallback != null && !fallback.isErrorStatus() && this.implementation.canSet(fallback)) {
+            return fallback;
+        }
+
+        if (fallback == null) {
+            logger.warn("No preview fallback bundle available for " + reason + ". Falling back to builtin bundle.");
+        } else if (fallback.isErrorStatus()) {
+            logger.warn("Preview fallback bundle is in error state for " + reason + ". Falling back to builtin bundle.");
+        } else {
+            logger.warn("Preview fallback bundle is not installable for " + reason + ". Falling back to builtin bundle.");
+        }
+
+        final BundleInfo builtin = this.implementation.getBundleInfo(BundleInfo.ID_BUILTIN);
+        if (builtin != null && !builtin.isErrorStatus() && this.implementation.canSet(builtin)) {
+            return builtin;
+        }
+
+        logger.error("Builtin bundle is not available to leave preview for " + reason);
+        return null;
     }
 
     private void endPreviewSession() {
@@ -2706,11 +2714,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     private void clearPreviewSessionBecauseDisabled() {
         logger.info("Preview session disabled by config; restoring preview fallback");
-        final BundleInfo fallback = this.implementation.getPreviewFallbackBundle();
-        final BundleInfo bundleToRestore =
-            fallback == null || fallback.isErrorStatus() ? this.implementation.getBundleInfo(BundleInfo.ID_BUILTIN) : fallback;
-
-        if (this.implementation.canSet(bundleToRestore)) {
+        final BundleInfo bundleToRestore = this.resolvePreviewFallbackBundle("preview disabled");
+        if (bundleToRestore != null) {
             this.implementation.stagePreviewFallbackReload(bundleToRestore);
         } else {
             logger.warn("Could not restore preview fallback while disabling preview");

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -502,6 +502,8 @@ public class CapacitorUpdaterUnitTest {
             "builtin"
         );
         private BundleInfo nextBundle;
+        private BundleInfo previewFallbackBundle;
+        private BundleInfo stagedPreviewFallbackBundle;
         private boolean resetCalled = false;
         private boolean prepareResetStateForTransitionCalled = false;
         private int prepareResetStateForTransitionCalls = 0;
@@ -515,6 +517,8 @@ public class CapacitorUpdaterUnitTest {
         private int setCalls = 0;
         private boolean stagePendingReloadResult = true;
         private int stagePendingReloadCalls = 0;
+        private boolean stagePreviewFallbackReloadResult = true;
+        private int stagePreviewFallbackReloadCalls = 0;
         private int finalizePendingReloadCalls = 0;
         private BundleInfo finalizedPendingReloadBundle;
         private String finalizePendingReloadPreviousBundleName;
@@ -539,6 +543,28 @@ public class CapacitorUpdaterUnitTest {
         @Override
         public BundleInfo getNextBundle() {
             return this.nextBundle;
+        }
+
+        @Override
+        public BundleInfo getPreviewFallbackBundle() {
+            return this.previewFallbackBundle;
+        }
+
+        @Override
+        public BundleInfo getBundleInfo(final String id) {
+            if (BundleInfo.ID_BUILTIN.equals(id)) {
+                return new BundleInfo(BundleInfo.ID_BUILTIN, "builtin", BundleStatus.SUCCESS, BundleInfo.DOWNLOADED_BUILTIN, "builtin");
+            }
+            if (this.currentBundle != null && this.currentBundle.getId().equals(id)) {
+                return this.currentBundle;
+            }
+            if (this.fallbackBundle != null && this.fallbackBundle.getId().equals(id)) {
+                return this.fallbackBundle;
+            }
+            if (this.previewFallbackBundle != null && this.previewFallbackBundle.getId().equals(id)) {
+                return this.previewFallbackBundle;
+            }
+            return new BundleInfo(id, id, BundleStatus.PENDING, new Date(), "");
         }
 
         @Override
@@ -573,6 +599,18 @@ public class CapacitorUpdaterUnitTest {
         boolean stagePendingReload(final BundleInfo bundle) {
             this.stagePendingReloadCalls++;
             return this.stagePendingReloadResult;
+        }
+
+        @Override
+        boolean stagePreviewFallbackReload(final BundleInfo bundle) {
+            this.stagePreviewFallbackReloadCalls++;
+            this.stagedPreviewFallbackBundle = bundle;
+            return this.stagePreviewFallbackReloadResult;
+        }
+
+        @Override
+        public Boolean delete(final String id, final Boolean removeInfo) {
+            return true;
         }
 
         @Override
@@ -619,6 +657,11 @@ public class CapacitorUpdaterUnitTest {
         protected boolean _reload() {
             return true;
         }
+
+        @Override
+        protected boolean reloadWithoutWaitingForAppReady() {
+            return true;
+        }
     }
 
     private static final class ReloadFailureCapacitorUpdaterPlugin extends TestableCapacitorUpdaterPlugin {
@@ -642,6 +685,11 @@ public class CapacitorUpdaterUnitTest {
         }
 
         @Override
+        protected boolean reloadWithoutWaitingForAppReady() {
+            return false;
+        }
+
+        @Override
         protected void restoreLiveBundleStateAfterFailedReload() {
             this.restoreLiveBundleStateAfterFailedReloadCalls++;
         }
@@ -659,6 +707,13 @@ public class CapacitorUpdaterUnitTest {
 
         @Override
         protected boolean _reload() {
+            final int resultIndex = Math.min(this.reloadCallCount, this.reloadResults.length - 1);
+            this.reloadCallCount++;
+            return this.reloadResults[resultIndex];
+        }
+
+        @Override
+        protected boolean reloadWithoutWaitingForAppReady() {
             final int resultIndex = Math.min(this.reloadCallCount, this.reloadResults.length - 1);
             this.reloadCallCount++;
             return this.reloadResults[resultIndex];
@@ -883,6 +938,12 @@ public class CapacitorUpdaterUnitTest {
         final Method method = CapacitorUpdaterPlugin.class.getDeclaredMethod("performReset", Boolean.class, Boolean.class, boolean.class);
         method.setAccessible(true);
         return (boolean) method.invoke(plugin, toLastSuccessful, usePendingBundle, internal);
+    }
+
+    private static boolean invokePrivatePreviewFallbackResetMethod(final CapacitorUpdaterPlugin plugin) throws Exception {
+        final Method method = CapacitorUpdaterPlugin.class.getDeclaredMethod("resetToPreviewFallbackBundle");
+        method.setAccessible(true);
+        return (boolean) method.invoke(plugin);
     }
 
     private static void invokePrivateSplashMethod(
@@ -1647,6 +1708,34 @@ public class CapacitorUpdaterUnitTest {
             assertEquals(1, updater.restoreResetStateCalls);
             assertSame(updater.capturedState, updater.restoredState);
             assertEquals(1, plugin.restoreLiveBundleStateAfterFailedReloadCalls);
+        }
+    }
+
+    @Test
+    public void testLeavePreviewUsesBuiltinWhenPreviewFallbackIsMissing() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final ReloadBypassCapacitorUpdaterPlugin plugin = new ReloadBypassCapacitorUpdaterPlugin();
+            final ResetTrackingCapgoUpdater updater = new ResetTrackingCapgoUpdater();
+            updater.currentBundle = new BundleInfo("preview-id", "preview", BundleStatus.SUCCESS, new Date(), "preview");
+            updater.previewFallbackBundle = null;
+
+            plugin.implementation = updater;
+            plugin.setLoggerForTesting(mock(Logger.class));
+
+            final boolean result = invokePrivatePreviewFallbackResetMethod(plugin);
+
+            assertTrue(result);
+            assertEquals(1, updater.stagePreviewFallbackReloadCalls);
+            assertEquals(BundleInfo.ID_BUILTIN, updater.stagedPreviewFallbackBundle.getId());
+            assertTrue(updater.finalizeResetTransitionCalled);
+            assertEquals("preview", updater.finalizeResetTransitionPreviousBundleName);
+            assertFalse(updater.finalizeResetTransitionInternal);
+            assertEquals(0, updater.restoreResetStateCalls);
         }
     }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -989,6 +989,29 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    func reloadWithoutWaitingForAppReady() -> Bool {
+        guard let bridge = self.bridge else { return false }
+
+        let performReload: () -> Bool = {
+            guard self.applyCurrentBundleToBridge(bridge) else {
+                return false
+            }
+            self.checkAppReady()
+            self.notifyListeners("appReloaded", data: [:])
+            return true
+        }
+
+        if Thread.isMainThread {
+            return performReload()
+        } else {
+            var result = false
+            DispatchQueue.main.sync {
+                result = performReload()
+            }
+            return result
+        }
+    }
+
     @objc func reload(_ call: CAPPluginCall) {
         let current: BundleInfo = self.implementation.getCurrentBundle()
         let next: BundleInfo? = self.implementation.getNextBundle()
@@ -1232,12 +1255,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func leavePreviewSessionWithoutReload(keepPreviewGuard: Bool = false) -> Bool {
         let previewBundle = self.implementation.getCurrentBundle()
-        guard let previewFallbackBundle = self.implementation.getPreviewFallbackBundle(), !previewFallbackBundle.isErrorStatus() else {
-            logger.error("No preview fallback bundle available")
-            return false
-        }
-        guard self.implementation.canSet(bundle: previewFallbackBundle) else {
-            logger.error("Preview fallback bundle is not installable")
+        guard let previewFallbackBundle = self.resolvePreviewFallbackBundle(reason: "preview deeplink launch") else {
             return false
         }
         guard self.implementation.stagePreviewFallbackReload(bundle: previewFallbackBundle) else {
@@ -1254,14 +1272,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private func leavePreviewSessionForIncomingPreviewLink() -> Bool {
         self.showPreviewTransitionLoader(reason: "incoming-preview-deeplink")
         let previewBundle = self.implementation.getCurrentBundle()
-        guard let previewFallbackBundle = self.implementation.getPreviewFallbackBundle(), !previewFallbackBundle.isErrorStatus() else {
-            logger.error("No preview fallback bundle available")
-            self.clearIncomingPreviewTransition()
-            self.hidePreviewTransitionLoader(reason: "incoming-preview-deeplink-failed")
-            return false
-        }
-        guard self.implementation.canSet(bundle: previewFallbackBundle) else {
-            logger.error("Preview fallback bundle is not installable")
+        guard let previewFallbackBundle = self.resolvePreviewFallbackBundle(reason: "incoming preview deeplink") else {
             self.clearIncomingPreviewTransition()
             self.hidePreviewTransitionLoader(reason: "incoming-preview-deeplink-failed")
             return false
@@ -1275,7 +1286,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             return false
         }
 
-        let didReload = self._reload()
+        let didReload = self.reloadWithoutWaitingForAppReady()
         if didReload {
             self.endPreviewSession(keepPreviewGuard: true)
             let restoredNextBundle = self.implementation.getNextBundle()
@@ -1312,7 +1323,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         if let payloadUrl = self.storedPreviewPayloadUrl() {
             didReload = self.refreshPreviewSessionFromPayloadUrl(payloadUrl)
         } else {
-            didReload = self._reload()
+            didReload = self.reloadWithoutWaitingForAppReady()
         }
 
         if !didReload {
@@ -1325,21 +1336,16 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.previewSessionEnabled
     }
 
-    private func resetToPreviewFallbackBundle() -> Bool {
+    func resetToPreviewFallbackBundle() -> Bool {
         guard self.canPerformResetTransition() else { return false }
-        guard let fallback = self.implementation.getPreviewFallbackBundle(), !fallback.isErrorStatus() else {
-            logger.error("No preview fallback bundle available")
-            return false
-        }
-        guard self.implementation.canSet(bundle: fallback) else {
-            logger.error("Preview fallback bundle is not installable")
+        guard let fallback = self.resolvePreviewFallbackBundle(reason: "leave preview") else {
             return false
         }
 
         let previousState = self.implementation.captureResetState()
         let previousBundleName = self.implementation.getCurrentBundle().getVersionName()
         logger.info("Resetting to preview fallback bundle: \(fallback.toString())")
-        if self.implementation.stagePreviewFallbackReload(bundle: fallback) && self._reload() {
+        if self.implementation.stagePreviewFallbackReload(bundle: fallback) && self.reloadWithoutWaitingForAppReady() {
             self.implementation.finalizeResetTransition(previousBundleName: previousBundleName, isInternal: false)
             self.notifyBundleSet(fallback)
             return true
@@ -1347,6 +1353,31 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.implementation.restoreResetState(previousState)
         self.restoreLiveBundleStateAfterFailedReload()
         return false
+    }
+
+    private func resolvePreviewFallbackBundle(reason: String) -> BundleInfo? {
+        let fallback = self.implementation.getPreviewFallbackBundle()
+        if let fallback, !fallback.isErrorStatus(), self.implementation.canSet(bundle: fallback) {
+            return fallback
+        }
+
+        if let fallback {
+            if fallback.isErrorStatus() {
+                logger.warn("Preview fallback bundle is in error state for \(reason). Falling back to builtin bundle.")
+            } else {
+                logger.warn("Preview fallback bundle is not installable for \(reason). Falling back to builtin bundle.")
+            }
+        } else {
+            logger.warn("No preview fallback bundle available for \(reason). Falling back to builtin bundle.")
+        }
+
+        let builtin = self.implementation.getBundleInfo(id: BundleInfo.ID_BUILTIN)
+        if !builtin.isErrorStatus(), self.implementation.canSet(bundle: builtin) {
+            return builtin
+        }
+
+        logger.error("Builtin bundle is not available to leave preview for \(reason)")
+        return nil
     }
 
     private func endPreviewSession(keepPreviewGuard: Bool = false) {
@@ -1374,15 +1405,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func clearPreviewSessionBecauseDisabled() {
         logger.info("Preview session disabled by config; restoring preview fallback")
-        let fallback = self.implementation.getPreviewFallbackBundle()
-        let bundleToRestore: BundleInfo
-        if let fallback, !fallback.isErrorStatus() {
-            bundleToRestore = fallback
-        } else {
-            bundleToRestore = self.implementation.getBundleInfo(id: BundleInfo.ID_BUILTIN)
-        }
-
-        if self.implementation.canSet(bundle: bundleToRestore) {
+        if let bundleToRestore = self.resolvePreviewFallbackBundle(reason: "preview disabled") {
             _ = self.implementation.stagePreviewFallbackReload(bundle: bundleToRestore)
         } else {
             logger.warn("Could not restore preview fallback while disabling preview")
@@ -1579,7 +1602,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             let current = self.implementation.getCurrentBundle()
             if current.getVersionName() == version {
                 self.logger.info("Preview payload unchanged, reloading current bundle")
-                return self._reload()
+                return self.reloadWithoutWaitingForAppReady()
             }
 
             let next = try self.downloadBundle(
@@ -1597,7 +1620,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             self.notifyBundleSet(next)
-            return self._reload()
+            return self.reloadWithoutWaitingForAppReady()
         } catch {
             self.logger.error("Could not refresh preview session: \(error.localizedDescription)")
             return false

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -147,6 +147,8 @@ private final class ResetTrackingCapgoUpdater: CapgoUpdater {
         checksum: "builtin"
     )
     var nextBundleValue: BundleInfo?
+    var previewFallbackBundleValue: BundleInfo?
+    var stagedPreviewFallbackBundle: BundleInfo?
     var resetCalled = false
     var resetIsInternal = false
     var prepareResetStateForTransitionCalled = false
@@ -161,6 +163,8 @@ private final class ResetTrackingCapgoUpdater: CapgoUpdater {
     var setCalls = 0
     var stagePendingReloadResult = true
     var stagePendingReloadCalls = 0
+    var stagePreviewFallbackReloadResult = true
+    var stagePreviewFallbackReloadCalls = 0
     var finalizePendingReloadCalls = 0
     var finalizedPendingReloadBundle: BundleInfo?
     var finalizePendingReloadPreviousBundleName: String?
@@ -182,6 +186,32 @@ private final class ResetTrackingCapgoUpdater: CapgoUpdater {
 
     override func getNextBundle() -> BundleInfo? {
         nextBundleValue
+    }
+
+    override func getPreviewFallbackBundle() -> BundleInfo? {
+        previewFallbackBundleValue
+    }
+
+    override func getBundleInfo(id: String?) -> BundleInfo {
+        if id == BundleInfo.ID_BUILTIN {
+            return BundleInfo(
+                id: BundleInfo.ID_BUILTIN,
+                version: "builtin",
+                status: .SUCCESS,
+                downloaded: BundleInfo.DOWNLOADED_BUILTIN,
+                checksum: "builtin"
+            )
+        }
+        if id == currentBundleValue.getId() {
+            return currentBundleValue
+        }
+        if id == fallbackBundleValue.getId() {
+            return fallbackBundleValue
+        }
+        if let previewFallbackBundleValue, id == previewFallbackBundleValue.getId() {
+            return previewFallbackBundleValue
+        }
+        return BundleInfo(id: id ?? "missing-id", version: id ?? "missing", status: .PENDING, downloaded: Date(), checksum: "")
     }
 
     override func canSet(bundle: BundleInfo) -> Bool {
@@ -210,6 +240,16 @@ private final class ResetTrackingCapgoUpdater: CapgoUpdater {
     override func stagePendingReload(bundle: BundleInfo) -> Bool {
         stagePendingReloadCalls += 1
         return stagePendingReloadResult
+    }
+
+    override func stagePreviewFallbackReload(bundle: BundleInfo) -> Bool {
+        stagePreviewFallbackReloadCalls += 1
+        stagedPreviewFallbackBundle = bundle
+        return stagePreviewFallbackReloadResult
+    }
+
+    override func delete(id _: String, removeInfo _: Bool) -> Bool {
+        true
     }
 
     override func finalizePendingReload(bundle: BundleInfo, previousBundleName: String) {
@@ -244,10 +284,18 @@ private final class ResetTestableCapacitorUpdaterPlugin: TestableCapacitorUpdate
     override func _reload() -> Bool {
         true
     }
+
+    override func reloadWithoutWaitingForAppReady() -> Bool {
+        true
+    }
 }
 
 private final class ReloadBypassCapacitorUpdaterPlugin: TestableCapacitorUpdaterPlugin {
     override func _reload() -> Bool {
+        true
+    }
+
+    override func reloadWithoutWaitingForAppReady() -> Bool {
         true
     }
 }
@@ -260,6 +308,10 @@ private final class ReloadFailureCapacitorUpdaterPlugin: TestableCapacitorUpdate
     }
 
     override func _reload() -> Bool {
+        false
+    }
+
+    override func reloadWithoutWaitingForAppReady() -> Bool {
         false
     }
 
@@ -982,6 +1034,29 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertEqual(resetImplementation.restoredState?.currentBundlePath, resetImplementation.capturedState.currentBundlePath)
         XCTAssertEqual(resetImplementation.restoredState?.fallbackBundleId, resetImplementation.capturedState.fallbackBundleId)
         XCTAssertEqual(resetImplementation.restoredState?.nextBundleId, resetImplementation.capturedState.nextBundleId)
+    }
+
+    func testLeavePreviewUsesBuiltinWhenPreviewFallbackIsMissing() {
+        let resetPlugin = ResetTestableCapacitorUpdaterPlugin()
+        let resetImplementation = ResetTrackingCapgoUpdater()
+        resetImplementation.currentBundleValue = BundleInfo(
+            id: "preview-id",
+            version: "preview",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "preview"
+        )
+        resetImplementation.previewFallbackBundleValue = nil
+
+        resetPlugin.implementation = resetImplementation
+
+        XCTAssertTrue(resetPlugin.resetToPreviewFallbackBundle())
+        XCTAssertEqual(resetImplementation.stagePreviewFallbackReloadCalls, 1)
+        XCTAssertEqual(resetImplementation.stagedPreviewFallbackBundle?.getId(), BundleInfo.ID_BUILTIN)
+        XCTAssertTrue(resetImplementation.finalizeResetTransitionCalled)
+        XCTAssertEqual(resetImplementation.finalizeResetTransitionPreviousBundleName, "preview")
+        XCTAssertFalse(resetImplementation.finalizeResetTransitionIsInternal)
+        XCTAssertEqual(resetImplementation.restoreResetStateCalls, 0)
     }
 
     func testResetToLastSuccessfulWithoutInstallableFallbackFallsBackToBuiltin() {


### PR DESCRIPTION
## What
- Make preview leave/deeplink restore paths fall back to the builtin bundle when the saved preview fallback is missing, invalid, or not installable.
- Use the preview non-blocking reload path when leaving or refreshing preview sessions so the escape path does not depend on the preview JS app-ready handshake.
- Add Android and iOS regression coverage for leaving preview when the saved fallback pointer is missing.

## Why
- Users can get stuck in a preview and see “Could not leave the test app” even though the native builtin bundle is available as a valid escape target.
- Incoming preview deeplinks should reset out of the current preview first without racing normal update readiness state.

## How
- Centralized preview fallback resolution on both Android and iOS.
- Reused builtin as the last-resort restore target for preview-only restore paths.
- Kept normal update reset behavior unchanged.

## Testing
- `bun run build`
- `bun run eslint` (passes with existing `_options` warnings in `src/web.ts`)
- `bun run prettier -- --check`
- `bun run verify:ios`
- `bun run verify:android`

## Not Tested
- `bun run test:ios` could not complete locally because `./scripts/test-ios.sh` was killed by the local runner before producing test output.
- `bun run swiftlint -- lint` could not complete locally because `node-swiftlint` was killed by the local runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview mode exit handling with enhanced fallback bundle validation and fallback to builtin bundle when necessary
  * Optimized reload behavior in preview mode transitions for better performance
  * Enhanced preview mode disabling logic to properly handle missing fallback bundles

* **Tests**
  * Expanded test coverage for preview fallback bundle scenarios across platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->