### PR TITLE
fix: stabilize preview shake leave

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -2519,7 +2519,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
 
         final BundleInfo previewFallbackBundle = this.implementation.getPreviewFallbackBundle();
-        this.endPreviewSession();
+        this.endPreviewSession(true);
         final BundleInfo restoredNextBundle = this.implementation.getNextBundle();
         this.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle, restoredNextBundle);
         return true;

--- a/android/src/main/java/ee/forgr/capacitor_updater/ShakeDetector.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ShakeDetector.java
@@ -17,8 +17,8 @@ public class ShakeDetector implements SensorEventListener {
         void onShakeDetected();
     }
 
-    private static final float SHAKE_THRESHOLD = 12.0f; // Acceleration threshold for shake detection
-    private static final int SHAKE_TIMEOUT = 500; // Minimum time between shake events (ms)
+    private static final float SHAKE_THRESHOLD = 16.0f; // Acceleration threshold for shake detection
+    private static final int SHAKE_TIMEOUT = 1000; // Minimum time between shake events (ms)
 
     private Listener listener;
     private SensorManager sensorManager;
@@ -34,7 +34,7 @@ public class ShakeDetector implements SensorEventListener {
         this.accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 
         if (accelerometer != null) {
-            sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_GAME);
+            sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_UI);
         }
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -11,8 +11,10 @@ import android.os.Looper;
 import android.webkit.WebView;
 import androidx.appcompat.app.AppCompatActivity;
 import com.getcapacitor.Bridge;
+import com.getcapacitor.CapConfig;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginConfig;
 import com.getcapacitor.PluginHandle;
 import io.github.g00fy2.versioncompare.Version;
 import java.io.File;
@@ -522,6 +524,8 @@ public class CapacitorUpdaterUnitTest {
         private int finalizePendingReloadCalls = 0;
         private BundleInfo finalizedPendingReloadBundle;
         private String finalizePendingReloadPreviousBundleName;
+        private int setPreviewFallbackBundleCalls = 0;
+        private String lastPreviewFallbackBundle;
         private int restoreResetStateCalls = 0;
         private final ResetState capturedState = new ResetState("/stored/current", "fallback-id", "next-id");
         private ResetState restoredState;
@@ -606,6 +610,16 @@ public class CapacitorUpdaterUnitTest {
             this.stagePreviewFallbackReloadCalls++;
             this.stagedPreviewFallbackBundle = bundle;
             return this.stagePreviewFallbackReloadResult;
+        }
+
+        @Override
+        public boolean setPreviewFallbackBundle(final String fallback) {
+            this.setPreviewFallbackBundleCalls++;
+            this.lastPreviewFallbackBundle = fallback;
+            if (fallback == null) {
+                this.previewFallbackBundle = null;
+            }
+            return true;
         }
 
         @Override
@@ -1758,6 +1772,56 @@ public class CapacitorUpdaterUnitTest {
             assertEquals("preview", updater.finalizeResetTransitionPreviousBundleName);
             assertFalse(updater.finalizeResetTransitionInternal);
             assertEquals(0, updater.restoreResetStateCalls);
+        }
+    }
+
+    @Test
+    public void testLeavePreviewFromShakeMenuKeepsPreviewGuardUntilAppReady() throws Exception {
+        try (
+            MockedStatic<Looper> looperMock = mockStatic(Looper.class);
+            MockedConstruction<Handler> ignored = mockConstruction(Handler.class)
+        ) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final ReloadBypassCapacitorUpdaterPlugin plugin = new ReloadBypassCapacitorUpdaterPlugin();
+            final ResetTrackingCapgoUpdater updater = new ResetTrackingCapgoUpdater();
+            final SharedPreferences prefs = mock(SharedPreferences.class);
+            final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+            final Bridge bridge = mock(Bridge.class);
+            final CapConfig capConfig = mock(CapConfig.class);
+            final PluginConfig pluginConfig = mock(PluginConfig.class);
+            final PluginHandle handle = mock(PluginHandle.class);
+
+            updater.currentBundle = new BundleInfo("preview-id", "preview", BundleStatus.SUCCESS, new Date(), "preview");
+            updater.previewFallbackBundle = new BundleInfo("fallback-id", "1.0.0", BundleStatus.SUCCESS, new Date(), "fallback");
+            updater.previewSession = true;
+            plugin.implementation = updater;
+            plugin.previewSessionEnabled = true;
+            plugin.setLoggerForTesting(mock(Logger.class));
+            setPrivateField(plugin, "prefs", prefs);
+            setPrivateField(plugin, "editor", editor);
+            setPrivateField(plugin, "bridge", bridge);
+            plugin.setPluginHandle(handle);
+
+            when(handle.getId()).thenReturn("CapacitorUpdater");
+            when(bridge.getConfig()).thenReturn(capConfig);
+            when(capConfig.getPluginConfiguration("CapacitorUpdater")).thenReturn(pluginConfig);
+            when(pluginConfig.getString(anyString(), nullable(String.class))).thenAnswer((invocation) -> invocation.getArgument(1));
+            when(pluginConfig.getBoolean(anyString(), anyBoolean())).thenAnswer((invocation) -> invocation.getArgument(1));
+            when(prefs.getString(anyString(), nullable(String.class))).thenAnswer((invocation) -> invocation.getArgument(1));
+            when(prefs.getBoolean(anyString(), anyBoolean())).thenAnswer((invocation) -> invocation.getArgument(1));
+            when(editor.remove(anyString())).thenReturn(editor);
+
+            assertTrue(plugin.leavePreviewSessionFromShakeMenu());
+            assertFalse(plugin.hasActivePreviewSession());
+            assertTrue(updater.previewSession);
+            assertEquals(1, updater.stagePreviewFallbackReloadCalls);
+            assertEquals("fallback-id", updater.stagedPreviewFallbackBundle.getId());
+            assertTrue(updater.finalizeResetTransitionCalled);
+            assertEquals("preview", updater.finalizeResetTransitionPreviousBundleName);
+            assertEquals(0, updater.restoreResetStateCalls);
+            assertNull(updater.lastPreviewFallbackBundle);
+            assertTrue(updater.setPreviewFallbackBundleCalls > 0);
         }
     }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1229,7 +1229,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         let previewFallbackBundle = self.implementation.getPreviewFallbackBundle()
-        self.endPreviewSession()
+        self.endPreviewSession(keepPreviewGuard: true)
         let restoredNextBundle = self.implementation.getNextBundle()
         self.deletePreviewBundleIfUnused(previewBundle, previewFallbackBundle: previewFallbackBundle, restoredNextBundle: restoredNextBundle)
         return true
@@ -1382,9 +1382,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func endPreviewSession(keepPreviewGuard: Bool = false) {
         let previousShakeMenuEnabled = UserDefaults.standard.object(forKey: self.previewPreviousShakeMenuDefaultsKey) as? Bool
-            ?? getConfig().getBoolean("shakeMenu", false)
+            ?? self.getBooleanConfig("shakeMenu", defaultValue: false)
         let previousShakeChannelSelectorEnabled = UserDefaults.standard.object(forKey: self.previewPreviousShakeChannelSelectorDefaultsKey) as? Bool
-            ?? getConfig().getBoolean("allowShakeChannelSelector", false)
+            ?? self.getBooleanConfig("allowShakeChannelSelector", defaultValue: false)
         self.restorePreviewPreviousNextBundle()
         self.restorePreviewPreviousAppId()
         self.restorePreviewPreviousDefaultChannel()
@@ -1419,9 +1419,23 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.isLeavingPreviewForIncomingLink = false
         self.implementation.previewSession = false
         self.hidePreviewTransitionLoader(reason: "preview-session-disabled")
-        self.shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
-        self.shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
+        self.shakeMenuEnabled = self.getBooleanConfig("shakeMenu", defaultValue: false)
+        self.shakeChannelSelectorEnabled = self.getBooleanConfig("allowShakeChannelSelector", defaultValue: false)
         self.clearPreviewSessionPreferences()
+    }
+
+    private func getBooleanConfig(_ key: String, defaultValue: Bool) -> Bool {
+        guard self.bridge != nil else {
+            return defaultValue
+        }
+        return getConfig().getBoolean(key, defaultValue)
+    }
+
+    private func getStringConfig(_ key: String, defaultValue: String) -> String {
+        guard self.bridge != nil else {
+            return defaultValue
+        }
+        return getConfig().getString(key, defaultValue) ?? defaultValue
     }
 
     private func clearPreviewSessionPreferences() {
@@ -1449,7 +1463,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func restorePreviewPreviousDefaultChannel() {
-        let configDefaultChannel = self.getConfig().getString("defaultChannel", "")!
+        let configDefaultChannel = self.getStringConfig("defaultChannel", defaultValue: "")
         let hadPreviousDefaultChannel = UserDefaults.standard.object(forKey: self.previewPreviousDefaultChannelWasSetDefaultsKey) as? Bool ?? false
 
         guard hadPreviousDefaultChannel,
@@ -1636,8 +1650,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.previewSessionAlertPending = false
         self.isLeavingPreviewForIncomingLink = false
         self.implementation.previewSession = false
-        self.shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
-        self.shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
+        self.shakeMenuEnabled = self.getBooleanConfig("shakeMenu", defaultValue: false)
+        self.shakeChannelSelectorEnabled = self.getBooleanConfig("allowShakeChannelSelector", defaultValue: false)
         self.restorePreviewPreviousAppId()
         self.restorePreviewPreviousDefaultChannel()
         _ = self.implementation.setPreviewFallbackBundle(fallback: nil)

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -7,6 +7,9 @@
 import UIKit
 import Capacitor
 
+private var lastShakeMenuShownAt: TimeInterval = 0
+private let shakeMenuCooldownSeconds: TimeInterval = 1.2
+
 extension UIApplication {
     // swiftlint:disable:next line_length
     public class func topViewController(_ base: UIViewController? = UIApplication.shared.windows.first?.rootViewController) -> UIViewController? {
@@ -43,25 +46,38 @@ extension UIWindow {
                 return
             }
 
+            let now = Date().timeIntervalSince1970
+            guard now - lastShakeMenuShownAt >= shakeMenuCooldownSeconds else {
+                plugin.logger.info("Shake menu ignored because cooldown is active")
+                return
+            }
+
             if canShowPreviewMenu {
-                showDefaultMenu(plugin: plugin, bridge: bridge)
+                if showDefaultMenu(plugin: plugin, bridge: bridge) {
+                    lastShakeMenuShownAt = now
+                }
             } else {
-                showChannelSelector(plugin: plugin, bridge: bridge)
+                if showChannelSelector(plugin: plugin, bridge: bridge) {
+                    lastShakeMenuShownAt = now
+                }
             }
         }
     }
 
-    private func showDefaultMenu(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) {
+    @discardableResult
+    private func showDefaultMenu(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) -> Bool {
         // Prevent multiple alerts from showing
-        if let topVC = UIApplication.topViewController(),
-           topVC.isKind(of: UIAlertController.self) {
+        guard let topVC = UIApplication.topViewController() else {
+            return false
+        }
+        if topVC.isKind(of: UIAlertController.self) {
             plugin.logger.info("UIAlertController is already presented")
-            return
+            return false
         }
 
         guard plugin.hasActivePreviewSession() else {
             plugin.logger.info("Shake preview menu ignored because no preview session is active")
-            return
+            return false
         }
 
         let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "App"
@@ -96,7 +112,7 @@ extension UIWindow {
         if plugin.shakeChannelSelectorEnabled {
             alertShake.addAction(UIAlertAction(title: "Switch channel", style: .default) { _ in
                 let showSelector = {
-                    self.showChannelSelector(plugin: plugin, bridge: bridge)
+                    _ = self.showChannelSelector(plugin: plugin, bridge: bridge)
                 }
 
                 if let presenter = alertShake.presentingViewController {
@@ -110,10 +126,9 @@ extension UIWindow {
         alertShake.addAction(UIAlertAction(title: cancelButtonTitle, style: .default))
 
         DispatchQueue.main.async {
-            if let topVC = UIApplication.topViewController() {
-                topVC.present(alertShake, animated: true)
-            }
+            topVC.present(alertShake, animated: true)
         }
+        return true
     }
 
     private func showConfiguredDefaultMenu(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) {
@@ -179,12 +194,15 @@ extension UIWindow {
         }
     }
 
-    private func showChannelSelector(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) {
+    @discardableResult
+    private func showChannelSelector(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) -> Bool {
         // Prevent multiple alerts from showing
-        if let topVC = UIApplication.topViewController(),
-           topVC.isKind(of: UIAlertController.self) {
+        guard let topVC = UIApplication.topViewController() else {
+            return false
+        }
+        if topVC.isKind(of: UIAlertController.self) {
             plugin.logger.info("UIAlertController is already presented")
-            return
+            return false
         }
 
         let updater = plugin.implementation
@@ -208,28 +226,27 @@ extension UIWindow {
         })
 
         DispatchQueue.main.async {
-            if let topVC = UIApplication.topViewController() {
-                topVC.present(loadingAlert, animated: true) {
-                    // Fetch channels in background
-                    DispatchQueue.global(qos: .userInitiated).async {
-                        let result = updater.listChannels()
+            topVC.present(loadingAlert, animated: true) {
+                // Fetch channels in background
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let result = updater.listChannels()
 
-                        DispatchQueue.main.async {
-                            loadingAlert.dismiss(animated: true) {
-                                guard !didCancel else { return }
-                                if !result.error.isEmpty {
-                                    self.showError(message: "Failed to load channels: \(result.error)", plugin: plugin)
-                                } else if result.channels.isEmpty {
-                                    self.showError(message: "No channels available for self-assignment", plugin: plugin)
-                                } else {
-                                    self.presentChannelPicker(channels: result.channels, plugin: plugin, bridge: bridge)
-                                }
+                    DispatchQueue.main.async {
+                        loadingAlert.dismiss(animated: true) {
+                            guard !didCancel else { return }
+                            if !result.error.isEmpty {
+                                self.showError(message: "Failed to load channels: \(result.error)", plugin: plugin)
+                            } else if result.channels.isEmpty {
+                                self.showError(message: "No channels available for self-assignment", plugin: plugin)
+                            } else {
+                                self.presentChannelPicker(channels: result.channels, plugin: plugin, bridge: bridge)
                             }
                         }
                     }
                 }
             }
         }
+        return true
     }
 
     private func presentChannelPicker(channels: [[String: Any]], plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol) {

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -168,6 +168,8 @@ private final class ResetTrackingCapgoUpdater: CapgoUpdater {
     var finalizePendingReloadCalls = 0
     var finalizedPendingReloadBundle: BundleInfo?
     var finalizePendingReloadPreviousBundleName: String?
+    var setPreviewFallbackBundleCalls = 0
+    var lastPreviewFallbackBundle: String?
     var restoreResetStateCalls = 0
     let capturedState = ResetState(
         currentBundlePath: "/stored/current",
@@ -246,6 +248,17 @@ private final class ResetTrackingCapgoUpdater: CapgoUpdater {
         stagePreviewFallbackReloadCalls += 1
         stagedPreviewFallbackBundle = bundle
         return stagePreviewFallbackReloadResult
+    }
+
+    override func setPreviewFallbackBundle(fallback: String?) -> Bool {
+        setPreviewFallbackBundleCalls += 1
+        lastPreviewFallbackBundle = fallback
+        if let fallback {
+            previewFallbackBundleValue = getBundleInfo(id: fallback)
+        } else {
+            previewFallbackBundleValue = nil
+        }
+        return true
     }
 
     override func delete(id _: String, removeInfo _: Bool) -> Bool {
@@ -1097,6 +1110,40 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertEqual(resetImplementation.finalizeResetTransitionPreviousBundleName, "preview")
         XCTAssertFalse(resetImplementation.finalizeResetTransitionIsInternal)
         XCTAssertEqual(resetImplementation.restoreResetStateCalls, 0)
+    }
+
+    func testLeavePreviewFromShakeMenuKeepsPreviewGuardUntilAppReady() {
+        let resetPlugin = ResetTestableCapacitorUpdaterPlugin()
+        let resetImplementation = ResetTrackingCapgoUpdater()
+        resetImplementation.currentBundleValue = BundleInfo(
+            id: "preview-id",
+            version: "preview",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "preview"
+        )
+        resetImplementation.previewFallbackBundleValue = BundleInfo(
+            id: "fallback-id",
+            version: "1.0.0",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "fallback"
+        )
+        resetImplementation.previewSession = true
+
+        resetPlugin.implementation = resetImplementation
+        resetPlugin.previewSessionEnabled = true
+
+        XCTAssertTrue(resetPlugin.leavePreviewSessionFromShakeMenu())
+        XCTAssertFalse(resetPlugin.hasActivePreviewSession())
+        XCTAssertTrue(resetImplementation.previewSession)
+        XCTAssertEqual(resetImplementation.stagePreviewFallbackReloadCalls, 1)
+        XCTAssertEqual(resetImplementation.stagedPreviewFallbackBundle?.getId(), "fallback-id")
+        XCTAssertTrue(resetImplementation.finalizeResetTransitionCalled)
+        XCTAssertEqual(resetImplementation.finalizeResetTransitionPreviousBundleName, "preview")
+        XCTAssertEqual(resetImplementation.restoreResetStateCalls, 0)
+        XCTAssertNil(resetImplementation.lastPreviewFallbackBundle)
+        XCTAssertGreaterThan(resetImplementation.setPreviewFallbackBundleCalls, 0)
     }
 
     func testResetToLastSuccessfulWithoutInstallableFallbackFallsBackToBuiltin() {


### PR DESCRIPTION
## What
- Keeps the preview transition guard active when leaving a preview session from the shake menu until the fallback app load calls `notifyAppReady`.
- Makes Android shake detection less sensitive by raising the acceleration threshold, increasing the debounce timeout, and using `SENSOR_DELAY_UI`.
- Adds an iOS shake-menu cooldown to avoid repeated menu openings from quick repeated shake events.
- Adds focused Android and iOS unit coverage for the shake-menu leave regression.
- Prepared by Codex.

## Why
- Scanning a QR preview, reloading it, shaking again, and choosing “Leave test app” could load the fallback bundle without keeping the native preview guard alive long enough for the restored load to be marked ready.
- The shake menu was too easy to trigger, especially during normal device handling.

## How
- Reuses the existing `endPreviewSession(... keepPreviewGuard ...)` path in both native shake leave handlers.
- Tunes Android detector constants and sensor delay.
- Adds a lightweight iOS cooldown around the existing UIKit shake event path.
- Extends existing reset/preview test doubles to assert the guard remains active after shake leave while preview UI state is off.

## Testing
- [x] `bun install --frozen-lockfile`
- [x] `bun run fmt` (passes; existing TypeScript unused-parameter warnings are reported by ESLint)
- [x] `bun run verify:web`
- [x] `bun run verify:ios`
- [x] `git diff --check`
- [ ] `bun run lint` (fails on existing SwiftLint baseline violations in files such as `CapgoUpdater.swift`, `CapacitorUpdaterPlugin.swift`, `ShakeMenu.swift`, and `CapacitorUpdaterPluginTests.swift`)
- [ ] `bun run verify:android` (local machine has no Java runtime: “Unable to locate a Java Runtime”)
- [ ] `bun run test:ios -- -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testLeavePreviewFromShakeMenuKeepsPreviewGuardUntilAppReady` (builds, but local simulator boot timed out after 60s before running the test body)

## Not Tested
- Android unit test execution locally, because Java is not installed in this environment.
- Manual QR preview scan/shake flow on physical Android/iOS devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shake menu now enforces a cooldown to prevent rapid repeated activation.

* **Bug Fixes**
  * Raised shake detection threshold and cooldown for more stable detection.
  * Leaving preview via shake menu now preserves the preview guard until app-ready and improves cleanup sequencing.
  * More robust config reading when runtime bridge/config may be unavailable.

* **Tests**
  * Added unit tests covering preview-session exit and fallback staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->