### PR TITLE
feat: add configurable shake menu gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,9 @@ CapacitorUpdater can be configured with these options:
 | **`keepUrlPathAfterReload`**    | <code>boolean</code>                                                                                       | Configure the plugin to keep the URL path after a reload. WARNING: When a reload is triggered, 'window.history' will be cleared.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | <code>false</code>                                                            | 6.8.0   |
 | **`disableJSLogging`**          | <code>boolean</code>                                                                                       | Disable the JavaScript logging of the plugin. if true, the plugin will not log to the JavaScript console. only the native log will be done                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | <code>false</code>                                                            | 7.3.0   |
 | **`osLogging`**                 | <code>boolean</code>                                                                                       | Enable OS-level logging. When enabled, logs are written to the system log which can be inspected in production builds. - **iOS**: Uses os_log instead of Swift.print, logs accessible via Console.app or Instruments - **Android**: Logs to Logcat (android.util.Log) When set to false, system logging is disabled on both platforms (only JavaScript console logging will occur if enabled). This is useful for debugging production apps (App Store/TestFlight builds on iOS, or production APKs on Android).                                                                                                                                                                                                                                                                                                                                                                                                       | <code>true</code>                                                             | 8.42.0  |
-| **`shakeMenu`**                 | <code>boolean</code>                                                                                       | Enable the shake gesture while a preview session is active. Outside preview sessions this preview menu is ignored, unless {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is enabled.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | <code>false</code>                                                            | 7.5.0   |
-| **`allowShakeChannelSelector`** | <code>boolean</code>                                                                                       | Enable the shake gesture to show a channel selector menu for switching between update channels. If {@link PluginsConfig.CapacitorUpdater.shakeMenu} is also enabled while a preview session is active, the shake menu includes both preview actions and channel switching. Only available for Android and iOS.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | <code>false</code>                                                            | 8.43.0  |
+| **`shakeMenu`**                 | <code>boolean</code>                                                                                       | Enable the native preview menu gesture while a preview session is active. Outside preview sessions this preview menu is ignored, unless {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is enabled.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | <code>false</code>                                                            | 7.5.0   |
+| **`shakeMenuGesture`**          | <code><a href="#shakemenugesture">ShakeMenuGesture</a></code>                                              | Choose which native gesture opens the preview/channel menu. This applies to both {@link PluginsConfig.CapacitorUpdater.shakeMenu} and {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}. Only available for Android and iOS.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | <code>'shake'</code>                                                          | 8.48.0  |
+| **`allowShakeChannelSelector`** | <code>boolean</code>                                                                                       | Enable the native menu gesture to show a channel selector menu for switching between update channels. If {@link PluginsConfig.CapacitorUpdater.shakeMenu} is also enabled while a preview session is active, the shake menu includes both preview actions and channel switching. The native gesture can be changed with {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}. Only available for Android and iOS.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | <code>false</code>                                                            | 8.43.0  |
 
 ### Examples
 
@@ -370,6 +371,7 @@ In `capacitor.config.json`:
       "disableJSLogging": undefined,
       "osLogging": undefined,
       "shakeMenu": undefined,
+      "shakeMenuGesture": undefined,
       "allowShakeChannelSelector": undefined
     }
   }
@@ -422,6 +424,7 @@ const config: CapacitorConfig = {
       disableJSLogging: undefined,
       osLogging: undefined,
       shakeMenu: undefined,
+      shakeMenuGesture: undefined,
       allowShakeChannelSelector: undefined,
     },
   },
@@ -1826,9 +1829,9 @@ Use this to:
 setShakeMenu(options: SetShakeMenuOptions) => Promise<void>
 ```
 
-Enable or disable the shake gesture menu.
+Enable or disable the native preview menu gesture.
 
-During preview sessions, users can shake their device to:
+During preview sessions, users can use the configured native gesture to:
 - Reload the current preview
 - Leave the test app and return to the fallback bundle
 - Switch update channel, when {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is also enabled
@@ -1839,6 +1842,8 @@ shown outside preview sessions when {@link PluginsConfig.CapacitorUpdater.allowS
 **Important:** Disable this in production builds or only enable for internal testers.
 
 Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
+The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
+or `options.gesture`.
 
 | Param         | Type                                                                |
 | ------------- | ------------------------------------------------------------------- |
@@ -1855,7 +1860,7 @@ Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
 isShakeMenuEnabled() => Promise<ShakeMenuEnabled>
 ```
 
-Check if the shake gesture debug menu is currently enabled.
+Check if the native preview menu gesture is currently enabled.
 
 Returns the current state of the shake menu feature that can be toggled via
 {@link setShakeMenu} or configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
@@ -1878,13 +1883,15 @@ Use this to:
 setShakeChannelSelector(options: SetShakeChannelSelectorOptions) => Promise<void>
 ```
 
-Enable or disable the shake channel selector at runtime.
+Enable or disable the channel selector menu gesture at runtime.
 
-When enabled, shaking the device can show a channel selector, including outside preview sessions.
+When enabled, the configured native gesture can show a channel selector, including outside preview sessions.
 If {@link setShakeMenu} is also enabled while a preview session is active, the shake menu includes
 both preview actions and channel switching.
 
 Can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
+or {@link setShakeMenu}.
 
 | Param         | Type                                                                                      |
 | ------------- | ----------------------------------------------------------------------------------------- |
@@ -2547,16 +2554,18 @@ State information for flexible update progress (Android only).
 
 ##### SetShakeMenuOptions
 
-| Prop          | Type                 |
-| ------------- | -------------------- |
-| **`enabled`** | <code>boolean</code> |
+| Prop          | Type                                                          | Description                                           | Default              |
+| ------------- | ------------------------------------------------------------- | ----------------------------------------------------- | -------------------- |
+| **`enabled`** | <code>boolean</code>                                          |                                                       |                      |
+| **`gesture`** | <code><a href="#shakemenugesture">ShakeMenuGesture</a></code> | Native gesture used to open the preview/channel menu. | <code>'shake'</code> |
 
 
 ##### ShakeMenuEnabled
 
-| Prop          | Type                 |
-| ------------- | -------------------- |
-| **`enabled`** | <code>boolean</code> |
+| Prop          | Type                                                          |
+| ------------- | ------------------------------------------------------------- |
+| **`enabled`** | <code>boolean</code>                                          |
+| **`gesture`** | <code><a href="#shakemenugesture">ShakeMenuGesture</a></code> |
 
 
 ##### SetShakeChannelSelectorOptions
@@ -2667,6 +2676,11 @@ failed by native clients.
 Payload emitted by {@link CapacitorUpdaterPlugin.addListener} with `breakingAvailable`.
 
 <code><a href="#majoravailableevent">MajorAvailableEvent</a></code>
+
+
+##### ShakeMenuGesture
+
+<code>'shake' | 'threeFingerPinch'</code>
 
 
 #### Enums

--- a/README.md
+++ b/README.md
@@ -1841,7 +1841,7 @@ shown outside preview sessions when {@link PluginsConfig.CapacitorUpdater.allowS
 
 **Important:** Disable this in production builds or only enable for internal testers.
 
-Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
+This can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
 The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
 or `options.gesture`.
 
@@ -1889,7 +1889,7 @@ When enabled, the configured native gesture can show a channel selector, includi
 If {@link setShakeMenu} is also enabled while a preview session is active, the shake menu includes
 both preview actions and channel switching.
 
-Can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+This can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
 The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
 or {@link setShakeMenu}.
 
@@ -2679,6 +2679,10 @@ Payload emitted by {@link CapacitorUpdaterPlugin.addListener} with `breakingAvai
 
 
 ##### ShakeMenuGesture
+
+Native gesture options that open the shake menu.
+
+Supported values are `shake` and `threeFingerPinch`.
 
 <code>'shake' | 'threeFingerPinch'</code>
 

--- a/README.md
+++ b/README.md
@@ -2562,10 +2562,10 @@ State information for flexible update progress (Android only).
 
 ##### ShakeMenuEnabled
 
-| Prop          | Type                                                          |
-| ------------- | ------------------------------------------------------------- |
-| **`enabled`** | <code>boolean</code>                                          |
-| **`gesture`** | <code><a href="#shakemenugesture">ShakeMenuGesture</a></code> |
+| Prop          | Type                                                          | Description                                                                                                                                                        | Since  |
+| ------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| **`enabled`** | <code>boolean</code>                                          |                                                                                                                                                                    |        |
+| **`gesture`** | <code><a href="#shakemenugesture">ShakeMenuGesture</a></code> | The currently configured native gesture used to open the preview/channel menu. Undefined means consumers should treat the gesture as the default `shake` behavior. | 8.48.0 |
 
 
 ##### SetShakeChannelSelectorOptions

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -79,6 +79,9 @@ import org.json.JSONObject;
 @CapacitorPlugin(name = "CapacitorUpdater")
 public class CapacitorUpdaterPlugin extends Plugin {
 
+    static final String SHAKE_MENU_GESTURE_SHAKE = "shake";
+    static final String SHAKE_MENU_GESTURE_THREE_FINGER_PINCH = "threeFingerPinch";
+
     private static final String AUTO_UPDATE_MODE_OFF = "off";
     private static final String AUTO_UPDATE_MODE_BACKGROUND = "atBackground";
     private static final String AUTO_UPDATE_MODE_INSTALL = "atInstall";
@@ -160,6 +163,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private volatile boolean onLaunchDirectUpdateUsed = false;
     Boolean shakeMenuEnabled = false;
     Boolean shakeChannelSelectorEnabled = false;
+    String shakeMenuGesture = SHAKE_MENU_GESTURE_SHAKE;
     volatile Boolean previewSessionEnabled = false;
     private Boolean previewSessionAlertPending = false;
     private volatile Boolean isLeavingPreviewForIncomingLink = false;
@@ -526,6 +530,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.implementation.timeout = this.getConfig().getInt("responseTimeout", 20) * 1000;
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
+        this.shakeMenuGesture = normalizedShakeMenuGesture(this.getConfig().getString("shakeMenuGesture", SHAKE_MENU_GESTURE_SHAKE));
         this.previewSessionEnabled = Boolean.TRUE.equals(this.allowPreview) && this.prefs.getBoolean(PREVIEW_SESSION_PREF_KEY, false);
         if (!Boolean.TRUE.equals(this.allowPreview) && this.prefs.getBoolean(PREVIEW_SESSION_PREF_KEY, false)) {
             this.clearPreviewSessionBecauseDisabled();
@@ -1502,6 +1507,25 @@ public class CapacitorUpdaterPlugin extends Plugin {
             default:
                 return AUTO_UPDATE_MODE_BACKGROUND;
         }
+    }
+
+    static String normalizedShakeMenuGesture(final String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return SHAKE_MENU_GESTURE_SHAKE;
+        }
+        final String normalized = value.trim();
+        if (SHAKE_MENU_GESTURE_THREE_FINGER_PINCH.equals(normalized)) {
+            return SHAKE_MENU_GESTURE_THREE_FINGER_PINCH;
+        }
+        return SHAKE_MENU_GESTURE_SHAKE;
+    }
+
+    static boolean isSupportedShakeMenuGesture(final String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return true;
+        }
+        final String normalized = value.trim();
+        return SHAKE_MENU_GESTURE_SHAKE.equals(normalized) || SHAKE_MENU_GESTURE_THREE_FINGER_PINCH.equals(normalized);
     }
 
     static String autoUpdateModeForLegacyDirectUpdateMode(final String directUpdateMode) {
@@ -2736,6 +2760,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.hidePreviewTransitionLoader("preview-session-disabled");
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
+        this.shakeMenuGesture = normalizedShakeMenuGesture(this.getConfig().getString("shakeMenuGesture", SHAKE_MENU_GESTURE_SHAKE));
         this.syncShakeMenuLifecycle();
         this.clearPreviewSessionPreferences();
     }
@@ -2959,6 +2984,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.implementation.previewSession = false;
         this.shakeMenuEnabled = this.getConfig().getBoolean("shakeMenu", false);
         this.shakeChannelSelectorEnabled = this.getConfig().getBoolean("allowShakeChannelSelector", false);
+        this.shakeMenuGesture = normalizedShakeMenuGesture(this.getConfig().getString("shakeMenuGesture", SHAKE_MENU_GESTURE_SHAKE));
         this.syncShakeMenuLifecycle();
         this.restorePreviewPreviousAppId();
         this.restorePreviewPreviousDefaultChannel();
@@ -2982,12 +3008,24 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private void ensureShakeMenuStarted() {
         if (getActivity() instanceof com.getcapacitor.BridgeActivity && shakeMenu == null) {
             try {
-                shakeMenu = new ShakeMenu(this, (com.getcapacitor.BridgeActivity) getActivity(), logger);
-                logger.info("Shake menu initialized");
+                shakeMenu = new ShakeMenu(this, (com.getcapacitor.BridgeActivity) getActivity(), logger, this.shakeMenuGesture);
+                logger.info("Shake menu initialized with " + this.shakeMenuGesture + " gesture");
             } catch (Exception e) {
                 logger.error("Failed to initialize shake menu: " + e.getMessage());
             }
         }
+    }
+
+    private void restartShakeMenuListener() {
+        if (shakeMenu != null) {
+            try {
+                shakeMenu.stop();
+            } catch (Exception e) {
+                logger.error("Failed to restart shake menu listener: " + e.getMessage());
+            }
+            shakeMenu = null;
+        }
+        this.syncShakeMenuLifecycle();
     }
 
     private void syncShakeMenuLifecycle() {
@@ -4423,10 +4461,29 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return;
         }
 
-        this.shakeMenuEnabled = enabled;
-        logger.info("Shake menu " + (enabled ? "enabled" : "disabled"));
+        final String gesture = call.getString("gesture", null);
+        final boolean gestureChanged;
+        if (gesture != null) {
+            if (!isSupportedShakeMenuGesture(gesture)) {
+                logger.error("Unsupported shake menu gesture: " + gesture);
+                call.reject("Unsupported shake menu gesture. Use \"shake\" or \"threeFingerPinch\".");
+                return;
+            }
+            final String normalizedGesture = normalizedShakeMenuGesture(gesture);
+            gestureChanged = !normalizedGesture.equals(this.shakeMenuGesture);
+            this.shakeMenuGesture = normalizedGesture;
+        } else {
+            gestureChanged = false;
+        }
 
-        this.syncShakeMenuLifecycle();
+        this.shakeMenuEnabled = enabled;
+        logger.info("Shake menu " + (enabled ? "enabled" : "disabled") + " with " + this.shakeMenuGesture + " gesture");
+
+        if (gestureChanged) {
+            this.restartShakeMenuListener();
+        } else {
+            this.syncShakeMenuLifecycle();
+        }
 
         call.resolve();
     }
@@ -4436,6 +4493,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         try {
             final JSObject ret = new JSObject();
             ret.put("enabled", this.shakeMenuEnabled);
+            ret.put("gesture", this.shakeMenuGesture);
             call.resolve(ret);
         } catch (final Exception e) {
             logger.error("Could not get shake menu status " + e.getMessage());

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1521,10 +1521,13 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     static boolean isSupportedShakeMenuGesture(final String value) {
-        if (value == null || value.trim().isEmpty()) {
+        if (value == null) {
             return true;
         }
         final String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            return false;
+        }
         return SHAKE_MENU_GESTURE_SHAKE.equals(normalized) || SHAKE_MENU_GESTURE_THREE_FINGER_PINCH.equals(normalized);
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 
-public class ShakeMenu implements ShakeDetector.Listener {
+public class ShakeMenu implements ShakeDetector.Listener, ThreeFingerPinchDetector.Listener {
 
     private interface PreviewMenuAction {
         boolean run();
@@ -33,28 +33,46 @@ public class ShakeMenu implements ShakeDetector.Listener {
     private CapacitorUpdaterPlugin plugin;
     private BridgeActivity activity;
     private ShakeDetector shakeDetector;
+    private ThreeFingerPinchDetector pinchDetector;
     private boolean isShowing = false;
     private Logger logger;
 
-    public ShakeMenu(CapacitorUpdaterPlugin plugin, BridgeActivity activity, Logger logger) {
+    public ShakeMenu(CapacitorUpdaterPlugin plugin, BridgeActivity activity, Logger logger, String gesture) {
         this.plugin = plugin;
         this.activity = activity;
         this.logger = logger;
 
-        SensorManager sensorManager = (SensorManager) activity.getSystemService(Activity.SENSOR_SERVICE);
-        this.shakeDetector = new ShakeDetector(this);
-        this.shakeDetector.start(sensorManager);
+        if (CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_THREE_FINGER_PINCH.equals(gesture)) {
+            this.pinchDetector = new ThreeFingerPinchDetector(this, logger);
+            this.pinchDetector.start(activity);
+        } else {
+            SensorManager sensorManager = (SensorManager) activity.getSystemService(Activity.SENSOR_SERVICE);
+            this.shakeDetector = new ShakeDetector(this);
+            this.shakeDetector.start(sensorManager);
+        }
     }
 
     public void stop() {
         if (shakeDetector != null) {
             shakeDetector.stop();
         }
+        if (pinchDetector != null) {
+            pinchDetector.stop();
+        }
     }
 
     @Override
     public void onShakeDetected() {
-        logger.info("Shake detected");
+        onMenuGestureDetected("Shake");
+    }
+
+    @Override
+    public void onThreeFingerPinchDetected() {
+        onMenuGestureDetected("Three finger pinch");
+    }
+
+    private void onMenuGestureDetected(String gestureName) {
+        logger.info(gestureName + " detected");
 
         boolean canShowPreviewMenu = Boolean.TRUE.equals(plugin.shakeMenuEnabled) && plugin.hasActivePreviewSession();
         boolean canShowChannelSelector = Boolean.TRUE.equals(plugin.shakeChannelSelectorEnabled);

--- a/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
@@ -78,33 +78,34 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
+        boolean consumedByPreviousListener = false;
         if (previousOnTouchListener != null && previousOnTouchListener != this) {
-            previousOnTouchListener.onTouch(view, event);
+            consumedByPreviousListener = previousOnTouchListener.onTouch(view, event);
         }
 
         int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP) {
             reset();
-            return false;
+            return consumedByPreviousListener;
         }
 
         if (event.getPointerCount() != REQUIRED_POINTER_COUNT) {
             if (action == MotionEvent.ACTION_POINTER_DOWN) {
                 reset();
             }
-            return false;
+            return consumedByPreviousListener;
         }
 
         float span = calculateSpan(event);
         if (span <= 0) {
-            return false;
+            return consumedByPreviousListener;
         }
 
         if (!tracking || action == MotionEvent.ACTION_POINTER_DOWN) {
             initialSpan = span;
             tracking = true;
             triggered = false;
-            return false;
+            return consumedByPreviousListener;
         }
 
         if (!triggered && Math.abs(span - initialSpan) / initialSpan >= MIN_SCALE_DELTA) {
@@ -118,7 +119,7 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
             }
         }
 
-        return false;
+        return consumedByPreviousListener;
     }
 
     private float calculateSpan(MotionEvent event) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
@@ -10,6 +10,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
+import java.lang.reflect.Field;
 
 public class ThreeFingerPinchDetector implements View.OnTouchListener {
 
@@ -24,6 +25,8 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
     private final Listener listener;
     private final Logger logger;
     private View targetView;
+    private View.OnTouchListener previousOnTouchListener;
+    private boolean touchListenerInstalled = false;
     private float initialSpan = 0;
     private boolean tracking = false;
     private boolean triggered = false;
@@ -35,6 +38,10 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
     }
 
     public void start(BridgeActivity activity) {
+        if (targetView != null) {
+            stop();
+        }
+
         View view = null;
         Bridge bridge = activity.getBridge();
         if (bridge != null && bridge.getWebView() != null) {
@@ -49,19 +56,32 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
         }
 
         this.targetView = view;
-        this.targetView.setOnTouchListener(this);
+        this.previousOnTouchListener = getCurrentOnTouchListener(view);
+        if (this.previousOnTouchListener != this) {
+            this.targetView.setOnTouchListener(this);
+            this.touchListenerInstalled = true;
+        }
     }
 
     public void stop() {
         if (targetView != null) {
-            targetView.setOnTouchListener(null);
+            View.OnTouchListener currentOnTouchListener = getCurrentOnTouchListener(targetView);
+            if (touchListenerInstalled && (currentOnTouchListener == this || currentOnTouchListener == null)) {
+                targetView.setOnTouchListener(previousOnTouchListener);
+            }
             targetView = null;
+            previousOnTouchListener = null;
+            touchListenerInstalled = false;
         }
         reset();
     }
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
+        if (previousOnTouchListener != null && previousOnTouchListener != this) {
+            previousOnTouchListener.onTouch(view, event);
+        }
+
         int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP) {
             reset();
@@ -118,6 +138,26 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
             totalDistance += Math.sqrt(dx * dx + dy * dy);
         }
         return totalDistance / REQUIRED_POINTER_COUNT;
+    }
+
+    private View.OnTouchListener getCurrentOnTouchListener(View view) {
+        try {
+            Field listenerInfoField = View.class.getDeclaredField("mListenerInfo");
+            listenerInfoField.setAccessible(true);
+            Object listenerInfo = listenerInfoField.get(view);
+            if (listenerInfo == null) {
+                return null;
+            }
+            Field onTouchListenerField = listenerInfo.getClass().getDeclaredField("mOnTouchListener");
+            onTouchListenerField.setAccessible(true);
+            Object listener = onTouchListenerField.get(listenerInfo);
+            if (listener instanceof View.OnTouchListener) {
+                return (View.OnTouchListener) listener;
+            }
+        } catch (ReflectiveOperationException | RuntimeException exception) {
+            logger.warn("Three finger pinch detector could not inspect the current touch listener: " + exception.getMessage());
+        }
+        return null;
     }
 
     private void reset() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
@@ -1,0 +1,128 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package ee.forgr.capacitor_updater;
+
+import android.view.MotionEvent;
+import android.view.View;
+import com.getcapacitor.Bridge;
+import com.getcapacitor.BridgeActivity;
+
+public class ThreeFingerPinchDetector implements View.OnTouchListener {
+
+    public interface Listener {
+        void onThreeFingerPinchDetected();
+    }
+
+    private static final int REQUIRED_POINTER_COUNT = 3;
+    private static final float MIN_SCALE_DELTA = 0.30f;
+    private static final long PINCH_TIMEOUT = 1000;
+
+    private final Listener listener;
+    private final Logger logger;
+    private View targetView;
+    private float initialSpan = 0;
+    private boolean tracking = false;
+    private boolean triggered = false;
+    private long lastPinchTime = 0;
+
+    public ThreeFingerPinchDetector(Listener listener, Logger logger) {
+        this.listener = listener;
+        this.logger = logger;
+    }
+
+    public void start(BridgeActivity activity) {
+        View view = null;
+        Bridge bridge = activity.getBridge();
+        if (bridge != null && bridge.getWebView() != null) {
+            view = bridge.getWebView();
+        }
+        if (view == null && activity.getWindow() != null) {
+            view = activity.getWindow().getDecorView().getRootView();
+        }
+        if (view == null) {
+            logger.warn("Three finger pinch detector could not find a target view");
+            return;
+        }
+
+        this.targetView = view;
+        this.targetView.setOnTouchListener(this);
+    }
+
+    public void stop() {
+        if (targetView != null) {
+            targetView.setOnTouchListener(null);
+            targetView = null;
+        }
+        reset();
+    }
+
+    @Override
+    public boolean onTouch(View view, MotionEvent event) {
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP) {
+            reset();
+            return false;
+        }
+
+        if (event.getPointerCount() != REQUIRED_POINTER_COUNT) {
+            if (action == MotionEvent.ACTION_POINTER_DOWN) {
+                reset();
+            }
+            return false;
+        }
+
+        float span = calculateSpan(event);
+        if (span <= 0) {
+            return false;
+        }
+
+        if (!tracking || action == MotionEvent.ACTION_POINTER_DOWN) {
+            initialSpan = span;
+            tracking = true;
+            triggered = false;
+            return false;
+        }
+
+        if (!triggered && Math.abs(span - initialSpan) / initialSpan >= MIN_SCALE_DELTA) {
+            long currentTime = System.currentTimeMillis();
+            if (currentTime - lastPinchTime > PINCH_TIMEOUT) {
+                triggered = true;
+                lastPinchTime = currentTime;
+                if (listener != null) {
+                    listener.onThreeFingerPinchDetected();
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private float calculateSpan(MotionEvent event) {
+        float centerX = 0;
+        float centerY = 0;
+        for (int i = 0; i < REQUIRED_POINTER_COUNT; i++) {
+            centerX += event.getX(i);
+            centerY += event.getY(i);
+        }
+        centerX /= REQUIRED_POINTER_COUNT;
+        centerY /= REQUIRED_POINTER_COUNT;
+
+        float totalDistance = 0;
+        for (int i = 0; i < REQUIRED_POINTER_COUNT; i++) {
+            float dx = event.getX(i) - centerX;
+            float dy = event.getY(i) - centerY;
+            totalDistance += Math.sqrt(dx * dx + dy * dy);
+        }
+        return totalDistance / REQUIRED_POINTER_COUNT;
+    }
+
+    private void reset() {
+        initialSpan = 0;
+        tracking = false;
+        triggered = false;
+    }
+}

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -2817,4 +2817,17 @@ public class CapacitorUpdaterUnitTest {
             assertEquals("42", result);
         }
     }
+
+    @Test
+    public void normalizeShakeMenuGestureSupportsThreeFingerPinch() {
+        assertEquals(CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_SHAKE, CapacitorUpdaterPlugin.normalizedShakeMenuGesture(null));
+        assertEquals(CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_SHAKE, CapacitorUpdaterPlugin.normalizedShakeMenuGesture("unknown"));
+        assertEquals(
+            CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_THREE_FINGER_PINCH,
+            CapacitorUpdaterPlugin.normalizedShakeMenuGesture("threeFingerPinch")
+        );
+        assertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("shake"));
+        assertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("threeFingerPinch"));
+        assertFalse(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("pinch"));
+    }
 }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -2821,6 +2821,7 @@ public class CapacitorUpdaterUnitTest {
     @Test
     public void normalizeShakeMenuGestureSupportsThreeFingerPinch() {
         assertEquals(CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_SHAKE, CapacitorUpdaterPlugin.normalizedShakeMenuGesture(null));
+        assertEquals(CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_SHAKE, CapacitorUpdaterPlugin.normalizedShakeMenuGesture("shake"));
         assertEquals(CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_SHAKE, CapacitorUpdaterPlugin.normalizedShakeMenuGesture("unknown"));
         assertEquals(
             CapacitorUpdaterPlugin.SHAKE_MENU_GESTURE_THREE_FINGER_PINCH,
@@ -2828,6 +2829,7 @@ public class CapacitorUpdaterUnitTest {
         );
         assertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("shake"));
         assertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("threeFingerPinch"));
+        assertFalse(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture(" "));
         assertFalse(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("pinch"));
     }
 }

--- a/api.md
+++ b/api.md
@@ -49,8 +49,9 @@ CapacitorUpdater can be configured with these options:
 | **`keepUrlPathAfterReload`** | `boolean` | Configure the plugin to keep the URL path after a reload. WARNING: When a reload is triggered, 'window.history' will be cleared. | `false` | 6.8.0 |
 | **`disableJSLogging`** | `boolean` | Disable the JavaScript logging of the plugin. if true, the plugin will not log to the JavaScript console. only the native log will be done | `false` | 7.3.0 |
 | **`osLogging`** | `boolean` | Enable OS-level logging. When enabled, logs are written to the system log which can be inspected in production builds. - **iOS**: Uses os_log instead of Swift.print, logs accessible via Console.app or Instruments - **Android**: Logs to Logcat (android.util.Log) When set to false, system logging is disabled on both platforms (only JavaScript console logging will occur if enabled). This is useful for debugging production apps (App Store/TestFlight builds on iOS, or production APKs on Android). | `true` | 8.42.0 |
-| **`shakeMenu`** | `boolean` | Enable the shake gesture while a preview session is active. Outside preview sessions this preview menu is ignored, unless {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is enabled. | `false` | 7.5.0 |
-| **`allowShakeChannelSelector`** | `boolean` | Enable the shake gesture to show a channel selector menu for switching between update channels. If {@link PluginsConfig.CapacitorUpdater.shakeMenu} is also enabled while a preview session is active, the shake menu includes both preview actions and channel switching. Only available for Android and iOS. | `false` | 8.43.0 |
+| **`shakeMenu`** | `boolean` | Enable the native preview menu gesture while a preview session is active. Outside preview sessions this preview menu is ignored, unless {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is enabled. | `false` | 7.5.0 |
+| **`shakeMenuGesture`** | `ShakeMenuGesture` | Choose which native gesture opens the preview/channel menu. This applies to both {@link PluginsConfig.CapacitorUpdater.shakeMenu} and {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}. Only available for Android and iOS. | `'shake'` | 8.48.0 |
+| **`allowShakeChannelSelector`** | `boolean` | Enable the native menu gesture to show a channel selector menu for switching between update channels. If {@link PluginsConfig.CapacitorUpdater.shakeMenu} is also enabled while a preview session is active, the shake menu includes both preview actions and channel switching. The native gesture can be changed with {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}. Only available for Android and iOS. | `false` | 8.43.0 |
 
 
 </docgen-config>
@@ -1779,9 +1780,9 @@ Use this to:
 setShakeMenu(options: SetShakeMenuOptions) => Promise<void>
 ```
 
-Enable or disable the shake gesture menu.
+Enable or disable the native preview menu gesture.
 
-During preview sessions, users can shake their device to:
+During preview sessions, users can use the configured native gesture to:
 - Reload the current preview
 - Leave the test app and return to the fallback bundle
 - Switch update channel, when {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is also enabled
@@ -1792,6 +1793,8 @@ shown outside preview sessions when {@link PluginsConfig.CapacitorUpdater.allowS
 **Important:** Disable this in production builds or only enable for internal testers.
 
 Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
+The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
+or `options.gesture`.
 
 **Parameters**
 
@@ -1817,7 +1820,7 @@ Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
 isShakeMenuEnabled() => Promise<ShakeMenuEnabled>
 ```
 
-Check if the shake gesture debug menu is currently enabled.
+Check if the native preview menu gesture is currently enabled.
 
 Returns the current state of the shake menu feature that can be toggled via
 {@link setShakeMenu} or configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
@@ -1829,7 +1832,7 @@ Use this to:
 
 **Returns**
 
-`Promise<ShakeMenuEnabled>` — Object with `enabled: true` or `enabled: false`.
+`Promise<ShakeMenuEnabled>` — Object with the current enabled state and gesture.
 
 **Since:** 7.5.0
 
@@ -1845,13 +1848,15 @@ Use this to:
 setShakeChannelSelector(options: SetShakeChannelSelectorOptions) => Promise<void>
 ```
 
-Enable or disable the shake channel selector at runtime.
+Enable or disable the channel selector menu gesture at runtime.
 
-When enabled, shaking the device can show a channel selector, including outside preview sessions.
+When enabled, the configured native gesture can show a channel selector, including outside preview sessions.
 If {@link setShakeMenu} is also enabled while a preview session is active, the shake menu includes
 both preview actions and channel switching.
 
 Can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
+or {@link setShakeMenu}.
 
 **Parameters**
 

--- a/api.md
+++ b/api.md
@@ -1792,7 +1792,7 @@ shown outside preview sessions when {@link PluginsConfig.CapacitorUpdater.allowS
 
 **Important:** Disable this in production builds or only enable for internal testers.
 
-Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
+This can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
 The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
 or `options.gesture`.
 
@@ -1854,7 +1854,7 @@ When enabled, the configured native gesture can show a channel selector, includi
 If {@link setShakeMenu} is also enabled while a preview session is active, the shake menu includes
 both preview actions and channel switching.
 
-Can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+This can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
 The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
 or {@link setShakeMenu}.
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -2790,10 +2790,13 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     static func isSupportedShakeMenuGesture(_ value: String?) -> Bool {
-        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let value else {
             return true
         }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty {
+            return false
+        }
         return normalized == shakeMenuGestureShake || normalized == shakeMenuGestureThreeFingerPinch
     }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -89,6 +89,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     static let autoUpdateModeLaunch = "onLaunch"
     static let autoUpdateModeAlways = "always"
     static let autoUpdateModeOnlyDownload = "onlyDownload"
+    static let shakeMenuGestureShake = "shake"
+    static let shakeMenuGestureThreeFingerPinch = "threeFingerPinch"
     private static let previewLoaderTimeoutMs = 60000
     private let keepUrlPathFlagKey = "__capgo_keep_url_path_after_reload"
     private let customIdDefaultsKey = "CapacitorUpdater.customId"
@@ -167,6 +169,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private var webViewStatsReporter: WebViewStatsReporter?
     public var shakeMenuEnabled = false
     public var shakeChannelSelectorEnabled = false
+    public var shakeMenuGesture = CapacitorUpdaterPlugin.shakeMenuGestureShake
+    var shakeMenuPinchGestureRecognizer: UIPinchGestureRecognizer?
+    var shakeMenuPinchGestureTriggered = false
     public var previewSessionEnabled = false
     private var previewSessionAlertPending = false
     private var isLeavingPreviewForIncomingLink = false
@@ -241,6 +246,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         resetWhenUpdate = getConfig().getBoolean("resetWhenUpdate", true)
         shakeMenuEnabled = getConfig().getBoolean("shakeMenu", false)
         shakeChannelSelectorEnabled = getConfig().getBoolean("allowShakeChannelSelector", false)
+        shakeMenuGesture = Self.normalizedShakeMenuGesture(getConfig().getString("shakeMenuGesture", Self.shakeMenuGestureShake))
         let storedPreviewSessionEnabled = UserDefaults.standard.bool(forKey: previewSessionDefaultsKey)
         let shouldClearPreviewSessionBecauseDisabled = !allowPreview && storedPreviewSessionEnabled
         previewSessionEnabled = allowPreview && storedPreviewSessionEnabled
@@ -251,6 +257,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             shakeChannelSelectorEnabled = UserDefaults.standard.object(forKey: previewPreviousShakeChannelSelectorDefaultsKey) as? Bool
                 ?? shakeChannelSelectorEnabled
         }
+        syncShakeMenuGestureRecognizer()
         periodCheckDelay = Self.normalizedPeriodCheckDelaySeconds(getConfig().getInt("periodCheckDelay", 0))
 
         implementation.setPublicKey(getConfig().getString("publicKey") ?? "")
@@ -1212,6 +1219,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.previewSessionAlertPending = true
         self.implementation.previewSession = true
         self.shakeMenuEnabled = true
+        self.syncShakeMenuGestureRecognizer()
         UserDefaults.standard.set(true, forKey: self.previewSessionDefaultsKey)
         UserDefaults.standard.set(true, forKey: self.previewSessionAlertPendingDefaultsKey)
         UserDefaults.standard.synchronize()
@@ -1398,6 +1406,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         self.shakeMenuEnabled = previousShakeMenuEnabled
         self.shakeChannelSelectorEnabled = previousShakeChannelSelectorEnabled
+        self.syncShakeMenuGestureRecognizer()
         _ = self.implementation.setPreviewFallbackBundle(fallback: nil)
         self.clearPreviewSessionPreferences()
         logger.info("Preview session ended")
@@ -1421,6 +1430,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.hidePreviewTransitionLoader(reason: "preview-session-disabled")
         self.shakeMenuEnabled = self.getBooleanConfig("shakeMenu", defaultValue: false)
         self.shakeChannelSelectorEnabled = self.getBooleanConfig("allowShakeChannelSelector", defaultValue: false)
+        self.shakeMenuGesture = Self.normalizedShakeMenuGesture(self.getStringConfig("shakeMenuGesture", defaultValue: Self.shakeMenuGestureShake))
+        self.syncShakeMenuGestureRecognizer()
         self.clearPreviewSessionPreferences()
     }
 
@@ -1652,6 +1663,8 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         self.implementation.previewSession = false
         self.shakeMenuEnabled = self.getBooleanConfig("shakeMenu", defaultValue: false)
         self.shakeChannelSelectorEnabled = self.getBooleanConfig("allowShakeChannelSelector", defaultValue: false)
+        self.shakeMenuGesture = Self.normalizedShakeMenuGesture(self.getStringConfig("shakeMenuGesture", defaultValue: Self.shakeMenuGestureShake))
+        self.syncShakeMenuGestureRecognizer()
         self.restorePreviewPreviousAppId()
         self.restorePreviewPreviousDefaultChannel()
         _ = self.implementation.setPreviewFallbackBundle(fallback: nil)
@@ -2765,6 +2778,25 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    static func normalizedShakeMenuGesture(_ value: String?) -> String {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return shakeMenuGestureShake
+        }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized == shakeMenuGestureThreeFingerPinch {
+            return shakeMenuGestureThreeFingerPinch
+        }
+        return shakeMenuGestureShake
+    }
+
+    static func isSupportedShakeMenuGesture(_ value: String?) -> Bool {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return true
+        }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized == shakeMenuGestureShake || normalized == shakeMenuGestureThreeFingerPinch
+    }
+
     static func autoUpdateModeForLegacyDirectUpdateMode(_ directUpdateMode: String) -> String {
         switch directUpdateMode {
         case autoUpdateModeInstall, autoUpdateModeLaunch, autoUpdateModeAlways:
@@ -3485,14 +3517,25 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
+        if let gesture = call.getString("gesture") {
+            guard Self.isSupportedShakeMenuGesture(gesture) else {
+                logger.error("Unsupported shake menu gesture: \(gesture)")
+                call.reject("Unsupported shake menu gesture. Use \"shake\" or \"threeFingerPinch\".")
+                return
+            }
+            self.shakeMenuGesture = Self.normalizedShakeMenuGesture(gesture)
+        }
+
         self.shakeMenuEnabled = enabled
-        logger.info("Shake menu \(enabled ? "enabled" : "disabled")")
+        self.syncShakeMenuGestureRecognizer()
+        logger.info("Shake menu \(enabled ? "enabled" : "disabled") with \(self.shakeMenuGesture) gesture")
         call.resolve()
     }
 
     @objc func isShakeMenuEnabled(_ call: CAPPluginCall) {
         call.resolve([
-            "enabled": self.shakeMenuEnabled
+            "enabled": self.shakeMenuEnabled,
+            "gesture": self.shakeMenuGesture
         ])
     }
 
@@ -3504,6 +3547,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         self.shakeChannelSelectorEnabled = enabled
+        self.syncShakeMenuGestureRecognizer()
         logger.info("Shake channel selector \(enabled ? "enabled" : "disabled")")
         call.resolve()
     }

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -96,8 +96,8 @@ extension CapacitorUpdaterPlugin: UIGestureRecognizerDelegate {
     }
 
     public func gestureRecognizer(
-        _ gestureRecognizer: UIGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        _: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith _: UIGestureRecognizer
     ) -> Bool {
         true
     }

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -9,6 +9,7 @@ import Capacitor
 
 private var lastShakeMenuShownAt: TimeInterval = 0
 private let shakeMenuCooldownSeconds: TimeInterval = 1.2
+private let threeFingerPinchScaleDelta: CGFloat = 0.30
 
 extension UIApplication {
     // swiftlint:disable:next line_length
@@ -26,42 +27,124 @@ extension UIApplication {
     }
 }
 
+extension CapacitorUpdaterPlugin: UIGestureRecognizerDelegate {
+    func syncShakeMenuGestureRecognizer() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            let shouldInstall = self.shakeMenuGesture == Self.shakeMenuGestureThreeFingerPinch &&
+                (self.shakeMenuEnabled || self.shakeChannelSelectorEnabled)
+
+            guard shouldInstall, let targetView = self.bridge?.webView ?? self.bridge?.viewController?.view else {
+                self.removeShakeMenuGestureRecognizer()
+                return
+            }
+
+            if self.shakeMenuPinchGestureRecognizer?.view === targetView {
+                return
+            }
+
+            self.removeShakeMenuGestureRecognizer()
+
+            let recognizer = UIPinchGestureRecognizer(target: self, action: #selector(self.handleShakeMenuPinch(_:)))
+            recognizer.cancelsTouchesInView = false
+            recognizer.delaysTouchesBegan = false
+            recognizer.delaysTouchesEnded = false
+            recognizer.delegate = self
+            targetView.addGestureRecognizer(recognizer)
+            self.shakeMenuPinchGestureRecognizer = recognizer
+            self.logger.info("Three finger pinch menu gesture initialized")
+        }
+    }
+
+    func removeShakeMenuGestureRecognizer() {
+        if let recognizer = self.shakeMenuPinchGestureRecognizer {
+            recognizer.view?.removeGestureRecognizer(recognizer)
+            self.shakeMenuPinchGestureRecognizer = nil
+            self.shakeMenuPinchGestureTriggered = false
+            self.logger.info("Three finger pinch menu gesture stopped")
+        }
+    }
+
+    @objc func handleShakeMenuPinch(_ recognizer: UIPinchGestureRecognizer) {
+        if recognizer.state == .ended || recognizer.state == .cancelled || recognizer.state == .failed {
+            self.shakeMenuPinchGestureTriggered = false
+            return
+        }
+        guard recognizer.state == .changed, !self.shakeMenuPinchGestureTriggered, recognizer.numberOfTouches == 3 else {
+            return
+        }
+        guard abs(recognizer.scale - 1) >= threeFingerPinchScaleDelta else {
+            return
+        }
+        guard self.shakeMenuGesture == Self.shakeMenuGestureThreeFingerPinch, let bridge = self.bridge else {
+            return
+        }
+        guard let window = recognizer.view?.window ?? bridge.viewController?.view.window else {
+            return
+        }
+
+        self.shakeMenuPinchGestureTriggered = true
+        _ = window.showCapacitorUpdaterMenu(plugin: self, bridge: bridge, gestureName: "Three finger pinch")
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer === self.shakeMenuPinchGestureRecognizer {
+            self.shakeMenuPinchGestureTriggered = false
+        }
+        return true
+    }
+
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
 extension UIWindow {
     override open func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         if motion == .motionShake {
-            // Find the CapacitorUpdaterPlugin instance
             guard let bridgeViewController = rootViewController as? CAPBridgeViewController,
                   let bridge = bridgeViewController.bridge,
                   let plugin = bridge.plugin(withName: "CapacitorUpdater") as? CapacitorUpdaterPlugin else {
                 return
             }
-
-            let canShowPreviewMenu = plugin.shakeMenuEnabled && plugin.hasActivePreviewSession()
-            let canShowChannelSelector = plugin.shakeChannelSelectorEnabled
-
-            if !canShowPreviewMenu && !canShowChannelSelector {
-                if plugin.shakeMenuEnabled {
-                    plugin.logger.info("Shake preview menu ignored because no preview session is active")
-                }
+            guard plugin.shakeMenuGesture == CapacitorUpdaterPlugin.shakeMenuGestureShake else {
                 return
             }
 
-            let now = Date().timeIntervalSince1970
-            guard now - lastShakeMenuShownAt >= shakeMenuCooldownSeconds else {
-                plugin.logger.info("Shake menu ignored because cooldown is active")
-                return
-            }
-
-            if canShowPreviewMenu {
-                if showDefaultMenu(plugin: plugin, bridge: bridge) {
-                    lastShakeMenuShownAt = now
-                }
-            } else {
-                if showChannelSelector(plugin: plugin, bridge: bridge) {
-                    lastShakeMenuShownAt = now
-                }
-            }
+            _ = showCapacitorUpdaterMenu(plugin: plugin, bridge: bridge, gestureName: "Shake")
         }
+    }
+
+    @discardableResult
+    fileprivate func showCapacitorUpdaterMenu(plugin: CapacitorUpdaterPlugin, bridge: CAPBridgeProtocol, gestureName: String) -> Bool {
+        let canShowPreviewMenu = plugin.shakeMenuEnabled && plugin.hasActivePreviewSession()
+        let canShowChannelSelector = plugin.shakeChannelSelectorEnabled
+
+        if !canShowPreviewMenu && !canShowChannelSelector {
+            if plugin.shakeMenuEnabled {
+                plugin.logger.info("\(gestureName) preview menu ignored because no preview session is active")
+            }
+            return false
+        }
+
+        let now = Date().timeIntervalSince1970
+        guard now - lastShakeMenuShownAt >= shakeMenuCooldownSeconds else {
+            plugin.logger.info("\(gestureName) menu ignored because cooldown is active")
+            return false
+        }
+
+        let didShow = canShowPreviewMenu
+            ? showDefaultMenu(plugin: plugin, bridge: bridge)
+            : showChannelSelector(plugin: plugin, bridge: bridge)
+
+        if didShow {
+            lastShakeMenuShownAt = now
+        }
+        return didShow
     }
 
     @discardableResult

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -1152,6 +1152,10 @@ class CapacitorUpdaterTests: XCTestCase {
             CapacitorUpdaterPlugin.shakeMenuGestureShake
         )
         XCTAssertEqual(
+            CapacitorUpdaterPlugin.normalizedShakeMenuGesture("shake"),
+            CapacitorUpdaterPlugin.shakeMenuGestureShake
+        )
+        XCTAssertEqual(
             CapacitorUpdaterPlugin.normalizedShakeMenuGesture("unknown"),
             CapacitorUpdaterPlugin.shakeMenuGestureShake
         )
@@ -1161,6 +1165,7 @@ class CapacitorUpdaterTests: XCTestCase {
         )
         XCTAssertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("shake"))
         XCTAssertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("threeFingerPinch"))
+        XCTAssertFalse(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture(" "))
         XCTAssertFalse(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("pinch"))
     }
 

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -1146,6 +1146,24 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertGreaterThan(resetImplementation.setPreviewFallbackBundleCalls, 0)
     }
 
+    func testNormalizeShakeMenuGestureSupportsThreeFingerPinch() {
+        XCTAssertEqual(
+            CapacitorUpdaterPlugin.normalizedShakeMenuGesture(nil),
+            CapacitorUpdaterPlugin.shakeMenuGestureShake
+        )
+        XCTAssertEqual(
+            CapacitorUpdaterPlugin.normalizedShakeMenuGesture("unknown"),
+            CapacitorUpdaterPlugin.shakeMenuGestureShake
+        )
+        XCTAssertEqual(
+            CapacitorUpdaterPlugin.normalizedShakeMenuGesture("threeFingerPinch"),
+            CapacitorUpdaterPlugin.shakeMenuGestureThreeFingerPinch
+        )
+        XCTAssertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("shake"))
+        XCTAssertTrue(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("threeFingerPinch"))
+        XCTAssertFalse(CapacitorUpdaterPlugin.isSupportedShakeMenuGesture("pinch"))
+    }
+
     func testResetToLastSuccessfulWithoutInstallableFallbackFallsBackToBuiltin() {
         let resetPlugin = ResetTestableCapacitorUpdaterPlugin()
         let resetImplementation = ResetTrackingCapgoUpdater()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -393,7 +393,7 @@ declare module '@capacitor/cli' {
       osLogging?: boolean;
 
       /**
-       * Enable the shake gesture while a preview session is active.
+       * Enable the native preview menu gesture while a preview session is active.
        * Outside preview sessions this preview menu is ignored, unless
        * {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is enabled.
        *
@@ -403,9 +403,22 @@ declare module '@capacitor/cli' {
       shakeMenu?: boolean;
 
       /**
-       * Enable the shake gesture to show a channel selector menu for switching between update channels.
+       * Choose which native gesture opens the preview/channel menu.
+       * This applies to both {@link PluginsConfig.CapacitorUpdater.shakeMenu}
+       * and {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+       *
+       * Only available for Android and iOS.
+       *
+       * @default 'shake'
+       * @since  8.48.0
+       */
+      shakeMenuGesture?: ShakeMenuGesture;
+
+      /**
+       * Enable the native menu gesture to show a channel selector menu for switching between update channels.
        * If {@link PluginsConfig.CapacitorUpdater.shakeMenu} is also enabled while a preview session is active,
        * the shake menu includes both preview actions and channel switching.
+       * The native gesture can be changed with {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
        *
        * Only available for Android and iOS.
        *
@@ -1382,9 +1395,9 @@ export interface CapacitorUpdaterPlugin {
   getFailedUpdate(): Promise<UpdateFailedEvent | null>;
 
   /**
-   * Enable or disable the shake gesture menu.
+   * Enable or disable the native preview menu gesture.
    *
-   * During preview sessions, users can shake their device to:
+   * During preview sessions, users can use the configured native gesture to:
    * - Reload the current preview
    * - Leave the test app and return to the fallback bundle
    * - Switch update channel, when {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector} is also enabled
@@ -1395,6 +1408,8 @@ export interface CapacitorUpdaterPlugin {
    * **Important:** Disable this in production builds or only enable for internal testers.
    *
    * Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
+   * The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
+   * or `options.gesture`.
    *
    * @param options {@link SetShakeMenuOptions} with `enabled: true` to enable or `enabled: false` to disable.
    * @returns {Promise<void>} Resolves when the setting is applied.
@@ -1404,7 +1419,7 @@ export interface CapacitorUpdaterPlugin {
   setShakeMenu(options: SetShakeMenuOptions): Promise<void>;
 
   /**
-   * Check if the shake gesture debug menu is currently enabled.
+   * Check if the native preview menu gesture is currently enabled.
    *
    * Returns the current state of the shake menu feature that can be toggled via
    * {@link setShakeMenu} or configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
@@ -1414,20 +1429,22 @@ export interface CapacitorUpdaterPlugin {
    * - Show/hide debug settings UI
    * - Verify configuration during testing
    *
-   * @returns {Promise<ShakeMenuEnabled>} Object with `enabled: true` or `enabled: false`.
+   * @returns {Promise<ShakeMenuEnabled>} Object with the current enabled state and gesture.
    * @throws {Error} If the operation fails.
    * @since 7.5.0
    */
   isShakeMenuEnabled(): Promise<ShakeMenuEnabled>;
 
   /**
-   * Enable or disable the shake channel selector at runtime.
+   * Enable or disable the channel selector menu gesture at runtime.
    *
-   * When enabled, shaking the device can show a channel selector, including outside preview sessions.
+   * When enabled, the configured native gesture can show a channel selector, including outside preview sessions.
    * If {@link setShakeMenu} is also enabled while a preview session is active, the shake menu includes
    * both preview actions and channel switching.
    *
    * Can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+   * The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
+   * or {@link setShakeMenu}.
    *
    * @param options {@link SetShakeChannelSelectorOptions} with `enabled: true` to enable or `enabled: false` to disable.
    * @returns {Promise<void>} Resolves when the setting is applied.
@@ -2284,12 +2301,21 @@ export interface TriggerUpdateCheckResult {
   queued: boolean;
 }
 
+export type ShakeMenuGesture = 'shake' | 'threeFingerPinch';
+
 export interface SetShakeMenuOptions {
   enabled: boolean;
+  /**
+   * Native gesture used to open the preview/channel menu.
+   *
+   * @default 'shake'
+   */
+  gesture?: ShakeMenuGesture;
 }
 
 export interface ShakeMenuEnabled {
   enabled: boolean;
+  gesture: ShakeMenuGesture;
 }
 
 export interface SetShakeChannelSelectorOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -2322,6 +2322,12 @@ export interface SetShakeMenuOptions {
 
 export interface ShakeMenuEnabled {
   enabled: boolean;
+  /**
+   * The currently configured native gesture used to open the preview/channel menu.
+   * Undefined means consumers should treat the gesture as the default `shake` behavior.
+   *
+   * @since 8.48.0
+   */
   gesture?: ShakeMenuGesture;
 }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -2322,7 +2322,7 @@ export interface SetShakeMenuOptions {
 
 export interface ShakeMenuEnabled {
   enabled: boolean;
-  gesture: ShakeMenuGesture;
+  gesture?: ShakeMenuGesture;
 }
 
 export interface SetShakeChannelSelectorOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1407,7 +1407,7 @@ export interface CapacitorUpdaterPlugin {
    *
    * **Important:** Disable this in production builds or only enable for internal testers.
    *
-   * Can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
+   * This can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
    * The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
    * or `options.gesture`.
    *
@@ -1442,7 +1442,7 @@ export interface CapacitorUpdaterPlugin {
    * If {@link setShakeMenu} is also enabled while a preview session is active, the shake menu includes
    * both preview actions and channel switching.
    *
-   * Can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
+   * This can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
    * The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
    * or {@link setShakeMenu}.
    *
@@ -2301,6 +2301,13 @@ export interface TriggerUpdateCheckResult {
   queued: boolean;
 }
 
+/**
+ * Native gesture options that open the shake menu.
+ *
+ * Supported values are `shake` and `threeFingerPinch`.
+ *
+ * @public
+ */
 export type ShakeMenuGesture = 'shake' | 'threeFingerPinch';
 
 export interface SetShakeMenuOptions {

--- a/src/web.ts
+++ b/src/web.ts
@@ -252,7 +252,7 @@ export class CapacitorUpdaterWeb extends WebPlugin implements CapacitorUpdaterPl
   }
 
   async isShakeMenuEnabled(): Promise<ShakeMenuEnabled> {
-    return Promise.resolve({ enabled: false });
+    return Promise.resolve({ enabled: false, gesture: 'shake' });
   }
 
   async setShakeChannelSelector(_options: SetShakeChannelSelectorOptions): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds `shakeMenuGesture` with `shake` and `threeFingerPinch` options for the native preview/channel menu.
- Wires the gesture through config, `setShakeMenu`, and `isShakeMenuEnabled` on web, Android, and iOS.
- Adds native Android/iOS three-finger pinch handlers and updates generated docs.
- AI-generated by Codex.

## Motivation
- Shake remains useful, but testers need an alternative gesture that avoids accidental activation after the sensitivity tuning in PR #808.
- A three-finger pinch is explicit enough for internal/debug flows while preserving the default `shake` behavior.
- AI-generated by Codex.

## Business Impact
- Reduces tester friction in QR preview flows by making the debug menu harder to trigger accidentally and configurable per app.
- Keeps existing customers backward-compatible because the default gesture remains `shake`.
- AI-generated by Codex.

## Test Plan
- [x] `bun run fmt` (passes; existing TypeScript unused-parameter warnings remain in `src/web.ts`)
- [x] `bun run verify:web`
- [x] `bun run verify:ios` (passes; existing `UIApplication.shared.windows` deprecation warning remains in `topViewController`)
- [x] `bun run test:ios -- -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testNormalizeShakeMenuGestureSupportsThreeFingerPinch -only-testing:CapacitorUpdaterPluginTests/CapacitorUpdaterTests/testLeavePreviewFromShakeMenuKeepsPreviewGuardUntilAppReady`
- [x] `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/martindonadieu/Library/Android/sdk" bun run verify:android`
- [x] `git diff --check`
- [ ] Manual physical-device validation of the three-finger pinch on Android and iOS.
- AI-generated by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable native preview menu gesture ("shake" or "threeFingerPinch"); gesture can be set in config or via API and is included in enabled-status.

* **Documentation**
  * Added `shakeMenuGesture` docs, updated API reference, examples, and notes on interaction with channel selector/preview behavior.

* **Tests**
  * Added unit tests for gesture normalization and supported-gesture validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->