### PR TITLE
[codex] Fix Android Maestro CI emulator teardown

### DIFF
--- a/scripts/maestro/run-android-live-update-ci.sh
+++ b/scripts/maestro/run-android-live-update-ci.sh
@@ -16,6 +16,8 @@ cleanup_android_emulator() {
   fi
 }
 
-trap cleanup_android_emulator EXIT
+if [[ "${CAPGO_MAESTRO_CLEANUP_ANDROID_EMULATOR_ON_EXIT:-0}" == "1" ]]; then
+  trap cleanup_android_emulator EXIT
+fi
 
 "$(dirname "$0")/run-android-live-update.sh" "$@"


### PR DESCRIPTION
## What
- Make the Android live-update Maestro CI wrapper leave emulator teardown disabled by default.
- Keep the old force-cleanup path available behind `CAPGO_MAESTRO_CLEANUP_ANDROID_EMULATOR_ON_EXIT=1`.

## Why
- The GitHub `reactivecircus/android-emulator-runner` action owns emulator lifecycle cleanup.
- The wrapper was killing the emulator on `EXIT`, so the action could fail during its own teardown after the Maestro scenario had already passed.

## How
- Guard the wrapper's `trap cleanup_android_emulator EXIT` behind an explicit opt-in env var.
- Leave the Maestro flow invocation unchanged.

## Testing
- `bash -n scripts/maestro/run-android-live-update-ci.sh`
- `bun run fmt`
- `bun run verify`

## Not Tested
- `bun run lint` currently fails on existing unrelated SwiftLint violations in iOS files; this PR does not touch those files.

AI-assisted by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Android emulator cleanup handling in CI pipelines by making cleanup conditional. The emulator cleanup on exit now only occurs when explicitly enabled via environment variable configuration, providing better control over the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->