### PR TITLE
fix: keep shake menu gesture config-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1842,8 +1842,7 @@ shown outside preview sessions when {@link PluginsConfig.CapacitorUpdater.allowS
 **Important:** Disable this in production builds or only enable for internal testers.
 
 This can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
-The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
-or `options.gesture`.
+The native gesture is configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
 
 | Param         | Type                                                                |
 | ------------- | ------------------------------------------------------------------- |
@@ -1890,8 +1889,7 @@ If {@link setShakeMenu} is also enabled while a preview session is active, the s
 both preview actions and channel switching.
 
 This can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
-The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
-or {@link setShakeMenu}.
+The native gesture is configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
 
 | Param         | Type                                                                                      |
 | ------------- | ----------------------------------------------------------------------------------------- |
@@ -2554,10 +2552,9 @@ State information for flexible update progress (Android only).
 
 ##### SetShakeMenuOptions
 
-| Prop          | Type                                                          | Description                                           | Default              |
-| ------------- | ------------------------------------------------------------- | ----------------------------------------------------- | -------------------- |
-| **`enabled`** | <code>boolean</code>                                          |                                                       |                      |
-| **`gesture`** | <code><a href="#shakemenugesture">ShakeMenuGesture</a></code> | Native gesture used to open the preview/channel menu. | <code>'shake'</code> |
+| Prop          | Type                 |
+| ------------- | -------------------- |
+| **`enabled`** | <code>boolean</code> |
 
 
 ##### ShakeMenuEnabled

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -3019,18 +3019,6 @@ public class CapacitorUpdaterPlugin extends Plugin {
         }
     }
 
-    private void restartShakeMenuListener() {
-        if (shakeMenu != null) {
-            try {
-                shakeMenu.stop();
-            } catch (Exception e) {
-                logger.error("Failed to restart shake menu listener: " + e.getMessage());
-            }
-            shakeMenu = null;
-        }
-        this.syncShakeMenuLifecycle();
-    }
-
     private void syncShakeMenuLifecycle() {
         if (this.shouldListenForShake()) {
             this.ensureShakeMenuStarted();
@@ -4464,29 +4452,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
             return;
         }
 
-        final String gesture = call.getString("gesture", null);
-        final boolean gestureChanged;
-        if (gesture != null) {
-            if (!isSupportedShakeMenuGesture(gesture)) {
-                logger.error("Unsupported shake menu gesture: " + gesture);
-                call.reject("Unsupported shake menu gesture. Use \"shake\" or \"threeFingerPinch\".");
-                return;
-            }
-            final String normalizedGesture = normalizedShakeMenuGesture(gesture);
-            gestureChanged = !normalizedGesture.equals(this.shakeMenuGesture);
-            this.shakeMenuGesture = normalizedGesture;
-        } else {
-            gestureChanged = false;
-        }
-
         this.shakeMenuEnabled = enabled;
         logger.info("Shake menu " + (enabled ? "enabled" : "disabled") + " with " + this.shakeMenuGesture + " gesture");
-
-        if (gestureChanged) {
-            this.restartShakeMenuListener();
-        } else {
-            this.syncShakeMenuLifecycle();
-        }
+        this.syncShakeMenuLifecycle();
 
         call.resolve();
     }

--- a/api.md
+++ b/api.md
@@ -1793,8 +1793,7 @@ shown outside preview sessions when {@link PluginsConfig.CapacitorUpdater.allowS
 **Important:** Disable this in production builds or only enable for internal testers.
 
 This can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
-The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
-or `options.gesture`.
+The native gesture is configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
 
 **Parameters**
 
@@ -1855,8 +1854,7 @@ If {@link setShakeMenu} is also enabled while a preview session is active, the s
 both preview actions and channel switching.
 
 This can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
-The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
-or {@link setShakeMenu}.
+The native gesture is configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
 
 **Parameters**
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -3520,15 +3520,6 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        if let gesture = call.getString("gesture") {
-            guard Self.isSupportedShakeMenuGesture(gesture) else {
-                logger.error("Unsupported shake menu gesture: \(gesture)")
-                call.reject("Unsupported shake menu gesture. Use \"shake\" or \"threeFingerPinch\".")
-                return
-            }
-            self.shakeMenuGesture = Self.normalizedShakeMenuGesture(gesture)
-        }
-
         self.shakeMenuEnabled = enabled
         self.syncShakeMenuGestureRecognizer()
         logger.info("Shake menu \(enabled ? "enabled" : "disabled") with \(self.shakeMenuGesture) gesture")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1408,8 +1408,7 @@ export interface CapacitorUpdaterPlugin {
    * **Important:** Disable this in production builds or only enable for internal testers.
    *
    * This can also be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenu}.
-   * The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
-   * or `options.gesture`.
+   * The native gesture is configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
    *
    * @param options {@link SetShakeMenuOptions} with `enabled: true` to enable or `enabled: false` to disable.
    * @returns {Promise<void>} Resolves when the setting is applied.
@@ -1443,8 +1442,7 @@ export interface CapacitorUpdaterPlugin {
    * both preview actions and channel switching.
    *
    * This can also be configured via {@link PluginsConfig.CapacitorUpdater.allowShakeChannelSelector}.
-   * The native gesture can be configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}
-   * or {@link setShakeMenu}.
+   * The native gesture is configured via {@link PluginsConfig.CapacitorUpdater.shakeMenuGesture}.
    *
    * @param options {@link SetShakeChannelSelectorOptions} with `enabled: true` to enable or `enabled: false` to disable.
    * @returns {Promise<void>} Resolves when the setting is applied.
@@ -2312,12 +2310,6 @@ export type ShakeMenuGesture = 'shake' | 'threeFingerPinch';
 
 export interface SetShakeMenuOptions {
   enabled: boolean;
-  /**
-   * Native gesture used to open the preview/channel menu.
-   *
-   * @default 'shake'
-   */
-  gesture?: ShakeMenuGesture;
 }
 
 export interface ShakeMenuEnabled {


### PR DESCRIPTION
## What
- Remove `gesture` from `setShakeMenu` options so the runtime API only toggles the preview menu on or off.
- Keep `shakeMenuGesture` as the Capacitor config option for choosing `shake` or `threeFingerPinch`.
- Regenerate `README.md` and `api.md` so docs no longer advertise `options.gesture`.

## Why
- The gesture should be controlled from Capacitor config, not changed through the `setShakeMenu` runtime method.
- This keeps the native listener setup stable and avoids expanding the runtime API unnecessarily.

## How
- Updated TypeScript definitions and generated docs.
- Removed Android and iOS `setShakeMenu` gesture parsing while preserving config-backed `shakeMenuGesture` behavior.
- Removed the now-unused Android listener restart helper.

## Testing
- AI-generated PR.
- `bun run fmt`
- `bun run verify`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/martindonadieu/Library/Android/sdk" bun run verify:android`
- `bun run verify:ios`
- `bun run verify:web`

## Not Tested
- Manual on-device three-finger pinch interaction was not re-tested in this follow-up; this PR only removes the runtime gesture override and keeps the existing config-backed implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shake-menu API documentation for clarity. Consolidated gesture setting references to use only the global plugin configuration.

* **Refactor**
  * Removed `gesture` option parameter from `setShakeMenu` method. Gesture configuration is now handled exclusively through global plugin settings, providing a simpler and more consistent configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->