### PR TITLE
fix: detect preview pinch above webview

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ThreeFingerPinchDetector.java
@@ -6,13 +6,22 @@
 
 package ee.forgr.capacitor_updater;
 
+import android.view.ActionMode;
+import android.view.KeyEvent;
+import android.view.KeyboardShortcutGroup;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.MotionEvent;
+import android.view.SearchEvent;
 import android.view.View;
-import com.getcapacitor.Bridge;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.accessibility.AccessibilityEvent;
 import com.getcapacitor.BridgeActivity;
-import java.lang.reflect.Field;
+import java.lang.ref.WeakReference;
+import java.util.List;
 
-public class ThreeFingerPinchDetector implements View.OnTouchListener {
+public class ThreeFingerPinchDetector {
 
     public interface Listener {
         void onThreeFingerPinchDetected();
@@ -24,9 +33,10 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
 
     private final Listener listener;
     private final Logger logger;
-    private View targetView;
-    private View.OnTouchListener previousOnTouchListener;
-    private boolean touchListenerInstalled = false;
+    private Window targetWindow;
+    private Window.Callback previousWindowCallback;
+    private Window.Callback windowCallback;
+    private WeakReference<ThreeFingerPinchDetector> detectorReference;
     private float initialSpan = 0;
     private boolean tracking = false;
     private boolean triggered = false;
@@ -38,74 +48,68 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
     }
 
     public void start(BridgeActivity activity) {
-        if (targetView != null) {
+        if (targetWindow != null) {
             stop();
         }
 
-        View view = null;
-        Bridge bridge = activity.getBridge();
-        if (bridge != null && bridge.getWebView() != null) {
-            view = bridge.getWebView();
-        }
-        if (view == null && activity.getWindow() != null) {
-            view = activity.getWindow().getDecorView().getRootView();
-        }
-        if (view == null) {
-            logger.warn("Three finger pinch detector could not find a target view");
+        Window window = activity.getWindow();
+        if (window == null) {
+            logger.warn("Three finger pinch detector could not find a target window");
             return;
         }
 
-        this.targetView = view;
-        this.previousOnTouchListener = getCurrentOnTouchListener(view);
-        if (this.previousOnTouchListener != this) {
-            this.targetView.setOnTouchListener(this);
-            this.touchListenerInstalled = true;
-        }
+        this.targetWindow = window;
+        this.previousWindowCallback = window.getCallback();
+        this.detectorReference = new WeakReference<>(this);
+        this.windowCallback = new PinchWindowCallback(this.previousWindowCallback, this.detectorReference);
+        window.setCallback(this.windowCallback);
+        logger.info("Three finger pinch detector installed on activity window");
     }
 
     public void stop() {
-        if (targetView != null) {
-            View.OnTouchListener currentOnTouchListener = getCurrentOnTouchListener(targetView);
-            if (touchListenerInstalled && (currentOnTouchListener == this || currentOnTouchListener == null)) {
-                targetView.setOnTouchListener(previousOnTouchListener);
+        if (targetWindow != null) {
+            if (windowCallback instanceof PinchWindowCallback) {
+                ((PinchWindowCallback) windowCallback).disable();
             }
-            targetView = null;
-            previousOnTouchListener = null;
-            touchListenerInstalled = false;
+            if (detectorReference != null) {
+                detectorReference.clear();
+            }
+            if (targetWindow.getCallback() == windowCallback) {
+                targetWindow.setCallback(previousWindowCallback);
+            }
+            targetWindow = null;
+            previousWindowCallback = null;
+            windowCallback = null;
+            detectorReference = null;
         }
         reset();
     }
 
-    @Override
-    public boolean onTouch(View view, MotionEvent event) {
-        boolean consumedByPreviousListener = false;
-        if (previousOnTouchListener != null && previousOnTouchListener != this) {
-            consumedByPreviousListener = previousOnTouchListener.onTouch(view, event);
-        }
-
+    private void handleTouch(MotionEvent event) {
         int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP) {
             reset();
-            return consumedByPreviousListener;
+            return;
         }
 
         if (event.getPointerCount() != REQUIRED_POINTER_COUNT) {
             if (action == MotionEvent.ACTION_POINTER_DOWN) {
                 reset();
             }
-            return consumedByPreviousListener;
+            return;
         }
 
         float span = calculateSpan(event);
         if (span <= 0) {
-            return consumedByPreviousListener;
+            return;
         }
 
         if (!tracking || action == MotionEvent.ACTION_POINTER_DOWN) {
             initialSpan = span;
             tracking = true;
             triggered = false;
-            return consumedByPreviousListener;
+            logger.info("Three finger pinch tracking started");
+            return;
         }
 
         if (!triggered && Math.abs(span - initialSpan) / initialSpan >= MIN_SCALE_DELTA) {
@@ -113,13 +117,12 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
             if (currentTime - lastPinchTime > PINCH_TIMEOUT) {
                 triggered = true;
                 lastPinchTime = currentTime;
+                logger.info("Three finger pinch threshold reached");
                 if (listener != null) {
                     listener.onThreeFingerPinchDetected();
                 }
             }
         }
-
-        return consumedByPreviousListener;
     }
 
     private float calculateSpan(MotionEvent event) {
@@ -141,29 +144,180 @@ public class ThreeFingerPinchDetector implements View.OnTouchListener {
         return totalDistance / REQUIRED_POINTER_COUNT;
     }
 
-    private View.OnTouchListener getCurrentOnTouchListener(View view) {
-        try {
-            Field listenerInfoField = View.class.getDeclaredField("mListenerInfo");
-            listenerInfoField.setAccessible(true);
-            Object listenerInfo = listenerInfoField.get(view);
-            if (listenerInfo == null) {
-                return null;
-            }
-            Field onTouchListenerField = listenerInfo.getClass().getDeclaredField("mOnTouchListener");
-            onTouchListenerField.setAccessible(true);
-            Object listener = onTouchListenerField.get(listenerInfo);
-            if (listener instanceof View.OnTouchListener) {
-                return (View.OnTouchListener) listener;
-            }
-        } catch (ReflectiveOperationException | RuntimeException exception) {
-            logger.warn("Three finger pinch detector could not inspect the current touch listener: " + exception.getMessage());
-        }
-        return null;
-    }
-
     private void reset() {
         initialSpan = 0;
         tracking = false;
         triggered = false;
+    }
+
+    private static class PinchWindowCallback implements Window.Callback {
+
+        private final Window.Callback delegate;
+        private final WeakReference<ThreeFingerPinchDetector> detectorReference;
+        private boolean enabled = true;
+
+        PinchWindowCallback(Window.Callback delegate, WeakReference<ThreeFingerPinchDetector> detectorReference) {
+            this.delegate = delegate;
+            this.detectorReference = detectorReference;
+        }
+
+        void disable() {
+            enabled = false;
+            if (detectorReference != null) {
+                detectorReference.clear();
+            }
+        }
+
+        @Override
+        public boolean dispatchKeyEvent(KeyEvent event) {
+            return delegate != null && delegate.dispatchKeyEvent(event);
+        }
+
+        @Override
+        public boolean dispatchKeyShortcutEvent(KeyEvent event) {
+            return delegate != null && delegate.dispatchKeyShortcutEvent(event);
+        }
+
+        @Override
+        public boolean dispatchTouchEvent(MotionEvent event) {
+            boolean handled = delegate != null && delegate.dispatchTouchEvent(event);
+            if (enabled) {
+                ThreeFingerPinchDetector detector = detectorReference == null ? null : detectorReference.get();
+                if (detector != null) {
+                    detector.handleTouch(event);
+                }
+            }
+            return handled;
+        }
+
+        @Override
+        public boolean dispatchTrackballEvent(MotionEvent event) {
+            return delegate != null && delegate.dispatchTrackballEvent(event);
+        }
+
+        @Override
+        public boolean dispatchGenericMotionEvent(MotionEvent event) {
+            return delegate != null && delegate.dispatchGenericMotionEvent(event);
+        }
+
+        @Override
+        public boolean dispatchPopulateAccessibilityEvent(AccessibilityEvent event) {
+            return delegate != null && delegate.dispatchPopulateAccessibilityEvent(event);
+        }
+
+        @Override
+        public View onCreatePanelView(int featureId) {
+            return delegate == null ? null : delegate.onCreatePanelView(featureId);
+        }
+
+        @Override
+        public boolean onCreatePanelMenu(int featureId, Menu menu) {
+            return delegate != null && delegate.onCreatePanelMenu(featureId, menu);
+        }
+
+        @Override
+        public boolean onPreparePanel(int featureId, View view, Menu menu) {
+            return delegate != null && delegate.onPreparePanel(featureId, view, menu);
+        }
+
+        @Override
+        public boolean onMenuOpened(int featureId, Menu menu) {
+            return delegate != null && delegate.onMenuOpened(featureId, menu);
+        }
+
+        @Override
+        public boolean onMenuItemSelected(int featureId, MenuItem item) {
+            return delegate != null && delegate.onMenuItemSelected(featureId, item);
+        }
+
+        @Override
+        public void onWindowAttributesChanged(WindowManager.LayoutParams attrs) {
+            if (delegate != null) {
+                delegate.onWindowAttributesChanged(attrs);
+            }
+        }
+
+        @Override
+        public void onContentChanged() {
+            if (delegate != null) {
+                delegate.onContentChanged();
+            }
+        }
+
+        @Override
+        public void onWindowFocusChanged(boolean hasFocus) {
+            if (delegate != null) {
+                delegate.onWindowFocusChanged(hasFocus);
+            }
+        }
+
+        @Override
+        public void onAttachedToWindow() {
+            if (delegate != null) {
+                delegate.onAttachedToWindow();
+            }
+        }
+
+        @Override
+        public void onDetachedFromWindow() {
+            if (delegate != null) {
+                delegate.onDetachedFromWindow();
+            }
+        }
+
+        @Override
+        public void onPanelClosed(int featureId, Menu menu) {
+            if (delegate != null) {
+                delegate.onPanelClosed(featureId, menu);
+            }
+        }
+
+        @Override
+        public boolean onSearchRequested() {
+            return delegate != null && delegate.onSearchRequested();
+        }
+
+        @Override
+        public boolean onSearchRequested(SearchEvent searchEvent) {
+            return delegate != null && delegate.onSearchRequested(searchEvent);
+        }
+
+        @Override
+        public ActionMode onWindowStartingActionMode(ActionMode.Callback callback) {
+            return delegate == null ? null : delegate.onWindowStartingActionMode(callback);
+        }
+
+        @Override
+        public ActionMode onWindowStartingActionMode(ActionMode.Callback callback, int type) {
+            return delegate == null ? null : delegate.onWindowStartingActionMode(callback, type);
+        }
+
+        @Override
+        public void onActionModeStarted(ActionMode mode) {
+            if (delegate != null) {
+                delegate.onActionModeStarted(mode);
+            }
+        }
+
+        @Override
+        public void onActionModeFinished(ActionMode mode) {
+            if (delegate != null) {
+                delegate.onActionModeFinished(mode);
+            }
+        }
+
+        @Override
+        public void onProvideKeyboardShortcuts(List<KeyboardShortcutGroup> data, Menu menu, int deviceId) {
+            if (delegate != null) {
+                delegate.onProvideKeyboardShortcuts(data, menu, deviceId);
+            }
+        }
+
+        @Override
+        public void onPointerCaptureChanged(boolean hasCapture) {
+            if (delegate != null) {
+                delegate.onPointerCaptureChanged(hasCapture);
+            }
+        }
     }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/ShakeMenu.swift
@@ -14,10 +14,11 @@ private let threeFingerPinchScaleDelta: CGFloat = 0.12
 final class ThreeFingerPinchGestureRecognizer: UIGestureRecognizer {
     private var initialSpan: CGFloat = 0
     private(set) var scale: CGFloat = 1
+    var onTrackingStarted: (() -> Void)?
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
-        guard let view = self.view, let activeTouches = activeTouches(in: view, with: event), activeTouches.count <= 3 else {
+        guard let view = self.view, let activeTouches = activeTouches(with: event), activeTouches.count <= 3 else {
             self.state = .failed
             return
         }
@@ -25,14 +26,18 @@ final class ThreeFingerPinchGestureRecognizer: UIGestureRecognizer {
         if activeTouches.count == 3 {
             self.initialSpan = span(for: activeTouches, in: view)
             self.scale = 1
-            self.state = self.initialSpan > 0 ? .began : .failed
+            if self.initialSpan > 0 {
+                self.onTrackingStarted?()
+            } else {
+                self.state = .failed
+            }
         }
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesMoved(touches, with: event)
         guard let view = self.view,
-              let activeTouches = activeTouches(in: view, with: event),
+              let activeTouches = activeTouches(with: event),
               activeTouches.count == 3,
               self.initialSpan > 0 else {
             self.state = .failed
@@ -40,12 +45,16 @@ final class ThreeFingerPinchGestureRecognizer: UIGestureRecognizer {
         }
 
         self.scale = span(for: activeTouches, in: view) / self.initialSpan
-        self.state = .changed
+        if abs(self.scale - 1) >= threeFingerPinchScaleDelta {
+            self.state = .recognized
+        }
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesEnded(touches, with: event)
-        self.state = self.state == .possible || self.state == .began ? .failed : .ended
+        if self.state == .possible {
+            self.state = .failed
+        }
     }
 
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -59,8 +68,8 @@ final class ThreeFingerPinchGestureRecognizer: UIGestureRecognizer {
         self.scale = 1
     }
 
-    private func activeTouches(in view: UIView, with event: UIEvent) -> [UITouch]? {
-        event.touches(for: view)?.filter { touch in
+    private func activeTouches(with event: UIEvent) -> [UITouch]? {
+        event.touches(for: self)?.filter { touch in
             touch.phase != .ended && touch.phase != .cancelled
         }
     }
@@ -106,7 +115,7 @@ extension CapacitorUpdaterPlugin: UIGestureRecognizerDelegate {
             let shouldInstall = self.shakeMenuGesture == Self.shakeMenuGestureThreeFingerPinch &&
                 (self.shakeMenuEnabled || self.shakeChannelSelectorEnabled)
 
-            guard shouldInstall, let targetView = self.bridge?.webView ?? self.bridge?.viewController?.view else {
+            guard shouldInstall, let targetView = self.bridge?.viewController?.view ?? self.bridge?.webView else {
                 self.removeShakeMenuGestureRecognizer()
                 return
             }
@@ -122,6 +131,9 @@ extension CapacitorUpdaterPlugin: UIGestureRecognizerDelegate {
             recognizer.delaysTouchesBegan = false
             recognizer.delaysTouchesEnded = false
             recognizer.delegate = self
+            recognizer.onTrackingStarted = { [weak self] in
+                self?.logger.info("Three finger pinch tracking started")
+            }
             targetView.addGestureRecognizer(recognizer)
             self.shakeMenuPinchGestureRecognizer = recognizer
             self.logger.info("Three finger pinch menu gesture initialized")
@@ -138,11 +150,7 @@ extension CapacitorUpdaterPlugin: UIGestureRecognizerDelegate {
     }
 
     @objc func handleShakeMenuPinch(_ recognizer: ThreeFingerPinchGestureRecognizer) {
-        if recognizer.state == .ended || recognizer.state == .cancelled || recognizer.state == .failed {
-            self.shakeMenuPinchGestureTriggered = false
-            return
-        }
-        guard recognizer.state == .changed, !self.shakeMenuPinchGestureTriggered else {
+        guard recognizer.state == .recognized, !self.shakeMenuPinchGestureTriggered else {
             return
         }
         guard abs(recognizer.scale - 1) >= threeFingerPinchScaleDelta else {
@@ -156,6 +164,7 @@ extension CapacitorUpdaterPlugin: UIGestureRecognizerDelegate {
         }
 
         self.shakeMenuPinchGestureTriggered = true
+        self.logger.info("Three finger pinch detected")
         _ = window.showCapacitorUpdaterMenu(plugin: self, bridge: bridge, gestureName: "Three finger pinch")
     }
 


### PR DESCRIPTION
## What
- Move the iOS three-finger pinch recognizer from the WebView-first target to the Capacitor root view first.
- Move Android three-finger pinch detection from a WebView OnTouchListener to an Activity Window callback so native touch events are observed before WebView handling.
- Add low-noise native logs for detector installation, tracking start, and threshold crossing.

## Why
- A preview session can be active while the preview WebView still prevents the three-finger pinch detector from seeing touches reliably.
- The preview menu gesture should be handled natively above web content so preview pages cannot block users from leaving or reloading a preview.

## How
- iOS now installs the gesture recognizer on bridge.viewController.view before falling back to bridge.webView.
- Android wraps the Activity Window.Callback, observes dispatchTouchEvent, then delegates the event normally.
- Android disables its callback wrapper on stop even if another callback has wrapped it later.

## Testing
- [x] bun run verify:ios
- [x] JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME="/Users/martindonadieu/Library/Android/sdk" bun run verify:android
- [x] bun run verify:web
- [x] git diff --check

## Not Tested
- [ ] Manual device validation of the three-finger pinch gesture in a real preview session.

Generated with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved three-finger pinch detection on Android with optimized gesture handling.
  * Enhanced gesture recognition on iOS with better targeting and additional logging for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->