### PR TITLE
docs: clarify setChannel device override visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,11 @@ Assign this device to a specific update channel at runtime.
 Channels allow you to distribute different bundle versions to different groups of users
 (e.g., "production", "beta", "staging"). This method switches the device to a new channel.
 
+**Device Override UI:** `setChannel()` validates the channel with the backend, then stores the
+selected channel locally on the device. It does not create or update a backend Device Override,
+so the device will not appear as overridden in the Capgo dashboard. Only assignments created
+from the dashboard or the Public API are shown in the Device Override UI.
+
 **Requirements:**
 - The target channel must allow self-assignment (configured in your Capgo dashboard or backend)
 - The backend may accept or reject the request based on channel settings
@@ -1272,7 +1277,8 @@ CapacitorUpdater.addListener('channelPrivate', (data) =&gt; {
 });
 ```
 
-This sends a request to the Capgo backend linking your device ID to the specified channel.
+This sends a request to the Capgo backend to validate the specified channel, then stores the
+channel locally on the device.
 
 | Param         | Type                                                            | Description                                                                                                                  |
 | ------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1299,7 +1299,8 @@ unsetChannel(options: UnsetChannelOptions) => Promise<void>
 
 Remove the plugin-managed local channel assignment and return to the default channel.
 
-This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, the device falls back to:
+This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, normal channel precedence applies:
+- An existing Dashboard or Public API Device Override, if one exists
 - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
 - Your backend default channel for this app
 

--- a/README.md
+++ b/README.md
@@ -1297,11 +1297,11 @@ channel locally on the device.
 unsetChannel(options: UnsetChannelOptions) => Promise<void>
 ```
 
-Remove the device's channel assignment and return to the default channel.
+Remove the plugin-managed local channel assignment and return to the default channel.
 
-This unlinks the device from any specifically assigned channel, causing it to fall back to:
+This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, the device falls back to:
 - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
-- Your backend's default channel for this app
+- Your backend default channel for this app
 
 Use this when:
 - Users opt out of beta/testing programs

--- a/api.md
+++ b/api.md
@@ -1091,6 +1091,11 @@ Assign this device to a specific update channel at runtime.
 Channels allow you to distribute different bundle versions to different groups of users
 (e.g., "production", "beta", "staging"). This method switches the device to a new channel.
 
+**Device Override UI:** `setChannel()` validates the channel with the backend, then stores the
+selected channel locally on the device. It does not create or update a backend Device Override,
+so the device will not appear as overridden in the Capgo dashboard. Only assignments created
+from the dashboard or the Public API are shown in the Device Override UI.
+
 **Requirements:**
 - The target channel must allow self-assignment (configured in your Capgo dashboard or backend)
 - The backend may accept or reject the request based on channel settings
@@ -1117,7 +1122,8 @@ CapacitorUpdater.addListener('channelPrivate', (data) => {
 });
 ```
 
-This sends a request to the Capgo backend linking your device ID to the specified channel.
+This sends a request to the Capgo backend to validate the specified channel, then stores the
+channel locally on the device.
 
 **Parameters**
 

--- a/api.md
+++ b/api.md
@@ -1151,7 +1151,8 @@ unsetChannel(options: UnsetChannelOptions) => Promise<void>
 
 Remove the plugin-managed local channel assignment and return to the default channel.
 
-This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, the device falls back to:
+This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, normal channel precedence applies:
+- An existing Dashboard or Public API Device Override, if one exists
 - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
 - Your backend default channel for this app
 

--- a/api.md
+++ b/api.md
@@ -1149,11 +1149,11 @@ channel locally on the device.
 unsetChannel(options: UnsetChannelOptions) => Promise<void>
 ```
 
-Remove the device's channel assignment and return to the default channel.
+Remove the plugin-managed local channel assignment and return to the default channel.
 
-This unlinks the device from any specifically assigned channel, causing it to fall back to:
+This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, the device falls back to:
 - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
-- Your backend's default channel for this app
+- Your backend default channel for this app
 
 Use this when:
 - Users opt out of beta/testing programs

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1050,11 +1050,11 @@ export interface CapacitorUpdaterPlugin {
   setChannel(options: SetChannelOptions): Promise<ChannelRes>;
 
   /**
-   * Remove the device's channel assignment and return to the default channel.
+   * Remove the plugin-managed local channel assignment and return to the default channel.
    *
-   * This unlinks the device from any specifically assigned channel, causing it to fall back to:
+   * This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, the device falls back to:
    * - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
-   * - Your backend's default channel for this app
+   * - Your backend default channel for this app
    *
    * Use this when:
    * - Users opt out of beta/testing programs

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1052,7 +1052,8 @@ export interface CapacitorUpdaterPlugin {
   /**
    * Remove the plugin-managed local channel assignment and return to the default channel.
    *
-   * This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, the device falls back to:
+   * This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, normal channel precedence applies:
+   * - An existing Dashboard or Public API Device Override, if one exists
    * - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
    * - Your backend default channel for this app
    *

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1008,6 +1008,11 @@ export interface CapacitorUpdaterPlugin {
    * Channels allow you to distribute different bundle versions to different groups of users
    * (e.g., "production", "beta", "staging"). This method switches the device to a new channel.
    *
+   * **Device Override UI:** `setChannel()` validates the channel with the backend, then stores the
+   * selected channel locally on the device. It does not create or update a backend Device Override,
+   * so the device will not appear as overridden in the Capgo dashboard. Only assignments created
+   * from the dashboard or the Public API are shown in the Device Override UI.
+   *
    * **Requirements:**
    * - The target channel must allow self-assignment (configured in your Capgo dashboard or backend)
    * - The backend may accept or reject the request based on channel settings
@@ -1034,7 +1039,8 @@ export interface CapacitorUpdaterPlugin {
    * });
    * ```
    *
-   * This sends a request to the Capgo backend linking your device ID to the specified channel.
+   * This sends a request to the Capgo backend to validate the specified channel, then stores the
+   * channel locally on the device.
    *
    * @param options The {@link SetChannelOptions} containing the channel name and optional auto-update trigger.
    * @returns {Promise<ChannelRes>} Channel operation result with status and optional error/message.


### PR DESCRIPTION
## What
- Clarify that plugin `setChannel()` validates with the backend but stores the selected channel locally on the device.
- Document that `setChannel()` does not create or update a backend Device Override and will not appear in the dashboard Device Override UI.
- Regenerate `README.md` and `api.md` from `src/definitions.ts`.

## Why
- Website docs are generated from the updater definitions, so this clarification needs to live in the source JSDoc to survive the next release/docs sync.

## How
- Updated the `setChannel()` JSDoc in `src/definitions.ts`.
- Ran `bun run docgen` to refresh generated docs.

## Testing
- `bun run docgen`
- `bun run fmt`
- `bun run verify:web`
- `bun run eslint`
- `bun run prettier -- --check`

## Not Tested
- `bun run verify` could not complete locally because Android verification requires a Java runtime and this machine has no Java runtime installed. The iOS portion completed successfully before Android stopped.
- `bun run lint` runs SwiftLint and currently reports existing SwiftLint violations in unrelated Swift files; ESLint and prettier pass for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `setChannel()` documentation regarding channel validation, local device storage behavior, and how assignments are displayed in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->