### PR TITLE
[codex] Report native version stats changes

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1332,17 +1332,23 @@ public class CapacitorUpdaterPlugin extends Plugin {
         final String previousVersionOs = this.prefs.getString(LAST_VERSION_OS_PREF_KEY, "");
         final String previousVersionBuild = this.prefs.getString(LAST_VERSION_BUILD_PREF_KEY, "");
         final String previousVersionCode = this.prefs.getString(LAST_VERSION_CODE_PREF_KEY, "");
-
-        if (
+        final boolean osVersionChanged =
             !normalizedVersionOs.isEmpty() &&
             previousVersionOs != null &&
             !previousVersionOs.isEmpty() &&
-            !previousVersionOs.equals(normalizedVersionOs)
-        ) {
+            !previousVersionOs.equals(normalizedVersionOs);
+
+        if (osVersionChanged) {
             final Map<String, String> metadata = new HashMap<>();
             metadata.put("previous_version_os", previousVersionOs);
             metadata.put("current_version_os", normalizedVersionOs);
-            this.implementation.sendStats(OS_VERSION_CHANGED_ACTION, this.implementation.getCurrentBundle().getVersionName(), "", metadata);
+            this.implementation.sendStats(
+                OS_VERSION_CHANGED_ACTION,
+                this.implementation.getCurrentBundle().getVersionName(),
+                "",
+                metadata,
+                () -> this.persistLastVersionOs(normalizedVersionOs)
+            );
         }
 
         final boolean hasPreviousNativeVersion =
@@ -1362,13 +1368,39 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 NATIVE_APP_VERSION_CHANGED_ACTION,
                 this.implementation.getCurrentBundle().getVersionName(),
                 "",
-                metadata
+                metadata,
+                () -> this.persistLastNativeAppVersion(normalizedVersionBuild, normalizedVersionCode)
             );
         }
 
-        this.editor.putString(LAST_VERSION_OS_PREF_KEY, normalizedVersionOs);
-        this.editor.putString(LAST_VERSION_BUILD_PREF_KEY, normalizedVersionBuild);
-        this.editor.putString(LAST_VERSION_CODE_PREF_KEY, normalizedVersionCode);
+        if (!osVersionChanged || !nativeVersionChanged) {
+            if (!osVersionChanged) {
+                this.editor.putString(LAST_VERSION_OS_PREF_KEY, normalizedVersionOs);
+            }
+            if (!nativeVersionChanged) {
+                this.editor.putString(LAST_VERSION_BUILD_PREF_KEY, normalizedVersionBuild);
+                this.editor.putString(LAST_VERSION_CODE_PREF_KEY, normalizedVersionCode);
+            }
+            this.editor.apply();
+        }
+    }
+
+    private void persistLastVersionOs(final String versionOs) {
+        if (this.editor == null) {
+            return;
+        }
+
+        this.editor.putString(LAST_VERSION_OS_PREF_KEY, versionOs);
+        this.editor.apply();
+    }
+
+    private void persistLastNativeAppVersion(final String versionBuild, final String versionCode) {
+        if (this.editor == null) {
+            return;
+        }
+
+        this.editor.putString(LAST_VERSION_BUILD_PREF_KEY, versionBuild);
+        this.editor.putString(LAST_VERSION_CODE_PREF_KEY, versionCode);
         this.editor.apply();
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -1828,9 +1828,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 );
             }
         } else {
-            final boolean enabled = configuredMode != null
-                ? "true".equals(configuredMode)
-                : Boolean.TRUE.equals(this.getConfig().getBoolean("autoUpdate", true));
+            final boolean enabled =
+                configuredMode != null
+                    ? "true".equals(configuredMode)
+                    : Boolean.TRUE.equals(this.getConfig().getBoolean("autoUpdate", true));
             this.autoUpdateMode = enabled
                 ? autoUpdateModeForLegacyDirectUpdateMode(this.resolveLegacyDirectUpdateModeFromConfig())
                 : AUTO_UPDATE_MODE_OFF;
@@ -3689,33 +3690,30 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, false);
         this.editor.apply();
 
-        new Handler(Looper.getMainLooper()).postDelayed(
-            () -> {
-                try {
-                    if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
-                        return;
-                    }
-                    if (getActivity() == null || getActivity().isFinishing()) {
-                        this.previewSessionAlertPending = true;
-                        this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
-                        this.editor.apply();
-                        return;
-                    }
-
-                    new AlertDialog.Builder(getActivity())
-                        .setTitle("Preview started")
-                        .setMessage("Shake your device anytime to reload or leave the test app.")
-                        .setPositiveButton("Got it", (dialog, which) -> dialog.dismiss())
-                        .show();
-                } catch (final Exception e) {
+        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+            try {
+                if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
+                    return;
+                }
+                if (getActivity() == null || getActivity().isFinishing()) {
                     this.previewSessionAlertPending = true;
                     this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
                     this.editor.apply();
-                    logger.warn("Could not show preview session notice: " + e.getMessage());
+                    return;
                 }
-            },
-            600
-        );
+
+                new AlertDialog.Builder(getActivity())
+                    .setTitle("Preview started")
+                    .setMessage("Shake your device anytime to reload or leave the test app.")
+                    .setPositiveButton("Got it", (dialog, which) -> dialog.dismiss())
+                    .show();
+            } catch (final Exception e) {
+                this.previewSessionAlertPending = true;
+                this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
+                this.editor.apply();
+                logger.warn("Could not show preview session notice: " + e.getMessage());
+            }
+        }, 600);
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -119,6 +119,11 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private static final String LAST_FAILED_BUNDLE_PREF_KEY = "CapacitorUpdater.lastFailedBundle";
     private static final String LAST_REPORTED_APP_EXIT_TIMESTAMP_PREF_KEY = "CapacitorUpdater.lastReportedAppExitTimestamp";
     private static final String LAST_WEBVIEW_RENDER_PROCESS_GONE_PREF_KEY = "CapacitorUpdater.lastWebViewRenderProcessGone";
+    private static final String LAST_VERSION_OS_PREF_KEY = "CapacitorUpdater.lastVersionOs";
+    private static final String LAST_VERSION_BUILD_PREF_KEY = "CapacitorUpdater.lastVersionBuild";
+    private static final String LAST_VERSION_CODE_PREF_KEY = "CapacitorUpdater.lastVersionCode";
+    private static final String OS_VERSION_CHANGED_ACTION = "os_version_changed";
+    private static final String NATIVE_APP_VERSION_CHANGED_ACTION = "native_app_version_changed";
     private static final String SPLASH_SCREEN_PLUGIN_ID = "SplashScreen";
     private static final int SPLASH_SCREEN_RETRY_DELAY_MS = 100;
     private static final int SPLASH_SCREEN_MAX_RETRIES = 20;
@@ -857,6 +862,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
             this.clearPreviewSessionForNativeBuildChange();
         }
         this.leavePreviewSessionForLaunchIntentIfNeeded();
+        this.reportNativeVersionStatsIfChanged();
         this.reportPreviousAppExitReasons();
         this.reportPreviousWebViewRenderProcessGone();
         this.installWebViewStatsReporter();
@@ -1297,6 +1303,77 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private boolean hasNativeBuildVersionChanged() {
         final String lastKnownVersion = this.getStoredNativeBuildVersion();
         return !lastKnownVersion.isEmpty() && !lastKnownVersion.equals(this.currentBuildVersion);
+    }
+
+    void reportNativeVersionStatsIfChanged() {
+        if (this.implementation == null || this.prefs == null || this.editor == null) {
+            return;
+        }
+
+        this.reportNativeVersionStatsIfChanged(
+            this.implementation.versionBuild,
+            this.implementation.versionCode,
+            this.implementation.versionOs
+        );
+    }
+
+    void reportNativeVersionStatsIfChanged(
+        final String currentVersionBuild,
+        final String currentVersionCode,
+        final String currentVersionOs
+    ) {
+        if (this.implementation == null || this.prefs == null || this.editor == null) {
+            return;
+        }
+
+        final String normalizedVersionBuild = this.normalizedStatsValue(currentVersionBuild);
+        final String normalizedVersionCode = this.normalizedStatsValue(currentVersionCode);
+        final String normalizedVersionOs = this.normalizedStatsValue(currentVersionOs);
+        final String previousVersionOs = this.prefs.getString(LAST_VERSION_OS_PREF_KEY, "");
+        final String previousVersionBuild = this.prefs.getString(LAST_VERSION_BUILD_PREF_KEY, "");
+        final String previousVersionCode = this.prefs.getString(LAST_VERSION_CODE_PREF_KEY, "");
+
+        if (
+            !normalizedVersionOs.isEmpty() &&
+            previousVersionOs != null &&
+            !previousVersionOs.isEmpty() &&
+            !previousVersionOs.equals(normalizedVersionOs)
+        ) {
+            final Map<String, String> metadata = new HashMap<>();
+            metadata.put("previous_version_os", previousVersionOs);
+            metadata.put("current_version_os", normalizedVersionOs);
+            this.implementation.sendStats(OS_VERSION_CHANGED_ACTION, this.implementation.getCurrentBundle().getVersionName(), "", metadata);
+        }
+
+        final boolean hasPreviousNativeVersion =
+            (previousVersionBuild != null && !previousVersionBuild.isEmpty()) ||
+            (previousVersionCode != null && !previousVersionCode.isEmpty());
+        final boolean nativeVersionChanged =
+            hasPreviousNativeVersion &&
+            (!Objects.equals(previousVersionBuild, normalizedVersionBuild) || !Objects.equals(previousVersionCode, normalizedVersionCode));
+
+        if (nativeVersionChanged) {
+            final Map<String, String> metadata = new HashMap<>();
+            metadata.put("previous_version_build", previousVersionBuild == null ? "" : previousVersionBuild);
+            metadata.put("current_version_build", normalizedVersionBuild);
+            metadata.put("previous_version_code", previousVersionCode == null ? "" : previousVersionCode);
+            metadata.put("current_version_code", normalizedVersionCode);
+            this.implementation.sendStats(
+                NATIVE_APP_VERSION_CHANGED_ACTION,
+                this.implementation.getCurrentBundle().getVersionName(),
+                "",
+                metadata
+            );
+        }
+
+        this.editor.putString(LAST_VERSION_OS_PREF_KEY, normalizedVersionOs);
+        this.editor.putString(LAST_VERSION_BUILD_PREF_KEY, normalizedVersionBuild);
+        this.editor.putString(LAST_VERSION_CODE_PREF_KEY, normalizedVersionCode);
+        this.editor.apply();
+    }
+
+    private String normalizedStatsValue(final String value) {
+        return value == null ? "" : value;
     }
 
     private void reportPreviousAppExitReasons() {
@@ -1751,10 +1828,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 );
             }
         } else {
-            final boolean enabled =
-                configuredMode != null
-                    ? "true".equals(configuredMode)
-                    : Boolean.TRUE.equals(this.getConfig().getBoolean("autoUpdate", true));
+            final boolean enabled = configuredMode != null
+                ? "true".equals(configuredMode)
+                : Boolean.TRUE.equals(this.getConfig().getBoolean("autoUpdate", true));
             this.autoUpdateMode = enabled
                 ? autoUpdateModeForLegacyDirectUpdateMode(this.resolveLegacyDirectUpdateModeFromConfig())
                 : AUTO_UPDATE_MODE_OFF;
@@ -3613,30 +3689,33 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, false);
         this.editor.apply();
 
-        new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            try {
-                if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
-                    return;
-                }
-                if (getActivity() == null || getActivity().isFinishing()) {
+        new Handler(Looper.getMainLooper()).postDelayed(
+            () -> {
+                try {
+                    if (!Boolean.TRUE.equals(this.previewSessionEnabled)) {
+                        return;
+                    }
+                    if (getActivity() == null || getActivity().isFinishing()) {
+                        this.previewSessionAlertPending = true;
+                        this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
+                        this.editor.apply();
+                        return;
+                    }
+
+                    new AlertDialog.Builder(getActivity())
+                        .setTitle("Preview started")
+                        .setMessage("Shake your device anytime to reload or leave the test app.")
+                        .setPositiveButton("Got it", (dialog, which) -> dialog.dismiss())
+                        .show();
+                } catch (final Exception e) {
                     this.previewSessionAlertPending = true;
                     this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
                     this.editor.apply();
-                    return;
+                    logger.warn("Could not show preview session notice: " + e.getMessage());
                 }
-
-                new AlertDialog.Builder(getActivity())
-                    .setTitle("Preview started")
-                    .setMessage("Shake your device anytime to reload or leave the test app.")
-                    .setPositiveButton("Got it", (dialog, which) -> dialog.dismiss())
-                    .show();
-            } catch (final Exception e) {
-                this.previewSessionAlertPending = true;
-                this.editor.putBoolean(PREVIEW_SESSION_ALERT_PENDING_PREF_KEY, true);
-                this.editor.apply();
-                logger.warn("Could not show preview session notice: " + e.getMessage());
-            }
-        }, 600);
+            },
+            600
+        );
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -102,10 +102,21 @@ public class CapgoUpdater {
     private static volatile boolean rateLimitStatisticSent = false;
 
     // Stats batching - queue events and send max once per second
-    private final List<JSONObject> statsQueue = new CopyOnWriteArrayList<>();
+    private final List<QueuedStatsEvent> statsQueue = new CopyOnWriteArrayList<>();
     private final ScheduledExecutorService statsScheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> statsFlushTask = null;
     private static final long STATS_FLUSH_INTERVAL_MS = 1000;
+
+    private static final class QueuedStatsEvent {
+
+        private final JSONObject event;
+        private final Runnable onSent;
+
+        private QueuedStatsEvent(final JSONObject event, final Runnable onSent) {
+            this.event = event;
+            this.onSent = onSent;
+        }
+    }
 
     private final Map<String, CompletableFuture<BundleInfo>> downloadFutures = new ConcurrentHashMap<>();
     private final ExecutorService io = Executors.newSingleThreadExecutor();
@@ -2086,6 +2097,16 @@ public class CapgoUpdater {
     }
 
     public void sendStats(final String action, final String versionName, final String oldVersionName, final Map<String, String> metadata) {
+        this.sendStats(action, versionName, oldVersionName, metadata, null);
+    }
+
+    public void sendStats(
+        final String action,
+        final String versionName,
+        final String oldVersionName,
+        final Map<String, String> metadata,
+        final Runnable onSent
+    ) {
         if (this.previewSession) {
             if (logger != null) {
                 logger.debug("Skipping sendStats during preview session.");
@@ -2120,7 +2141,7 @@ public class CapgoUpdater {
             return;
         }
 
-        statsQueue.add(json);
+        statsQueue.add(new QueuedStatsEvent(json, onSent));
         ensureStatsTimerStarted();
     }
 
@@ -2147,7 +2168,7 @@ public class CapgoUpdater {
         }
 
         // Copy and clear the queue atomically using synchronized block
-        List<JSONObject> eventsToSend;
+        List<QueuedStatsEvent> eventsToSend;
         synchronized (statsQueue) {
             if (statsQueue.isEmpty()) {
                 return;
@@ -2157,8 +2178,8 @@ public class CapgoUpdater {
         }
 
         JSONArray jsonArray = new JSONArray();
-        for (JSONObject event : eventsToSend) {
-            jsonArray.put(event);
+        for (QueuedStatsEvent queuedEvent : eventsToSend) {
+            jsonArray.put(queuedEvent.event);
         }
 
         Request request = new Request.Builder()
@@ -2186,6 +2207,7 @@ public class CapgoUpdater {
                         if (response.isSuccessful()) {
                             logger.info("Stats batch sent successfully");
                             logger.debug("Sent " + eventCount + " events");
+                            runStatsCallbacks(eventsToSend);
                         } else {
                             logger.error("Error sending stats batch");
                             logger.debug("Response code: " + response.code());
@@ -2194,6 +2216,23 @@ public class CapgoUpdater {
                 }
             }
         );
+    }
+
+    private void runStatsCallbacks(final List<QueuedStatsEvent> sentEvents) {
+        for (final QueuedStatsEvent sentEvent : sentEvents) {
+            if (sentEvent.onSent == null) {
+                continue;
+            }
+
+            try {
+                sentEvent.onSent.run();
+            } catch (Exception e) {
+                if (logger != null) {
+                    logger.error("Error running stats sent callback");
+                    logger.debug("Error: " + e.getMessage());
+                }
+            }
+        }
     }
 
     public BundleInfo getBundleInfo(final String id) {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -756,6 +756,7 @@ public class CapacitorUpdaterUnitTest {
         private final List<Map<String, String>> sentStatsMetadata = new ArrayList<>();
         private String lastStatsOldVersionName;
         private Map<String, String> lastStatsMetadata;
+        private boolean acknowledgeStats = true;
 
         PendingReloadFinalizeCapgoUpdater() {
             super(null);
@@ -799,6 +800,20 @@ public class CapacitorUpdaterUnitTest {
             this.lastStatsVersionName = versionName;
             this.lastStatsOldVersionName = oldVersionName;
             this.lastStatsMetadata = metadata;
+        }
+
+        @Override
+        public void sendStats(
+            final String action,
+            final String versionName,
+            final String oldVersionName,
+            final Map<String, String> metadata,
+            final Runnable onSent
+        ) {
+            this.sendStats(action, versionName, oldVersionName, metadata);
+            if (this.acknowledgeStats && onSent != null) {
+                onSent.run();
+            }
         }
     }
 
@@ -1531,7 +1546,35 @@ public class CapacitorUpdaterUnitTest {
             verify(editor).putString("CapacitorUpdater.lastVersionOs", "14");
             verify(editor).putString("CapacitorUpdater.lastVersionBuild", "1.1.0");
             verify(editor).putString("CapacitorUpdater.lastVersionCode", "101");
-            verify(editor).apply();
+            verify(editor, times(2)).apply();
+        }
+    }
+
+    @Test
+    public void testReportNativeVersionStatsKeepsChangedSnapshotPendingUntilStatsAck() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final PendingReloadFinalizeCapgoUpdater updater = new PendingReloadFinalizeCapgoUpdater();
+            final SharedPreferences prefs = mock(SharedPreferences.class);
+            final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+            updater.acknowledgeStats = false;
+
+            plugin.implementation = updater;
+            setPrivateField(plugin, "prefs", prefs);
+            setPrivateField(plugin, "editor", editor);
+            when(prefs.getString("CapacitorUpdater.lastVersionOs", "")).thenReturn("13");
+            when(prefs.getString("CapacitorUpdater.lastVersionBuild", "")).thenReturn("1.0.0");
+            when(prefs.getString("CapacitorUpdater.lastVersionCode", "")).thenReturn("100");
+
+            plugin.reportNativeVersionStatsIfChanged("1.1.0", "101", "14");
+
+            assertEquals(List.of("os_version_changed", "native_app_version_changed"), updater.sentStatsActions);
+            verify(editor, never()).putString("CapacitorUpdater.lastVersionOs", "14");
+            verify(editor, never()).putString("CapacitorUpdater.lastVersionBuild", "1.1.0");
+            verify(editor, never()).putString("CapacitorUpdater.lastVersionCode", "101");
+            verify(editor, never()).apply();
         }
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -749,12 +749,21 @@ public class CapacitorUpdaterUnitTest {
     private static final class PendingReloadFinalizeCapgoUpdater extends CapgoUpdater {
 
         private final Map<String, BundleInfo> bundleInfos = new HashMap<>();
+        private final BundleInfo currentBundle = new BundleInfo("current-id", "1.0.0", BundleStatus.SUCCESS, new Date(), "abc123");
         private String lastStatsAction;
         private String lastStatsVersionName;
+        private final List<String> sentStatsActions = new ArrayList<>();
+        private final List<Map<String, String>> sentStatsMetadata = new ArrayList<>();
         private String lastStatsOldVersionName;
+        private Map<String, String> lastStatsMetadata;
 
         PendingReloadFinalizeCapgoUpdater() {
             super(null);
+        }
+
+        @Override
+        public BundleInfo getCurrentBundle() {
+            return this.currentBundle;
         }
 
         @Override
@@ -769,9 +778,27 @@ public class CapacitorUpdaterUnitTest {
 
         @Override
         public void sendStats(final String action, final String versionName, final String oldVersionName) {
+            this.sentStatsActions.add(action);
+            this.sentStatsMetadata.add(null);
             this.lastStatsAction = action;
             this.lastStatsVersionName = versionName;
             this.lastStatsOldVersionName = oldVersionName;
+            this.lastStatsMetadata = null;
+        }
+
+        @Override
+        public void sendStats(
+            final String action,
+            final String versionName,
+            final String oldVersionName,
+            final Map<String, String> metadata
+        ) {
+            this.sentStatsActions.add(action);
+            this.sentStatsMetadata.add(metadata);
+            this.lastStatsAction = action;
+            this.lastStatsVersionName = versionName;
+            this.lastStatsOldVersionName = oldVersionName;
+            this.lastStatsMetadata = metadata;
         }
     }
 
@@ -1444,6 +1471,66 @@ public class CapacitorUpdaterUnitTest {
             plugin.persistCurrentNativeBuildVersion();
 
             verify(editor).putString("LatestNativeBuildVersion", "8");
+            verify(editor).apply();
+        }
+    }
+
+    @Test
+    public void testReportNativeVersionStatsPersistsFirstSnapshotWithoutEvent() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final PendingReloadFinalizeCapgoUpdater updater = new PendingReloadFinalizeCapgoUpdater();
+            final SharedPreferences prefs = mock(SharedPreferences.class);
+            final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+
+            plugin.implementation = updater;
+            setPrivateField(plugin, "prefs", prefs);
+            setPrivateField(plugin, "editor", editor);
+            when(prefs.getString("CapacitorUpdater.lastVersionOs", "")).thenReturn("");
+            when(prefs.getString("CapacitorUpdater.lastVersionBuild", "")).thenReturn("");
+            when(prefs.getString("CapacitorUpdater.lastVersionCode", "")).thenReturn("");
+
+            plugin.reportNativeVersionStatsIfChanged("1.0.0", "100", "14");
+
+            assertTrue(updater.sentStatsActions.isEmpty());
+            verify(editor).putString("CapacitorUpdater.lastVersionOs", "14");
+            verify(editor).putString("CapacitorUpdater.lastVersionBuild", "1.0.0");
+            verify(editor).putString("CapacitorUpdater.lastVersionCode", "100");
+            verify(editor).apply();
+        }
+    }
+
+    @Test
+    public void testReportNativeVersionStatsSendsChangedOsAndNativeVersionEvents() throws Exception {
+        try (MockedStatic<Looper> looperMock = mockStatic(Looper.class)) {
+            looperMock.when(Looper::getMainLooper).thenReturn(mock(Looper.class));
+
+            final TestableCapacitorUpdaterPlugin plugin = new TestableCapacitorUpdaterPlugin();
+            final PendingReloadFinalizeCapgoUpdater updater = new PendingReloadFinalizeCapgoUpdater();
+            final SharedPreferences prefs = mock(SharedPreferences.class);
+            final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+
+            plugin.implementation = updater;
+            setPrivateField(plugin, "prefs", prefs);
+            setPrivateField(plugin, "editor", editor);
+            when(prefs.getString("CapacitorUpdater.lastVersionOs", "")).thenReturn("13");
+            when(prefs.getString("CapacitorUpdater.lastVersionBuild", "")).thenReturn("1.0.0");
+            when(prefs.getString("CapacitorUpdater.lastVersionCode", "")).thenReturn("100");
+
+            plugin.reportNativeVersionStatsIfChanged("1.1.0", "101", "14");
+
+            assertEquals(List.of("os_version_changed", "native_app_version_changed"), updater.sentStatsActions);
+            assertEquals("13", updater.sentStatsMetadata.get(0).get("previous_version_os"));
+            assertEquals("14", updater.sentStatsMetadata.get(0).get("current_version_os"));
+            assertEquals("1.0.0", updater.sentStatsMetadata.get(1).get("previous_version_build"));
+            assertEquals("1.1.0", updater.sentStatsMetadata.get(1).get("current_version_build"));
+            assertEquals("100", updater.sentStatsMetadata.get(1).get("previous_version_code"));
+            assertEquals("101", updater.sentStatsMetadata.get(1).get("current_version_code"));
+            verify(editor).putString("CapacitorUpdater.lastVersionOs", "14");
+            verify(editor).putString("CapacitorUpdater.lastVersionBuild", "1.1.0");
+            verify(editor).putString("CapacitorUpdater.lastVersionCode", "101");
             verify(editor).apply();
         }
     }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -352,12 +352,12 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             self.clearPreviewSessionForNativeBuildChange()
         }
         self.leavePreviewSessionForLaunchURLIfNeeded()
-        self.reportNativeVersionStatsIfChanged()
 
         if resetWhenUpdate {
             let didResetCurrentBundle = self.resetCurrentBundleForNativeBuildChangeIfNeeded()
             self.cleanupObsoleteVersions(didResetCurrentBundle: didResetCurrentBundle)
         }
+        self.reportNativeVersionStatsIfChanged()
 
         // Load the server
         // This is very much swift specific, android does not do that

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -552,8 +552,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let previousVersionOs = userDefaults.string(forKey: self.lastVersionOsDefaultsKey) ?? ""
         let previousVersionBuild = userDefaults.string(forKey: self.lastVersionBuildDefaultsKey) ?? ""
         let previousVersionCode = userDefaults.string(forKey: self.lastVersionCodeDefaultsKey) ?? ""
+        let osVersionChanged = !normalizedVersionOs.isEmpty && !previousVersionOs.isEmpty && previousVersionOs != normalizedVersionOs
 
-        if !normalizedVersionOs.isEmpty, !previousVersionOs.isEmpty, previousVersionOs != normalizedVersionOs {
+        if osVersionChanged {
             self.implementation.sendStats(
                 action: self.osVersionChangedAction,
                 versionName: self.implementation.getCurrentBundle().getVersionName(),
@@ -561,7 +562,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 metadata: [
                     "previous_version_os": previousVersionOs,
                     "current_version_os": normalizedVersionOs
-                ]
+                ],
+                onSent: { [weak self] in
+                    self?.persistLastVersionOs(normalizedVersionOs)
+                }
             )
         }
 
@@ -578,14 +582,34 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                     "current_version_build": normalizedVersionBuild,
                     "previous_version_code": previousVersionCode,
                     "current_version_code": normalizedVersionCode
-                ]
+                ],
+                onSent: { [weak self] in
+                    self?.persistLastNativeAppVersion(build: normalizedVersionBuild, code: normalizedVersionCode)
+                }
             )
         }
 
-        userDefaults.set(normalizedVersionOs, forKey: self.lastVersionOsDefaultsKey)
-        userDefaults.set(normalizedVersionBuild, forKey: self.lastVersionBuildDefaultsKey)
-        userDefaults.set(normalizedVersionCode, forKey: self.lastVersionCodeDefaultsKey)
-        userDefaults.synchronize()
+        if !osVersionChanged || !nativeVersionChanged {
+            if !osVersionChanged {
+                userDefaults.set(normalizedVersionOs, forKey: self.lastVersionOsDefaultsKey)
+            }
+            if !nativeVersionChanged {
+                userDefaults.set(normalizedVersionBuild, forKey: self.lastVersionBuildDefaultsKey)
+                userDefaults.set(normalizedVersionCode, forKey: self.lastVersionCodeDefaultsKey)
+            }
+            userDefaults.synchronize()
+        }
+    }
+
+    private func persistLastVersionOs(_ versionOs: String) {
+        UserDefaults.standard.set(versionOs, forKey: self.lastVersionOsDefaultsKey)
+        UserDefaults.standard.synchronize()
+    }
+
+    private func persistLastNativeAppVersion(build: String, code: String) {
+        UserDefaults.standard.set(build, forKey: self.lastVersionBuildDefaultsKey)
+        UserDefaults.standard.set(code, forKey: self.lastVersionCodeDefaultsKey)
+        UserDefaults.standard.synchronize()
     }
 
     private func normalizedStatsValue(_ value: String?) -> String {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -105,6 +105,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     private let channelUrlDefaultsKey = "CapacitorUpdater.channelUrl"
     private let defaultChannelDefaultsKey = "CapacitorUpdater.defaultChannel"
     private let lastFailedBundleDefaultsKey = "CapacitorUpdater.lastFailedBundle"
+    private let lastVersionOsDefaultsKey = "CapacitorUpdater.lastVersionOs"
+    private let lastVersionBuildDefaultsKey = "CapacitorUpdater.lastVersionBuild"
+    private let lastVersionCodeDefaultsKey = "CapacitorUpdater.lastVersionCode"
+    private let osVersionChangedAction = "os_version_changed"
+    private let nativeAppVersionChangedAction = "native_app_version_changed"
     private let previewSessionDefaultsKey = "CapacitorUpdater.previewSession"
     private let previewPreviousShakeMenuDefaultsKey = "CapacitorUpdater.previewPreviousShakeMenu"
     private let previewPreviousShakeChannelSelectorDefaultsKey = "CapacitorUpdater.previewPreviousShakeChannelSelector"
@@ -347,6 +352,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             self.clearPreviewSessionForNativeBuildChange()
         }
         self.leavePreviewSessionForLaunchURLIfNeeded()
+        self.reportNativeVersionStatsIfChanged()
 
         if resetWhenUpdate {
             let didResetCurrentBundle = self.resetCurrentBundleForNativeBuildChangeIfNeeded()
@@ -528,6 +534,62 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     func hasNativeBuildVersionChanged() -> Bool {
         let previous = self.storedNativeBuildVersion()
         return previous != "0" && self.currentBuildVersion != previous
+    }
+
+    func reportNativeVersionStatsIfChanged() {
+        self.reportNativeVersionStatsIfChanged(
+            currentVersionBuild: self.implementation.versionBuild,
+            currentVersionCode: self.currentBuildVersion,
+            currentVersionOs: UIDevice.current.systemVersion
+        )
+    }
+
+    func reportNativeVersionStatsIfChanged(currentVersionBuild: String?, currentVersionCode: String?, currentVersionOs: String?) {
+        let normalizedVersionBuild = self.normalizedStatsValue(currentVersionBuild)
+        let normalizedVersionCode = self.normalizedStatsValue(currentVersionCode)
+        let normalizedVersionOs = self.normalizedStatsValue(currentVersionOs)
+        let userDefaults = UserDefaults.standard
+        let previousVersionOs = userDefaults.string(forKey: self.lastVersionOsDefaultsKey) ?? ""
+        let previousVersionBuild = userDefaults.string(forKey: self.lastVersionBuildDefaultsKey) ?? ""
+        let previousVersionCode = userDefaults.string(forKey: self.lastVersionCodeDefaultsKey) ?? ""
+
+        if !normalizedVersionOs.isEmpty, !previousVersionOs.isEmpty, previousVersionOs != normalizedVersionOs {
+            self.implementation.sendStats(
+                action: self.osVersionChangedAction,
+                versionName: self.implementation.getCurrentBundle().getVersionName(),
+                oldVersionName: "",
+                metadata: [
+                    "previous_version_os": previousVersionOs,
+                    "current_version_os": normalizedVersionOs
+                ]
+            )
+        }
+
+        let hasPreviousNativeVersion = !previousVersionBuild.isEmpty || !previousVersionCode.isEmpty
+        let nativeVersionChanged = hasPreviousNativeVersion &&
+            (previousVersionBuild != normalizedVersionBuild || previousVersionCode != normalizedVersionCode)
+        if nativeVersionChanged {
+            self.implementation.sendStats(
+                action: self.nativeAppVersionChangedAction,
+                versionName: self.implementation.getCurrentBundle().getVersionName(),
+                oldVersionName: "",
+                metadata: [
+                    "previous_version_build": previousVersionBuild,
+                    "current_version_build": normalizedVersionBuild,
+                    "previous_version_code": previousVersionCode,
+                    "current_version_code": normalizedVersionCode
+                ]
+            )
+        }
+
+        userDefaults.set(normalizedVersionOs, forKey: self.lastVersionOsDefaultsKey)
+        userDefaults.set(normalizedVersionBuild, forKey: self.lastVersionBuildDefaultsKey)
+        userDefaults.set(normalizedVersionCode, forKey: self.lastVersionCodeDefaultsKey)
+        userDefaults.synchronize()
+    }
+
+    private func normalizedStatsValue(_ value: String?) -> String {
+        value ?? ""
     }
 
     @discardableResult

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -51,10 +51,15 @@ import UIKit
     private static var rateLimitStatisticSent = false
 
     // Stats batching - queue events and send max once per second
-    private var statsQueue: [StatsEvent] = []
+    private var statsQueue: [QueuedStatsEvent] = []
     private let statsQueueLock = NSLock()
     private var statsFlushTimer: Timer?
     private static let statsFlushInterval: TimeInterval = 1.0
+
+    private struct QueuedStatsEvent {
+        let event: StatsEvent
+        let onSent: (() -> Void)?
+    }
 
     private static func sanitizeHeaderValue(_ value: String) -> String {
         if value.isEmpty {
@@ -2474,14 +2479,24 @@ import UIKit
     }()
 
     func sendStats(action: String, versionName: String? = nil, oldVersionName: String? = "") {
-        sendStatsWithMetadata(action: action, versionName: versionName, oldVersionName: oldVersionName, metadata: nil)
+        sendStatsWithMetadata(action: action, versionName: versionName, oldVersionName: oldVersionName, metadata: nil, onSent: nil)
     }
 
     func sendStats(action: String, versionName: String?, oldVersionName: String?, metadata: [String: String]) {
-        sendStatsWithMetadata(action: action, versionName: versionName, oldVersionName: oldVersionName, metadata: metadata)
+        sendStatsWithMetadata(action: action, versionName: versionName, oldVersionName: oldVersionName, metadata: metadata, onSent: nil)
     }
 
-    private func sendStatsWithMetadata(action: String, versionName: String?, oldVersionName: String?, metadata: [String: String]?) {
+    func sendStats(action: String, versionName: String?, oldVersionName: String?, metadata: [String: String], onSent: @escaping () -> Void) {
+        sendStatsWithMetadata(action: action, versionName: versionName, oldVersionName: oldVersionName, metadata: metadata, onSent: onSent)
+    }
+
+    private func sendStatsWithMetadata(
+        action: String,
+        versionName: String?,
+        oldVersionName: String?,
+        metadata: [String: String]?,
+        onSent: (() -> Void)?
+    ) {
         if previewSession {
             logger.debug("Skipping sendStats during preview session.")
             return
@@ -2522,7 +2537,7 @@ import UIKit
         )
 
         statsQueueLock.lock()
-        statsQueue.append(event)
+        statsQueue.append(QueuedStatsEvent(event: event, onSent: onSent))
         statsQueueLock.unlock()
 
         ensureStatsTimerStarted()
@@ -2549,9 +2564,12 @@ import UIKit
             statsQueueLock.unlock()
             return
         }
-        let eventsToSend = statsQueue
+        let queuedEvents = statsQueue
         statsQueue.removeAll()
         statsQueueLock.unlock()
+
+        let eventsToSend = queuedEvents.map(\.event)
+        let onSentCallbacks = queuedEvents.compactMap(\.onSent)
 
         operationQueue.maxConcurrentOperationCount = 1
 
@@ -2570,10 +2588,18 @@ import UIKit
                     return
                 }
 
+                if let statusCode = response.response?.statusCode, !(200...299).contains(statusCode) {
+                    self.logger.error("Error sending stats batch")
+                    self.logger.debug("Response code: \(statusCode)")
+                    semaphore.signal()
+                    return
+                }
+
                 switch response.result {
                 case .success:
                     self.logger.info("Stats batch sent successfully")
                     self.logger.debug("Sent \(eventsToSend.count) events")
+                    onSentCallbacks.forEach { $0() }
                 case let .failure(error):
                     self.logger.error("Error sending stats batch")
                     self.logger.debug("Response: \(response.value?.debugDescription ?? "nil"), Error: \(error.localizedDescription)")

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -104,6 +104,7 @@ private class HealthStatsCapgoUpdater: CapgoUpdater {
     var lastStatsVersionName: String?
     var lastStatsOldVersionName: String?
     var lastStatsMetadata: [String: String]?
+    var acknowledgeStats = true
 
     override func getCurrentBundle() -> BundleInfo {
         currentBundleValue
@@ -123,6 +124,13 @@ private class HealthStatsCapgoUpdater: CapgoUpdater {
         lastStatsVersionName = versionName
         lastStatsOldVersionName = oldVersionName
         lastStatsMetadata = metadata
+    }
+
+    override func sendStats(action: String, versionName: String?, oldVersionName: String?, metadata: [String: String], onSent: @escaping () -> Void) {
+        sendStats(action: action, versionName: versionName, oldVersionName: oldVersionName, metadata: metadata)
+        if acknowledgeStats {
+            onSent()
+        }
     }
 }
 
@@ -1990,6 +1998,33 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionOs"), "17.0")
         XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionBuild"), "1.1.0")
         XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionCode"), "101")
+    }
+
+    func testReportNativeVersionStatsKeepsChangedSnapshotPendingUntilStatsAck() {
+        let values = [
+            "CapacitorUpdater.lastVersionOs": "16.0",
+            "CapacitorUpdater.lastVersionBuild": "1.0.0",
+            "CapacitorUpdater.lastVersionCode": "100"
+        ]
+        for (key, value) in values {
+            UserDefaults.standard.set(value, forKey: key)
+        }
+        defer {
+            for key in values.keys {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let statsImplementation = HealthStatsCapgoUpdater()
+        statsImplementation.acknowledgeStats = false
+        plugin.implementation = statsImplementation
+
+        plugin.reportNativeVersionStatsIfChanged(currentVersionBuild: "1.1.0", currentVersionCode: "101", currentVersionOs: "17.0")
+
+        XCTAssertEqual(statsImplementation.sentStatsActions, ["os_version_changed", "native_app_version_changed"])
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionOs"), "16.0")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionBuild"), "1.0.0")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionCode"), "100")
     }
 
     func testNativeVersionStatsAfterNativeBuildResetUseBuiltinBundle() {

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -91,7 +91,7 @@ private final class FreshDownloadCapgoUpdater: CapgoUpdater {
     }
 }
 
-private final class HealthStatsCapgoUpdater: CapgoUpdater {
+private class HealthStatsCapgoUpdater: CapgoUpdater {
     var currentBundleValue = BundleInfo(
         id: "current-id",
         version: "1.0.0",
@@ -123,6 +123,20 @@ private final class HealthStatsCapgoUpdater: CapgoUpdater {
         lastStatsVersionName = versionName
         lastStatsOldVersionName = oldVersionName
         lastStatsMetadata = metadata
+    }
+}
+
+private final class ResettingHealthStatsCapgoUpdater: HealthStatsCapgoUpdater {
+    private let builtinBundle = BundleInfo(
+        id: BundleInfo.ID_BUILTIN,
+        version: "builtin",
+        status: .SUCCESS,
+        downloaded: BundleInfo.DOWNLOADED_BUILTIN,
+        checksum: "builtin"
+    )
+
+    override func reset(isInternal _: Bool) {
+        currentBundleValue = builtinBundle
     }
 }
 
@@ -1976,6 +1990,41 @@ class CapacitorUpdaterTests: XCTestCase {
         XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionOs"), "17.0")
         XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionBuild"), "1.1.0")
         XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionCode"), "101")
+    }
+
+    func testNativeVersionStatsAfterNativeBuildResetUseBuiltinBundle() {
+        let values = [
+            "LatestNativeBuildVersion": "1",
+            "CapacitorUpdater.lastVersionOs": "17.0",
+            "CapacitorUpdater.lastVersionBuild": "1.0.0",
+            "CapacitorUpdater.lastVersionCode": "1"
+        ]
+        for (key, value) in values {
+            UserDefaults.standard.set(value, forKey: key)
+        }
+        defer {
+            for key in values.keys {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let resetPlugin = TestableCapacitorUpdaterPlugin()
+        let statsImplementation = ResettingHealthStatsCapgoUpdater()
+        statsImplementation.currentBundleValue = BundleInfo(
+            id: "ota-id",
+            version: "ota-version",
+            status: .SUCCESS,
+            downloaded: Date(),
+            checksum: "ota"
+        )
+        resetPlugin.implementation = statsImplementation
+        resetPlugin.setCurrentBuildVersionForTesting("2")
+
+        XCTAssertTrue(resetPlugin.resetCurrentBundleForNativeBuildChangeIfNeeded())
+        resetPlugin.reportNativeVersionStatsIfChanged(currentVersionBuild: "2.0.0", currentVersionCode: "2", currentVersionOs: "17.0")
+
+        XCTAssertEqual(statsImplementation.sentStatsActions, ["native_app_version_changed"])
+        XCTAssertEqual(statsImplementation.lastStatsVersionName, "builtin")
     }
 
     func testResetCurrentBundleForNativeBuildChangeIfNeededResetsSynchronously() {

--- a/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/CapacitorUpdaterPluginTests.swift
@@ -100,6 +100,7 @@ private final class HealthStatsCapgoUpdater: CapgoUpdater {
         checksum: "abc123"
     )
     var sentStatsActions: [String] = []
+    var sentStatsMetadata: [[String: String]?] = []
     var lastStatsVersionName: String?
     var lastStatsOldVersionName: String?
     var lastStatsMetadata: [String: String]?
@@ -110,6 +111,7 @@ private final class HealthStatsCapgoUpdater: CapgoUpdater {
 
     override func sendStats(action: String, versionName: String? = nil, oldVersionName: String? = "") {
         sentStatsActions.append(action)
+        sentStatsMetadata.append(nil)
         lastStatsVersionName = versionName
         lastStatsOldVersionName = oldVersionName
         lastStatsMetadata = nil
@@ -117,6 +119,7 @@ private final class HealthStatsCapgoUpdater: CapgoUpdater {
 
     override func sendStats(action: String, versionName: String?, oldVersionName: String?, metadata: [String: String]) {
         sentStatsActions.append(action)
+        sentStatsMetadata.append(metadata)
         lastStatsVersionName = versionName
         lastStatsOldVersionName = oldVersionName
         lastStatsMetadata = metadata
@@ -1915,6 +1918,64 @@ class CapacitorUpdaterTests: XCTestCase {
         plugin.setCurrentBuildVersionForTesting("2")
 
         XCTAssertTrue(plugin.hasNativeBuildVersionChanged())
+    }
+
+    func testReportNativeVersionStatsPersistsFirstSnapshotWithoutEvent() {
+        let keys = [
+            "CapacitorUpdater.lastVersionOs",
+            "CapacitorUpdater.lastVersionBuild",
+            "CapacitorUpdater.lastVersionCode"
+        ]
+        for key in keys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        defer {
+            for key in keys {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let statsImplementation = HealthStatsCapgoUpdater()
+        plugin.implementation = statsImplementation
+
+        plugin.reportNativeVersionStatsIfChanged(currentVersionBuild: "1.0.0", currentVersionCode: "100", currentVersionOs: "17.0")
+
+        XCTAssertTrue(statsImplementation.sentStatsActions.isEmpty)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionOs"), "17.0")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionBuild"), "1.0.0")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionCode"), "100")
+    }
+
+    func testReportNativeVersionStatsSendsChangedOsAndNativeVersionEvents() {
+        let values = [
+            "CapacitorUpdater.lastVersionOs": "16.0",
+            "CapacitorUpdater.lastVersionBuild": "1.0.0",
+            "CapacitorUpdater.lastVersionCode": "100"
+        ]
+        for (key, value) in values {
+            UserDefaults.standard.set(value, forKey: key)
+        }
+        defer {
+            for key in values.keys {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let statsImplementation = HealthStatsCapgoUpdater()
+        plugin.implementation = statsImplementation
+
+        plugin.reportNativeVersionStatsIfChanged(currentVersionBuild: "1.1.0", currentVersionCode: "101", currentVersionOs: "17.0")
+
+        XCTAssertEqual(statsImplementation.sentStatsActions, ["os_version_changed", "native_app_version_changed"])
+        XCTAssertEqual(statsImplementation.sentStatsMetadata[0]?["previous_version_os"], "16.0")
+        XCTAssertEqual(statsImplementation.sentStatsMetadata[0]?["current_version_os"], "17.0")
+        XCTAssertEqual(statsImplementation.sentStatsMetadata[1]?["previous_version_build"], "1.0.0")
+        XCTAssertEqual(statsImplementation.sentStatsMetadata[1]?["current_version_build"], "1.1.0")
+        XCTAssertEqual(statsImplementation.sentStatsMetadata[1]?["previous_version_code"], "100")
+        XCTAssertEqual(statsImplementation.sentStatsMetadata[1]?["current_version_code"], "101")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionOs"), "17.0")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionBuild"), "1.1.0")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "CapacitorUpdater.lastVersionCode"), "101")
     }
 
     func testResetCurrentBundleForNativeBuildChangeIfNeededResetsSynchronously() {

--- a/scripts/maestro/run-ios-live-update.sh
+++ b/scripts/maestro/run-ios-live-update.sh
@@ -293,6 +293,13 @@ reinstall_example_app() {
   ASSUME_CLEAN_INSTALL=0
 }
 
+reset_ios_maestro_driver() {
+  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner >/dev/null 2>&1 || true
+  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests >/dev/null 2>&1 || true
+  pkill -f 'maestro-driver-iosUITests' >/dev/null 2>&1 || true
+  pkill -x xcodebuild >/dev/null 2>&1 || true
+}
+
 control_server() {
   local action="$1"
   local scenario="$2"
@@ -442,7 +449,7 @@ run_flow() {
       echo "Retrying iOS Maestro flow after simulator/XCTest instability: ${flow_path}" >&2
       rm -f "$output_file"
       xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
-      xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
+      reset_ios_maestro_driver
       boot_simulator
       reinstall_example_app
       sleep 5

--- a/scripts/maestro/run-ios-live-update.sh
+++ b/scripts/maestro/run-ios-live-update.sh
@@ -130,6 +130,22 @@ PY
   return $?
 }
 
+run_cleanup_command() {
+  local timeout_seconds="$1"
+  shift
+
+  set +e
+  run_with_timeout "$timeout_seconds" "$@" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ $status -eq 124 ]]; then
+    echo "Timed out after ${timeout_seconds}s while cleaning up: $*" >&2
+  fi
+
+  return 0
+}
+
 debug_log_has_retryable_failure() {
   local debug_log="$1"
 
@@ -285,7 +301,7 @@ reinstall_example_app() {
   if [[ "$ASSUME_CLEAN_INSTALL" == "1" ]]; then
     echo "Installing iOS app without pre-uninstall on clean simulator."
   else
-    xcrun simctl uninstall "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
+    run_cleanup_command 20 xcrun simctl uninstall "$SIMULATOR_ID" "$APP_ID"
   fi
 
   xcrun simctl install "$SIMULATOR_ID" "$APP_PATH"
@@ -294,10 +310,10 @@ reinstall_example_app() {
 }
 
 reset_ios_maestro_driver() {
-  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner >/dev/null 2>&1 || true
-  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests >/dev/null 2>&1 || true
-  pkill -f 'maestro-driver-iosUITests' >/dev/null 2>&1 || true
-  pkill -x xcodebuild >/dev/null 2>&1 || true
+  run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner
+  run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests
+  run_cleanup_command 5 pkill -f 'maestro-driver-iosUITests'
+  run_cleanup_command 5 pkill -x xcodebuild
 }
 
 control_server() {
@@ -448,7 +464,7 @@ run_flow() {
     }; then
       echo "Retrying iOS Maestro flow after simulator/XCTest instability: ${flow_path}" >&2
       rm -f "$output_file"
-      xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
+      run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID"
       reset_ios_maestro_driver
       boot_simulator
       reinstall_example_app

--- a/scripts/maestro/run-ios-live-update.sh
+++ b/scripts/maestro/run-ios-live-update.sh
@@ -145,6 +145,25 @@ run_cleanup_command() {
 
   return 0
 }
+maestro_xcodebuild_pids() {
+  local driver_pattern="maestro-driver-iosUITests"
+
+  ps ax -o pid= -o command= |
+    awk -v driver="$driver_pattern" '
+      $0 ~ /xcodebuild/ && index($0, driver) > 0 && $0 !~ /awk/ {
+        print $1
+      }
+    '
+}
+
+terminate_maestro_xcodebuild() {
+  local pid=""
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    run_cleanup_command 5 kill "$pid"
+  done < <(maestro_xcodebuild_pids)
+}
 
 debug_log_has_retryable_failure() {
   local debug_log="$1"
@@ -313,7 +332,7 @@ reset_ios_maestro_driver() {
   run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner
   run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests
   run_cleanup_command 5 pkill -f 'maestro-driver-iosUITests'
-  run_cleanup_command 5 pkill -x xcodebuild
+  terminate_maestro_xcodebuild
 }
 
 control_server() {

--- a/scripts/test-maestro-ios.sh
+++ b/scripts/test-maestro-ios.sh
@@ -111,6 +111,25 @@ run_cleanup_command() {
 
   return 0
 }
+maestro_xcodebuild_pids() {
+  local driver_pattern="maestro-driver-iosUITests"
+
+  ps ax -o pid= -o command= |
+    awk -v driver="$driver_pattern" '
+      $0 ~ /xcodebuild/ && index($0, driver) > 0 && $0 !~ /awk/ {
+        print $1
+      }
+    '
+}
+
+terminate_maestro_xcodebuild() {
+  local pid=""
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    run_cleanup_command 5 kill "$pid"
+  done < <(maestro_xcodebuild_pids)
+}
 
 install_example_app() {
   local started="$SECONDS"
@@ -131,7 +150,7 @@ reset_ios_maestro_driver() {
   run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner
   run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests
   run_cleanup_command 5 pkill -f 'maestro-driver-iosUITests'
-  run_cleanup_command 5 pkill -x xcodebuild
+  terminate_maestro_xcodebuild
 }
 
 wait_for_server() {

--- a/scripts/test-maestro-ios.sh
+++ b/scripts/test-maestro-ios.sh
@@ -96,14 +96,30 @@ PY
   return $?
 }
 
+run_cleanup_command() {
+  local timeout_seconds="$1"
+  shift
+
+  set +e
+  run_with_timeout "$timeout_seconds" "$@" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ $status -eq 124 ]]; then
+    echo "Timed out after ${timeout_seconds}s while cleaning up: $*" >&2
+  fi
+
+  return 0
+}
+
 install_example_app() {
   local started="$SECONDS"
 
   if [[ "$ASSUME_CLEAN_INSTALL" == "1" ]]; then
     echo "Installing iOS app without pre-uninstall on clean simulator."
   else
-    xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
-    xcrun simctl uninstall "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
+    run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID"
+    run_cleanup_command 20 xcrun simctl uninstall "$SIMULATOR_ID" "$APP_ID"
   fi
 
   xcrun simctl install "$SIMULATOR_ID" "$APP_PATH"
@@ -112,10 +128,10 @@ install_example_app() {
 }
 
 reset_ios_maestro_driver() {
-  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner >/dev/null 2>&1 || true
-  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests >/dev/null 2>&1 || true
-  pkill -f 'maestro-driver-iosUITests' >/dev/null 2>&1 || true
-  pkill -x xcodebuild >/dev/null 2>&1 || true
+  run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner
+  run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests
+  run_cleanup_command 5 pkill -f 'maestro-driver-iosUITests'
+  run_cleanup_command 5 pkill -x xcodebuild
 }
 
 wait_for_server() {
@@ -460,7 +476,7 @@ while (( attempt <= MAESTRO_TEST_RETRIES )); do
   if (( attempt < MAESTRO_TEST_RETRIES )) && { [[ $status -eq 124 ]] || grep -Eq "$FLOW_RETRY_PATTERN" "$output_file"; }; then
     echo "Retrying iOS Maestro smoke flow after simulator/XCTest instability." >&2
     rm -f "$output_file"
-    xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
+    run_cleanup_command 10 xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID"
     reset_ios_maestro_driver
     run_with_timeout "$SIMULATOR_BOOT_TIMEOUT_SECONDS" xcrun simctl bootstatus "$SIMULATOR_ID" -b || true
     reset_fake_server

--- a/scripts/test-maestro-ios.sh
+++ b/scripts/test-maestro-ios.sh
@@ -111,6 +111,13 @@ install_example_app() {
   ASSUME_CLEAN_INSTALL=0
 }
 
+reset_ios_maestro_driver() {
+  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests.xctrunner >/dev/null 2>&1 || true
+  xcrun simctl terminate "$SIMULATOR_ID" dev.mobile.maestro-driver-iosUITests >/dev/null 2>&1 || true
+  pkill -f 'maestro-driver-iosUITests' >/dev/null 2>&1 || true
+  pkill -x xcodebuild >/dev/null 2>&1 || true
+}
+
 wait_for_server() {
   for _ in $(seq 1 30); do
     if curl --silent --fail "$HOST_SERVER_URL/health" >/dev/null; then
@@ -454,8 +461,7 @@ while (( attempt <= MAESTRO_TEST_RETRIES )); do
     echo "Retrying iOS Maestro smoke flow after simulator/XCTest instability." >&2
     rm -f "$output_file"
     xcrun simctl terminate "$SIMULATOR_ID" "$APP_ID" >/dev/null 2>&1 || true
-    xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
-    xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
+    reset_ios_maestro_driver
     run_with_timeout "$SIMULATOR_BOOT_TIMEOUT_SECONDS" xcrun simctl bootstatus "$SIMULATOR_ID" -b || true
     reset_fake_server
     if [[ "${CAPGO_MAESTRO_IOS_REINSTALL_ON_RETRY:-0}" == "1" ]]; then


### PR DESCRIPTION
## What
- Report `os_version_changed` and `native_app_version_changed` stats from iOS and Android when the app opens and detects persisted native values changed.
- Persist the first observed OS/native app version snapshot without sending an event.
- Add iOS and Android tests covering first snapshot persistence and changed-version reporting.

## Why
- We need updater clients to send stats when the user OS version changes or the native app version/build changes, without requiring the event to happen during an update flow.

## How
- Store the last observed OS, native build/version, and native code/build number in platform preferences.
- On plugin load, compare the stored values to current native values and send stats with previous/current metadata when values changed.
- Keep the comparison backward-compatible by only reporting after a previous snapshot exists.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/martindonadieu/Library/Android/sdk bun run verify` (iOS build passed; Android initially needed dependencies installed, then rerun below)
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/martindonadieu/Library/Android/sdk bun run verify:android`
- `bun run verify:web`
- `bun run test:ios` (rerun passed after resetting a simulator boot failure)

## Not Tested
- Manual device validation on physical iOS/Android devices.

Backend support PR: https://github.com/Cap-go/capgo/pull/2490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and tracking of native OS version and native app version changes across Android and iOS, with stats reporting when changes are detected.
* **Improvements**
  * Enhanced stats batching to support per-event completion callbacks and execute them only after successful delivery.
* **Tests**
  * Expanded unit test coverage to verify initial snapshot persistence and correct emitted stats events/metadata behavior across scenarios.
* **Chores**
  * Improved iOS Maestro test automation cleanup and added targeted driver reset logic with timeout-safe command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->