### PR TITLE
fix(ios): restore manifest download concurrency regressed in #779

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -1060,8 +1060,8 @@ import UIKit
 
         let totalFiles = manifest.count
 
-        // Keep this bounded because each manifest operation waits on a URLSession callback.
-        manifestDownloadQueue.maxConcurrentOperationCount = min(8, max(1, totalFiles))
+        // Configure concurrent operation count similar to Android: min(64, max(32, totalFiles))
+        manifestDownloadQueue.maxConcurrentOperationCount = min(64, max(32, totalFiles))
 
         // Thread-safe counters for concurrent operations
         let completedFiles = AtomicCounter()


### PR DESCRIPTION
## Summary

iOS manifest (delta) updates became significantly slower starting in **8.47.0**. The cause is the manifest download concurrency, which was lowered as an incidental change in #779:

```diff
- // Keep this bounded because each manifest operation waits on a URLSession callback.
- manifestDownloadQueue.maxConcurrentOperationCount = min(8, max(1, totalFiles))
+ // Configure concurrent operation count similar to Android: min(64, max(32, totalFiles))
+ manifestDownloadQueue.maxConcurrentOperationCount = min(64, max(32, totalFiles))
```

Android was never changed and still uses `Math.min(64, Math.max(32, totalFiles))` (`DownloadService.java`), so this restores cross-platform parity with the value iOS itself used before #779.

## Why it matters

Manifest downloads are **latency-bound**, not bandwidth-bound. Each file is a separate request, and ~95% of each request is spent waiting for the server's first byte (TTFB), not transferring data. Total time ≈ `files × TTFB / concurrency`, so cutting concurrency 4–8× slowed real-world updates proportionally.

Measured on a delta update (292 changed files, 4.93 MB), the regression added tens of seconds versus the pre-8.47.0 behavior.

## Change

- Restore manifest download concurrency to `min(64, max(32, totalFiles))`, matching Android.

One-line change, iOS only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased the number of files that can be downloaded at the same time during manifest updates, which should improve speed for larger downloads.
  * Better matches higher-concurrency update behavior for more efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->