### PR TITLE
Switch release changelog to Cloudflare Workers AI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         run: bun run build
       - name: Generate AI changelog
         id: changelog
+        continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -67,11 +68,11 @@ jobs:
           body: |
             ## 🆕 Changelog
             
-            ${{ steps.changelog.outputs.result }}
+            ${{ steps.changelog.outputs.result || '_Changelog was not generated automatically for this release._' }}
             
             ---
 
-            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
+            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag || github.ref_name }}...${{ steps.changelog.outputs.to_tag || github.ref_name }}
           make_latest: true
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,10 @@ jobs:
         run: bun run build
       - name: Generate AI changelog
         id: changelog
-        uses: mistricky/ccc@v0.2.6
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929 
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bun run changelog:ai
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "watch": "tsc --watch",
     "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs",
+    "changelog:ai": "node scripts/generate-ai-changelog.mjs",
     "example:install": "cd example-app && bun install --frozen-lockfile",
     "example:build": "bun run build && cd example-app && bun install --frozen-lockfile && bun run build"
   },

--- a/scripts/generate-ai-changelog.mjs
+++ b/scripts/generate-ai-changelog.mjs
@@ -4,7 +4,7 @@
  * Invoked from build.yml on tag releases via `bun run changelog:ai`.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
 const DEFAULT_MODEL = '@cf/moonshotai/kimi-k2.7-code';
@@ -19,8 +19,8 @@ function parseArgs(argv) {
   return args;
 }
 
-function sh(cmd) {
-  return execSync(cmd, { encoding: 'utf8' }).trim();
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
 }
 
 function resolveTags({ fromTag, toTag }) {
@@ -34,13 +34,14 @@ function resolveTags({ fromTag, toTag }) {
     throw new Error('Missing target tag. Set GITHUB_REF to refs/tags/<tag> or pass --to-tag.');
   }
 
-  const previousTag = fromTag ?? sh(`git describe --tags --abbrev=0 "${currentTag}^"`);
+  const previousTag = fromTag ?? git(['describe', '--tags', '--abbrev=0', `${currentTag}^`]);
   return { previousTag, currentTag };
 }
 
 function buildPrompt(previousTag, currentTag) {
-  const commits = sh(`git log ${previousTag}..${currentTag} --pretty=format:%s`);
-  const diffStat = sh(`git diff --stat ${previousTag}..${currentTag} | tail -1`);
+  const commits = git(['log', `${previousTag}..${currentTag}`, '--pretty=format:%s']);
+  const diffLines = git(['diff', '--stat', `${previousTag}..${currentTag}`]).split('\n');
+  const diffStat = diffLines.at(-1)?.trim() ?? '';
 
   return `You are a technical writer creating a changelog for a software project.
 
@@ -101,7 +102,7 @@ async function generateChangelog(prompt, model) {
   }
 
   const content = payload.result?.choices?.[0]?.message?.content ?? payload.result?.response;
-  if (!content) {
+  if (!content || typeof content !== 'string') {
     throw new Error('Cloudflare AI returned an empty changelog response');
   }
 
@@ -129,7 +130,8 @@ console.error(`Range: ${previousTag}..${currentTag}`);
 try {
   const result = await generateChangelog(prompt, model);
   writeGithubOutput({ result, fromTag: previousTag, toTag: currentTag });
-} catch {
-  console.error('Changelog generation failed');
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  console.error(`Changelog generation failed: ${message}`);
   process.exit(1);
 }

--- a/scripts/generate-ai-changelog.mjs
+++ b/scripts/generate-ai-changelog.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Generate a release changelog with Cloudflare Workers AI in CI.
+ * Invoked from build.yml on tag releases via `bun run changelog:ai`.
+ */
+
+import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const DEFAULT_MODEL = '@cf/moonshotai/kimi-k2.7-code';
+
+function parseArgs(argv) {
+  const args = { fromTag: process.env.FROM_TAG, toTag: process.env.TO_TAG };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--from-tag') args.fromTag = argv[++i];
+    if (argv[i] === '--to-tag') args.toTag = argv[++i];
+    if (argv[i] === '--model') args.model = argv[++i];
+  }
+  return args;
+}
+
+function sh(cmd) {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function resolveTags({ fromTag, toTag }) {
+  const currentTag =
+    toTag ??
+    (process.env.GITHUB_REF?.startsWith('refs/tags/')
+      ? process.env.GITHUB_REF.replace('refs/tags/', '')
+      : null);
+
+  if (!currentTag) {
+    throw new Error('Missing target tag. Set GITHUB_REF to refs/tags/<tag> or pass --to-tag.');
+  }
+
+  const previousTag = fromTag ?? sh(`git describe --tags --abbrev=0 "${currentTag}^"`);
+  return { previousTag, currentTag };
+}
+
+function buildPrompt(previousTag, currentTag) {
+  const commits = sh(`git log ${previousTag}..${currentTag} --pretty=format:%s`);
+  const diffStat = sh(`git diff --stat ${previousTag}..${currentTag} | tail -1`);
+
+  return `You are a technical writer creating a changelog for a software project.
+
+There are changes in the git repository between two points:
+- From tag: ${previousTag}
+- To tag: ${currentTag}
+- Commits:
+${commits || '(none)'}
+- Diff summary: ${diffStat || '(no file changes)'}
+
+## Instructions:
+1. **Categorize changes** using standard changelog categories:
+   - **Added**: New features
+   - **Changed**: Changes in existing functionality
+   - **Deprecated**: Soon-to-be removed features
+   - **Removed**: Removed features
+   - **Fixed**: Bug fixes
+   - **Security**: Security improvements
+
+2. **Write clear, user-focused descriptions** that explain:
+   - What changed from a user's perspective
+   - Why it matters
+   - Any breaking changes or migration notes
+
+3. **Use consistent formatting**:
+   - Each item should be a concise bullet point
+   - Start with an action verb when possible
+   - Group related changes together
+
+4. **Focus on semantic meaning** rather than technical implementation details
+
+Output ONLY the changelog content in markdown format. Do NOT include any explanatory text, metadata, introductory phrases like "Based on the git analysis" or "Here's the changelog", or concluding remarks. Start IMMEDIATELY with the changelog categories and items (e.g., "## Added"). Do not include version numbers or dates. Do not preface your response with any text whatsoever.`;
+}
+
+async function generateChangelog(prompt, model) {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+  if (!accountId || !apiToken) {
+    throw new Error('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required.');
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok || !payload.success) {
+    throw new Error(`Cloudflare AI request failed (${response.status}): ${JSON.stringify(payload.errors ?? payload)}`);
+  }
+
+  const content = payload.result?.choices?.[0]?.message?.content ?? payload.result?.response;
+  if (!content) {
+    throw new Error(`Unexpected Cloudflare AI response: ${JSON.stringify(payload.result)}`);
+  }
+
+  return content.trim();
+}
+
+function writeGithubOutput({ result, fromTag, toTag }) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+
+  const delimiter = `changelog_${Date.now()}`;
+  appendFileSync(outputFile, `result<<${delimiter}\n${result}\n${delimiter}\n`);
+  appendFileSync(outputFile, `from_tag=${fromTag}\n`);
+  appendFileSync(outputFile, `to_tag=${toTag}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const model = args.model ?? process.env.CLOUDFLARE_AI_MODEL ?? DEFAULT_MODEL;
+  const { previousTag, currentTag } = resolveTags(args);
+  const prompt = buildPrompt(previousTag, currentTag);
+
+  console.error(`Generating changelog with ${model}`);
+  console.error(`Range: ${previousTag}..${currentTag}`);
+
+  const result = await generateChangelog(prompt, model);
+  console.log(result);
+  writeGithubOutput({ result, fromTag: previousTag, toTag: currentTag });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/generate-ai-changelog.mjs
+++ b/scripts/generate-ai-changelog.mjs
@@ -97,12 +97,12 @@ async function generateChangelog(prompt, model) {
 
   const payload = await response.json();
   if (!response.ok || !payload.success) {
-    throw new Error(`Cloudflare AI request failed (${response.status}): ${JSON.stringify(payload.errors ?? payload)}`);
+    throw new Error(`Cloudflare AI request failed with status ${response.status}`);
   }
 
   const content = payload.result?.choices?.[0]?.message?.content ?? payload.result?.response;
   if (!content) {
-    throw new Error(`Unexpected Cloudflare AI response: ${JSON.stringify(payload.result)}`);
+    throw new Error('Cloudflare AI returned an empty changelog response');
   }
 
   return content.trim();
@@ -129,7 +129,7 @@ console.error(`Range: ${previousTag}..${currentTag}`);
 try {
   const result = await generateChangelog(prompt, model);
   writeGithubOutput({ result, fromTag: previousTag, toTag: currentTag });
-} catch (error) {
-  console.error(error instanceof Error ? error.message : error);
+} catch {
+  console.error('Changelog generation failed');
   process.exit(1);
 }

--- a/scripts/generate-ai-changelog.mjs
+++ b/scripts/generate-ai-changelog.mjs
@@ -118,21 +118,18 @@ function writeGithubOutput({ result, fromTag, toTag }) {
   appendFileSync(outputFile, `to_tag=${toTag}\n`);
 }
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
-  const model = args.model ?? process.env.CLOUDFLARE_AI_MODEL ?? DEFAULT_MODEL;
-  const { previousTag, currentTag } = resolveTags(args);
-  const prompt = buildPrompt(previousTag, currentTag);
+const args = parseArgs(process.argv.slice(2));
+const model = args.model ?? process.env.CLOUDFLARE_AI_MODEL ?? DEFAULT_MODEL;
+const { previousTag, currentTag } = resolveTags(args);
+const prompt = buildPrompt(previousTag, currentTag);
 
-  console.error(`Generating changelog with ${model}`);
-  console.error(`Range: ${previousTag}..${currentTag}`);
+console.error(`Generating changelog with ${model}`);
+console.error(`Range: ${previousTag}..${currentTag}`);
 
+try {
   const result = await generateChangelog(prompt, model);
-  console.log(result);
   writeGithubOutput({ result, fromTag: previousTag, toTag: currentTag });
-}
-
-main().catch((error) => {
+} catch (error) {
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);
-});
+}


### PR DESCRIPTION
## Summary
- Replace `mistricky/ccc` (Claude) with a CI-only script that generates release changelogs via Cloudflare Workers AI.
- Use `@cf/moonshotai/kimi-k2.7-code` as the default model.
- Wire `build.yml` to `bun run changelog:ai` with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.

## Test plan
- [ ] CI `test` workflow passes on this PR
- [ ] Confirm `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are available as org/repo secrets before the next tag release
- [ ] Validate on the next tag release that the GitHub release body is populated with the AI changelog


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated changelog generation for releases, producing a markdown summary of recent changes.
  * The release workflow now uses a new generation process with clearer input handling and output formatting.

* **Bug Fixes**
  * Improved reliability by validating required settings and failing cleanly when changelog generation cannot complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->