### PR TITLE
test: add RSA public-decrypt native contract fixtures

### DIFF
--- a/android/src/test/java/ee/forgr/capacitor_updater/RsaContractTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/RsaContractTest.java
@@ -1,0 +1,169 @@
+package ee.forgr.capacitor_updater;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.PublicKey;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class RsaContractTest {
+
+    @BeforeClass
+    public static void setUpClass() {
+        CryptoCipher.setLogger(new Logger("RsaContractTest", new Logger.Options(Logger.LogLevel.silent)));
+    }
+
+    private static JSONObject contract() {
+        try {
+            return new JSONObject(new String(Files.readAllBytes(contractFile()), StandardCharsets.UTF_8));
+        } catch (Exception error) {
+            throw new AssertionError("Unable to load RSA contract fixture", error);
+        }
+    }
+
+    private static Path contractFile() throws IOException {
+        Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        while (current != null) {
+            Path candidate = current.resolve("native-contract-tests/crypto-rsa.json");
+            if (Files.exists(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IOException("native-contract-tests/crypto-rsa.json not found");
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        int len = hex.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4) + Character.digit(hex.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+
+    private static String fixturePublicKey() throws Exception {
+        return contract().getString("publicKeyPem");
+    }
+
+    @Test
+    public void rsaPublicDecryptMatchesNativeContract() throws Exception {
+        String publicKeyPem = fixturePublicKey();
+        PublicKey publicKey = CryptoCipher.stringToPublicKey(publicKeyPem);
+        JSONArray cases = contract().getJSONArray("rsaPublicDecrypt");
+
+        for (int index = 0; index < cases.length(); index++) {
+            JSONObject testCase = cases.getJSONObject(index);
+            String id = testCase.getString("id");
+            String ciphertextHex = testCase.getJSONObject("input").getString("ciphertextHex");
+            String expectedPlaintextHex = testCase.getJSONObject("expect").getString("plaintextHex");
+
+            byte[] decrypted = CryptoCipher.decryptRSA(hexToBytes(ciphertextHex), publicKey);
+            assertNotNull(id, decrypted);
+            assertEquals(id, expectedPlaintextHex, bytesToHex(decrypted));
+        }
+    }
+
+    @Test
+    public void decryptChecksumMatchesNativeContract() throws Exception {
+        String publicKeyPem = fixturePublicKey();
+        JSONArray cases = contract().getJSONArray("decryptChecksum");
+
+        for (int index = 0; index < cases.length(); index++) {
+            JSONObject testCase = cases.getJSONObject(index);
+            String id = testCase.getString("id");
+            String checksumHex = testCase.getJSONObject("input").getString("checksumHex");
+            String expectedDecryptedHex = testCase.getJSONObject("expect").getString("decryptedHex");
+
+            String result = CryptoCipher.decryptChecksum(checksumHex, publicKeyPem);
+            assertEquals(id, expectedDecryptedHex, result);
+        }
+    }
+
+    @Test
+    public void decryptChecksumInvalidMatchesNativeContract() throws Exception {
+        String publicKeyPem = fixturePublicKey();
+        JSONArray cases = contract().getJSONArray("decryptChecksumInvalid");
+
+        for (int index = 0; index < cases.length(); index++) {
+            JSONObject testCase = cases.getJSONObject(index);
+            String id = testCase.getString("id");
+            String checksumHex = testCase.getJSONObject("input").getString("checksumHex");
+            boolean shouldThrow = testCase.getJSONObject("expect").getBoolean("throws");
+
+            if (shouldThrow) {
+                try {
+                    CryptoCipher.decryptChecksum(checksumHex, publicKeyPem);
+                    fail(id + ": expected decryptChecksum to throw");
+                } catch (IOException ignored) {
+                    // expected
+                }
+            }
+        }
+    }
+
+    @Test
+    public void calcKeyIdMatchesNativeContract() throws Exception {
+        JSONArray cases = contract().getJSONArray("calcKeyId");
+
+        for (int index = 0; index < cases.length(); index++) {
+            JSONObject testCase = cases.getJSONObject(index);
+            String id = testCase.getString("id");
+            String publicKeyPem = testCase.getJSONObject("input").getString("publicKeyPem");
+            String expectedKeyId = testCase.getJSONObject("expect").getString("keyId");
+
+            assertEquals(id, expectedKeyId, CryptoCipher.calcKeyId(publicKeyPem));
+        }
+    }
+
+    @Test
+    public void rsaPublicKeyLoadMatchesNativeContract() throws Exception {
+        JSONArray cases = contract().getJSONArray("rsaPublicKeyLoad");
+
+        for (int index = 0; index < cases.length(); index++) {
+            JSONObject testCase = cases.getJSONObject(index);
+            String id = testCase.getString("id");
+            String publicKeyPem = testCase.getJSONObject("input").getString("publicKeyPem");
+            boolean shouldLoad = testCase.getJSONObject("expect").getBoolean("loads");
+
+            PublicKey loaded = null;
+            try {
+                loaded = CryptoCipher.stringToPublicKey(publicKeyPem);
+            } catch (Exception ignored) {
+                loaded = null;
+            }
+
+            if (shouldLoad) {
+                assertNotNull(id, loaded);
+            } else {
+                assertNull(id, loaded);
+            }
+        }
+    }
+}

--- a/ios/Tests/CapacitorUpdaterPluginTests/RsaContractTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/RsaContractTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import XCTest
+@testable import CapacitorUpdaterPlugin
+
+final class RsaContractTests: XCTestCase {
+    private static let contract: [String: Any] = {
+        do {
+            let data = try Data(contentsOf: contractFileURL())
+            let value = try JSONSerialization.jsonObject(with: data)
+            guard let contract = value as? [String: Any] else {
+                throw ContractError.invalidRoot
+            }
+            return contract
+        } catch {
+            XCTFail("Unable to load RSA contract fixture: \(error)")
+            return [:]
+        }
+    }()
+
+    private enum ContractError: Error {
+        case missingFixture
+        case invalidRoot
+        case invalidCases(String)
+        case invalidCase(String)
+    }
+
+    override class func setUp() {
+        super.setUp()
+        CryptoCipher.setLogger(Logger(withTag: "RsaContractTests", options: Logger.Options(level: .silent)))
+    }
+
+    private static func contractFileURL() throws -> URL {
+        let fileManager = FileManager.default
+        let roots = [
+            URL(fileURLWithPath: fileManager.currentDirectoryPath),
+            URL(fileURLWithPath: #filePath)
+        ]
+
+        for root in roots {
+            var current = root
+            while current.path != "/" {
+                let candidate = current
+                    .appendingPathComponent("native-contract-tests")
+                    .appendingPathComponent("crypto-rsa.json")
+                if fileManager.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
+                current.deleteLastPathComponent()
+            }
+        }
+        throw ContractError.missingFixture
+    }
+
+    private func contractCases(_ key: String) throws -> [[String: Any]] {
+        guard let cases = Self.contract[key] as? [[String: Any]] else {
+            throw ContractError.invalidCases(key)
+        }
+        return cases
+    }
+
+    private func dictionary(_ source: [String: Any], _ key: String, id: String) throws -> [String: Any] {
+        guard let value = source[key] as? [String: Any] else {
+            throw ContractError.invalidCase("\(id).\(key)")
+        }
+        return value
+    }
+
+    private func string(_ source: [String: Any], _ key: String, id: String) throws -> String {
+        guard let value = source[key] as? String else {
+            throw ContractError.invalidCase("\(id).\(key)")
+        }
+        return value
+    }
+
+    private func bool(_ source: [String: Any], _ key: String, id: String) throws -> Bool {
+        guard let value = source[key] as? Bool else {
+            throw ContractError.invalidCase("\(id).\(key)")
+        }
+        return value
+    }
+
+    private func fixturePublicKey() throws -> String {
+        if let key = Self.contract["publicKeyPem"] as? String {
+            return key
+        }
+        throw ContractError.invalidRoot
+    }
+
+    private func hexToData(_ hex: String) -> Data? {
+        var data = Data()
+        var iterator = hex.makeIterator()
+        while let char1 = iterator.next(), let char2 = iterator.next() {
+            guard let byte = UInt8(String([char1, char2]), radix: 16) else {
+                return nil
+            }
+            data.append(byte)
+        }
+        return data
+    }
+
+    private func dataToHex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    func testRsaPublicDecryptMatchesNativeContract() throws {
+        let publicKey = try fixturePublicKey()
+        guard let rsaPublicKey = RSAPublicKey.load(rsaPublicKey: publicKey) else {
+            XCTFail("Fixture public key must load")
+            return
+        }
+
+        for testCase in try contractCases("rsaPublicDecrypt") {
+            let id = try string(testCase, "id", id: "rsaPublicDecrypt")
+            let input = try dictionary(testCase, "input", id: id)
+            let expect = try dictionary(testCase, "expect", id: id)
+            let ciphertextHex = try string(input, "ciphertextHex", id: id)
+            let expectedPlaintextHex = try string(expect, "plaintextHex", id: id)
+
+            guard let ciphertext = hexToData(ciphertextHex) else {
+                XCTFail("\(id): invalid ciphertext hex")
+                continue
+            }
+
+            guard let decrypted = rsaPublicKey.decrypt(data: ciphertext) else {
+                XCTFail("\(id): RSA public decrypt returned nil")
+                continue
+            }
+
+            XCTAssertEqual(dataToHex(decrypted), expectedPlaintextHex, id)
+        }
+    }
+
+    func testDecryptChecksumMatchesNativeContract() throws {
+        let publicKey = try fixturePublicKey()
+
+        for testCase in try contractCases("decryptChecksum") {
+            let id = try string(testCase, "id", id: "decryptChecksum")
+            let input = try dictionary(testCase, "input", id: id)
+            let expect = try dictionary(testCase, "expect", id: id)
+            let checksumHex = try string(input, "checksumHex", id: id)
+            let expectedDecryptedHex = try string(expect, "decryptedHex", id: id)
+
+            let result = try CryptoCipher.decryptChecksum(checksum: checksumHex, publicKey: publicKey)
+            XCTAssertEqual(result, expectedDecryptedHex, id)
+        }
+    }
+
+    func testDecryptChecksumInvalidMatchesNativeContract() throws {
+        let publicKey = try fixturePublicKey()
+
+        for testCase in try contractCases("decryptChecksumInvalid") {
+            let id = try string(testCase, "id", id: "decryptChecksumInvalid")
+            let input = try dictionary(testCase, "input", id: id)
+            let expect = try dictionary(testCase, "expect", id: id)
+            let checksumHex = try string(input, "checksumHex", id: id)
+            let shouldThrow = try bool(expect, "throws", id: id)
+
+            if shouldThrow {
+                XCTAssertThrowsError(
+                    try CryptoCipher.decryptChecksum(checksum: checksumHex, publicKey: publicKey),
+                    id
+                )
+            }
+        }
+    }
+
+    func testCalcKeyIdMatchesNativeContract() throws {
+        for testCase in try contractCases("calcKeyId") {
+            let id = try string(testCase, "id", id: "calcKeyId")
+            let input = try dictionary(testCase, "input", id: id)
+            let expect = try dictionary(testCase, "expect", id: id)
+            let publicKey = try string(input, "publicKeyPem", id: id)
+            let expectedKeyId = try string(expect, "keyId", id: id)
+
+            XCTAssertEqual(CryptoCipher.calcKeyId(publicKey: publicKey), expectedKeyId, id)
+        }
+    }
+
+    func testRsaPublicKeyLoadMatchesNativeContract() throws {
+        for testCase in try contractCases("rsaPublicKeyLoad") {
+            let id = try string(testCase, "id", id: "rsaPublicKeyLoad")
+            let input = try dictionary(testCase, "input", id: id)
+            let expect = try dictionary(testCase, "expect", id: id)
+            let publicKey = try string(input, "publicKeyPem", id: id)
+            let shouldLoad = try bool(expect, "loads", id: id)
+
+            let loaded = RSAPublicKey.load(rsaPublicKey: publicKey) != nil
+            XCTAssertEqual(loaded, shouldLoad, id)
+        }
+    }
+}

--- a/native-contract-tests/README.md
+++ b/native-contract-tests/README.md
@@ -14,8 +14,24 @@ Current runners:
 
 - Android: `android/src/test/java/ee/forgr/capacitor_updater/NativeContractTest.java`
 - iOS: `ios/Tests/CapacitorUpdaterPluginTests/NativeContractTests.swift`
+- Android: `android/src/test/java/ee/forgr/capacitor_updater/RsaContractTest.java`
+- iOS: `ios/Tests/CapacitorUpdaterPluginTests/RsaContractTests.swift`
 
-Run them with:
+RSA public-decrypt fixtures live in `native-contract-tests/crypto-rsa.json`.
+Regenerate them with:
+
+```bash
+bun scripts/generate-rsa-contract-fixtures.mjs
+```
+
+Run RSA contract tests with:
+
+```bash
+bun run native:contract:crypto:ios
+bun run native:contract:crypto:android
+```
+
+Run core contract tests with:
 
 ```bash
 bun run native:contract:android

--- a/native-contract-tests/crypto-rsa.json
+++ b/native-contract-tests/crypto-rsa.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "description": "RSA public-decrypt contract vectors generated with crypto.privateEncrypt (PKCS#1), matching Capgo CLI encryption.",
+  "publicKeyPem": "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEAqJikYizowR4jGct5Uv8NdTjc+oXdnSp+I/P27huEx/eHTP+UQRIR\nv6cYq2d9wOCU5qZpyf4P7u5qibvfWM+Db2L9FS6zjLrFxaKIVk4bnixHEkzFEwJ4\nlIWq2cuwyVpdwriXvKRTen1bxslJHDKSkRAZX/u2rS+lbfs5k//2FBnVXK2aNGIv\nI3Kl9bHl4xhnwe1CAahX+5j4mB50jrGJEYU/Ocp9gGHwwm4+smJhJRw8d6060dRY\nSmoGQ34X4J4jO16Wln26TGNaSA0iBPVJt82MvO1FJJJFMAuIJDQfbysIKYFBWlBA\n2OCmylv7cVls7DdUCiDIWbzNefCZa3RyBwIDAQAB\n-----END RSA PUBLIC KEY-----",
+  "rsaPublicDecrypt": [
+    {
+      "id": "session-key-16-bytes",
+      "input": {
+        "ciphertextHex": "371cabdcb9827ffbc75fa978701d4bb5751fbdbddc0f46b6670c10f4529a0d212ecebd1460b5aecda16fe3a13f14cfbc48da3768db978b93acc1e707fa7eab54ffc13062601eb2bce6a8f17bd0faa042cc44660f8f7235451c96860977abb57bfe031e01a21787d21fcc2f9bdf9f9fba07a8ab089db417bd0443633accbdad56d4a8ec0a1d3d35c7aafd163bd5f1b96fd94791911b2fe7f4561038dd9350ad703839281da43f07b06c78418e6af3530dc78d1fb9d4467ab2c83d745f01f051431cfbd70c8cad6db2f3153759e5bed6045a7e1b316d18a6aa06a1af38277e1daca559c5f1dc887268c1ff19b51199a51e948fcc9cb9de8be0a05d2fd90c1d1988"
+      },
+      "expect": {
+        "plaintextHex": "abababababababababababababababab"
+      }
+    },
+    {
+      "id": "checksum-sha256-32-bytes",
+      "input": {
+        "ciphertextHex": "05d6d98e02793a420054175330ffdad7bf0bbf64459829341663ca59c9ee2ef278ab8291b6d094410fbdd25d4bf40528d965d8b4fad590daf212b0d309602f895b3bbcd492e7fd42783fbfe23afa70370afa9e6c6a0a606dc12ecbc2c14c6d7bde8e008b378c9dbe4d269626ecb2475c6ab86e8f9ea183352bad4439fd561273b8fa75799382b4dc99d16172793ac200c5f885c9f5e91527afe2b95b0d0c6a9bcd8ce12897a7aff0c4901551f444396ba059d9adf4805719a86529ccc77cbaae58f6456eeeb44b936443b37a40e3b86ec883e4d58b16fb5dc1059171d4149568d42cda2ba474dcea82d706a8d89b55620c5fbac3d719922ee6753ff05f0d2bc8"
+      },
+      "expect": {
+        "plaintextHex": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "decryptChecksum": [
+    {
+      "id": "hex-encoded-rsa-ciphertext",
+      "input": {
+        "checksumHex": "05d6d98e02793a420054175330ffdad7bf0bbf64459829341663ca59c9ee2ef278ab8291b6d094410fbdd25d4bf40528d965d8b4fad590daf212b0d309602f895b3bbcd492e7fd42783fbfe23afa70370afa9e6c6a0a606dc12ecbc2c14c6d7bde8e008b378c9dbe4d269626ecb2475c6ab86e8f9ea183352bad4439fd561273b8fa75799382b4dc99d16172793ac200c5f885c9f5e91527afe2b95b0d0c6a9bcd8ce12897a7aff0c4901551f444396ba059d9adf4805719a86529ccc77cbaae58f6456eeeb44b936443b37a40e3b86ec883e4d58b16fb5dc1059171d4149568d42cda2ba474dcea82d706a8d89b55620c5fbac3d719922ee6753ff05f0d2bc8"
+      },
+      "expect": {
+        "decryptedHex": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "calcKeyId": [
+    {
+      "id": "fixture-public-key",
+      "input": {
+        "publicKeyPem": "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEAqJikYizowR4jGct5Uv8NdTjc+oXdnSp+I/P27huEx/eHTP+UQRIR\nv6cYq2d9wOCU5qZpyf4P7u5qibvfWM+Db2L9FS6zjLrFxaKIVk4bnixHEkzFEwJ4\nlIWq2cuwyVpdwriXvKRTen1bxslJHDKSkRAZX/u2rS+lbfs5k//2FBnVXK2aNGIv\nI3Kl9bHl4xhnwe1CAahX+5j4mB50jrGJEYU/Ocp9gGHwwm4+smJhJRw8d6060dRY\nSmoGQ34X4J4jO16Wln26TGNaSA0iBPVJt82MvO1FJJJFMAuIJDQfbysIKYFBWlBA\n2OCmylv7cVls7DdUCiDIWbzNefCZa3RyBwIDAQAB\n-----END RSA PUBLIC KEY-----"
+      },
+      "expect": {
+        "keyId": "MIIBCgKCAQEAqJikYizo"
+      }
+    }
+  ],
+  "rsaPublicKeyLoad": [
+    {
+      "id": "valid-pkcs1-pem",
+      "input": {
+        "publicKeyPem": "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEAqJikYizowR4jGct5Uv8NdTjc+oXdnSp+I/P27huEx/eHTP+UQRIR\nv6cYq2d9wOCU5qZpyf4P7u5qibvfWM+Db2L9FS6zjLrFxaKIVk4bnixHEkzFEwJ4\nlIWq2cuwyVpdwriXvKRTen1bxslJHDKSkRAZX/u2rS+lbfs5k//2FBnVXK2aNGIv\nI3Kl9bHl4xhnwe1CAahX+5j4mB50jrGJEYU/Ocp9gGHwwm4+smJhJRw8d6060dRY\nSmoGQ34X4J4jO16Wln26TGNaSA0iBPVJt82MvO1FJJJFMAuIJDQfbysIKYFBWlBA\n2OCmylv7cVls7DdUCiDIWbzNefCZa3RyBwIDAQAB\n-----END RSA PUBLIC KEY-----"
+      },
+      "expect": {
+        "loads": true
+      }
+    },
+    {
+      "id": "invalid-pem",
+      "input": {
+        "publicKeyPem": "not-a-key"
+      },
+      "expect": {
+        "loads": false
+      }
+    }
+  ],
+  "decryptChecksumInvalid": [
+    {
+      "id": "wrong-size-255-bytes",
+      "input": {
+        "checksumHex": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "expect": {
+        "throws": true
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -73,7 +73,11 @@
     "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs",
     "example:install": "cd example-app && bun install --frozen-lockfile",
-    "example:build": "bun run build && cd example-app && bun install --frozen-lockfile && bun run build"
+    "example:build": "bun run build && cd example-app && bun install --frozen-lockfile && bun run build",
+    "native:contract:crypto": "bun run native:contract:crypto:ios && bun run native:contract:crypto:android",
+    "native:contract:crypto:ios": "./scripts/test-ios.sh -only-testing:CapacitorUpdaterPluginTests/RsaContractTests",
+    "native:contract:crypto:android": "cd android && ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.RsaContractTest && cd ..",
+    "generate:rsa-contract": "bun scripts/generate-rsa-contract-fixtures.mjs"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",

--- a/scripts/generate-rsa-contract-fixtures.mjs
+++ b/scripts/generate-rsa-contract-fixtures.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+/**
+ * Generates native-contract-tests/crypto-rsa.json using Node.js crypto.privateEncrypt,
+ * matching Capgo bundle encryption (RSA PKCS#1 + public decrypt on device).
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const outputPath = path.join(root, 'native-contract-tests', 'crypto-rsa.json');
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+});
+
+function privateEncrypt(plaintext) {
+  return crypto.privateEncrypt(
+    { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
+    plaintext,
+  );
+}
+
+function toHex(buffer) {
+  return buffer.toString('hex');
+}
+
+const sessionKeyPlaintext = Buffer.alloc(16, 0xab);
+const checksumPlaintext = Buffer.from(
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  'hex',
+);
+
+const sessionKeyCiphertext = privateEncrypt(sessionKeyPlaintext);
+const checksumCiphertext = privateEncrypt(checksumPlaintext);
+
+if (sessionKeyCiphertext.length !== 256 || checksumCiphertext.length !== 256) {
+  throw new Error(`Expected 256-byte RSA ciphertext, got ${sessionKeyCiphertext.length}`);
+}
+
+const cleanedKey = publicKey
+  .replace(/-----BEGIN RSA PUBLIC KEY-----/g, '')
+  .replace(/-----END RSA PUBLIC KEY-----/g, '')
+  .replace(/\s+/g, '');
+
+const fixture = {
+  version: 1,
+  description:
+    'RSA public-decrypt contract vectors generated with crypto.privateEncrypt (PKCS#1), matching Capgo CLI encryption.',
+  publicKeyPem: publicKey.trim(),
+  rsaPublicDecrypt: [
+    {
+      id: 'session-key-16-bytes',
+      input: { ciphertextHex: toHex(sessionKeyCiphertext) },
+      expect: { plaintextHex: toHex(sessionKeyPlaintext) },
+    },
+    {
+      id: 'checksum-sha256-32-bytes',
+      input: { ciphertextHex: toHex(checksumCiphertext) },
+      expect: { plaintextHex: toHex(checksumPlaintext) },
+    },
+  ],
+  decryptChecksum: [
+    {
+      id: 'hex-encoded-rsa-ciphertext',
+      input: { checksumHex: toHex(checksumCiphertext) },
+      expect: { decryptedHex: toHex(checksumPlaintext) },
+    },
+  ],
+  calcKeyId: [
+    {
+      id: 'fixture-public-key',
+      input: { publicKeyPem: publicKey.trim() },
+      expect: { keyId: cleanedKey.slice(0, 20) },
+    },
+  ],
+  rsaPublicKeyLoad: [
+    {
+      id: 'valid-pkcs1-pem',
+      input: { publicKeyPem: publicKey.trim() },
+      expect: { loads: true },
+    },
+    {
+      id: 'invalid-pem',
+      input: { publicKeyPem: 'not-a-key' },
+      expect: { loads: false },
+    },
+  ],
+  decryptChecksumInvalid: [
+    {
+      id: 'wrong-size-255-bytes',
+      input: { checksumHex: '00'.repeat(255) },
+      expect: { throws: true },
+    },
+  ],
+};
+
+fs.writeFileSync(outputPath, `${JSON.stringify(fixture, null, 2)}\n`);
+console.log(`Wrote ${outputPath}`);


### PR DESCRIPTION
## Summary
- Adds shared `native-contract-tests/crypto-rsa.json` vectors generated with Node `crypto.privateEncrypt` (PKCS#1), matching Capgo bundle encryption
- Adds iOS (`RsaContractTests`) and Android (`RsaContractTest`) runners covering RSA public decrypt, `decryptChecksum`, `calcKeyId`, and key load validation
- Adds `bun run native:contract:crypto` and `bun scripts/generate-rsa-contract-fixtures.mjs` for local runs / fixture regeneration

## Why
These tests lock down the RSA scope before rewriting the iOS BigInt implementation (Option B: minimal vendored modPow) without risking decryption regressions across platforms.

## How
- Fixture covers 16-byte session key and 32-byte SHA-256 checksum ciphertexts (RSA-2048, 256-byte blocks)
- iOS tests use `RSAPublicKey` + `CryptoCipher`; Android tests use `CryptoCipher.decryptRSA` + `decryptChecksum`
- Invalid checksum size case ensures `decryptChecksum` rejects non-256-byte input

## Test plan
- [x] `bun run native:contract:crypto:ios`
- [x] `bun run native:contract:crypto:android`
- [x] `bun run verify`
- [ ] CI green

## Not Tested
- End-to-end encrypted bundle download on device (contract tests only, no network/filesystem)

Made with [Cursor](https://cursor.com)