### PR TITLE
fix(android): reschedule Background Runner after OTA bundle switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,9 @@ For multi-file delta updates, provide the `manifest` array.
 **Android Background Runner note:** `@capacitor/background-runner` loads its
 configured runner script from native APK assets. Live updates cannot replace
 that runner script. Keep it stable across OTA updates and ship a native app
-update when the runner code changes.
+update when the runner code changes. When a bundle switch happens, Capacitor
+Updater cancels and reschedules configured Background Runner WorkManager jobs
+and syncs the bundled runner script into native `public/` storage when present.
 
 | Param         | Type                                                        | Description                                                                                  |
 | ------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -17,8 +17,8 @@ import androidx.work.Constraints;
 import androidx.work.Data;
 import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.ExistingWorkPolicy;
-import androidx.work.NetworkType;
 import androidx.work.ListenableWorker;
+import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkInfo;
@@ -1002,6 +1002,7 @@ public class CapgoUpdater {
     }
 
     static final class BackgroundRunnerWorkConfig {
+
         final String label;
         final String src;
         final String event;
@@ -1090,10 +1091,7 @@ public class CapgoUpdater {
         }
 
         final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
-        try (
-            final FileInputStream input = new FileInputStream(source);
-            final FileOutputStream output = new FileOutputStream(tempFile)
-        ) {
+        try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
             final byte[] buffer = new byte[1024 * 1024];
             int length;
             while ((length = input.read(buffer)) != -1) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -13,7 +13,14 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.work.Constraints;
 import androidx.work.Data;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.ListenableWorker;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 import com.google.common.util.concurrent.Futures;
@@ -69,6 +76,7 @@ public class CapgoUpdater {
     private static final String TEMP_UNZIP_PREFIX = "capgo_unzip_";
     private static final String CAPACITOR_CONFIG_ASSET = "capacitor.config.json";
     private static final String BACKGROUND_RUNNER_CONFIG_KEY = "BackgroundRunner";
+    private static final String BACKGROUND_RUNNER_WORKER_CLASS = "io.ionic.backgroundrunner.plugin.RunnerWorker";
 
     public static final String TAG = "Capacitor-updater";
     public SharedPreferences.Editor editor;
@@ -983,7 +991,7 @@ public class CapgoUpdater {
     }
 
     private void setCurrentBundle(final File bundle) {
-        this.cancelBackgroundRunnerWorkBeforeBundleSwitch();
+        this.resetBackgroundRunnerWorkForBundleSwitch(bundle);
         this.editor.putString(this.CAP_SERVER_PATH, bundle.getPath());
         logger.info("Current bundle set to: " + bundle);
         this.editor.commit();
@@ -993,7 +1001,32 @@ public class CapgoUpdater {
         return bundlePath != null && !bundlePath.trim().isEmpty() && !isBuiltin && !hasStoredBundleInfo;
     }
 
-    static String getBackgroundRunnerLabelFromConfig(final String configJson) {
+    static final class BackgroundRunnerWorkConfig {
+        final String label;
+        final String src;
+        final String event;
+        final boolean autoStart;
+        final boolean repeat;
+        final int interval;
+
+        BackgroundRunnerWorkConfig(
+            final String label,
+            final String src,
+            final String event,
+            final boolean autoStart,
+            final boolean repeat,
+            final int interval
+        ) {
+            this.label = label;
+            this.src = src;
+            this.event = event;
+            this.autoStart = autoStart;
+            this.repeat = repeat;
+            this.interval = interval;
+        }
+    }
+
+    static BackgroundRunnerWorkConfig getBackgroundRunnerWorkConfigFromConfig(final String configJson) {
         if (configJson == null || configJson.trim().isEmpty()) {
             return null;
         }
@@ -1011,10 +1044,28 @@ public class CapgoUpdater {
             }
 
             final String label = backgroundRunner.optString("label", "").trim();
-            return label.isEmpty() ? null : label;
+            if (label.isEmpty()) {
+                return null;
+            }
+
+            final String src = backgroundRunner.optString("src", "").trim();
+            final String event = backgroundRunner.optString("event", "").trim();
+            return new BackgroundRunnerWorkConfig(
+                label,
+                src,
+                event,
+                backgroundRunner.optBoolean("autoStart", false),
+                backgroundRunner.optBoolean("repeat", false),
+                backgroundRunner.optInt("interval", 0)
+            );
         } catch (JSONException ignored) {
             return null;
         }
+    }
+
+    static String getBackgroundRunnerLabelFromConfig(final String configJson) {
+        final BackgroundRunnerWorkConfig config = getBackgroundRunnerWorkConfigFromConfig(configJson);
+        return config == null ? null : config.label;
     }
 
     private String readAssetAsString(final String assetPath) throws IOException {
@@ -1032,31 +1083,130 @@ public class CapgoUpdater {
         return buffer.toString();
     }
 
-    private void cancelBackgroundRunnerWorkBeforeBundleSwitch() {
+    private void copyFileAtomically(final File source, final File dest) throws IOException {
+        final File parent = dest.getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            throw new IOException("Failed to create parent directory: " + parent.getAbsolutePath());
+        }
+
+        final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
+        try (
+            final FileInputStream input = new FileInputStream(source);
+            final FileOutputStream output = new FileOutputStream(tempFile)
+        ) {
+            final byte[] buffer = new byte[1024 * 1024];
+            int length;
+            while ((length = input.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+        }
+
+        if (!tempFile.renameTo(dest)) {
+            if (!dest.delete() || !tempFile.renameTo(dest)) {
+                tempFile.delete();
+                throw new IOException("Failed to replace file: " + dest.getAbsolutePath());
+            }
+        }
+    }
+
+    private void syncBackgroundRunnerScriptFromBundle(final File bundle, final BackgroundRunnerWorkConfig config) {
+        if (this.activity == null || bundle == null || config == null || config.src == null || config.src.isEmpty()) {
+            return;
+        }
+
+        if (bundle.getPath().endsWith("/public") || "public".equals(bundle.getName())) {
+            return;
+        }
+
+        try {
+            final File source = resolvePathInsideDirectory(bundle, config.src);
+            if (!source.isFile()) {
+                return;
+            }
+
+            final File publicDir = new File(this.activity.getFilesDir(), "public");
+            final File dest = resolvePathInsideDirectory(publicDir, config.src);
+            this.copyFileAtomically(source, dest);
+            logger.info("Synced Background Runner script into native public storage before bundle switch.");
+            logger.debug("Background Runner script path: " + dest.getAbsolutePath());
+        } catch (Exception e) {
+            logger.debug("Background Runner script sync skipped: " + e.getMessage());
+        }
+    }
+
+    private void resetBackgroundRunnerWorkForBundleSwitch(final File bundle) {
         if (this.activity == null) {
             return;
         }
 
-        final String label;
+        final BackgroundRunnerWorkConfig config;
         try {
-            label = getBackgroundRunnerLabelFromConfig(this.readAssetAsString(CAPACITOR_CONFIG_ASSET));
+            config = getBackgroundRunnerWorkConfigFromConfig(this.readAssetAsString(CAPACITOR_CONFIG_ASSET));
         } catch (IOException ignored) {
             return;
         }
 
-        if (label == null) {
+        if (config == null) {
             return;
         }
 
         try {
             final WorkManager workManager = WorkManager.getInstance(this.activity.getApplicationContext());
-            workManager.cancelUniqueWork(label);
-            workManager.cancelAllWorkByTag(label);
+            workManager.cancelUniqueWork(config.label);
+            workManager.cancelAllWorkByTag(config.label);
             logger.info("Cancelled Background Runner work before bundle switch.");
-            logger.debug("Background Runner label: " + label);
+            logger.debug("Background Runner label: " + config.label);
         } catch (Exception e) {
             logger.warn("Failed to cancel Background Runner work before bundle switch.");
             logger.debug("Background Runner cancellation error: " + e.getMessage());
+        }
+
+        this.syncBackgroundRunnerScriptFromBundle(bundle, config);
+        this.rescheduleBackgroundRunnerWork(config);
+    }
+
+    private void rescheduleBackgroundRunnerWork(final BackgroundRunnerWorkConfig config) {
+        if (!config.autoStart || config.interval <= 0 || config.src.isEmpty()) {
+            return;
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final Class<? extends ListenableWorker> workerClass = (Class<? extends ListenableWorker>) Class.forName(
+                BACKGROUND_RUNNER_WORKER_CLASS
+            );
+            final Data data = new Data.Builder()
+                .putString("label", config.label)
+                .putString("src", config.src)
+                .putString("event", config.event)
+                .build();
+            final Constraints constraints = new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
+            final WorkManager workManager = WorkManager.getInstance(this.activity.getApplicationContext());
+
+            if (!config.repeat) {
+                final OneTimeWorkRequest work = new OneTimeWorkRequest.Builder(workerClass)
+                    .setInitialDelay(config.interval, TimeUnit.MINUTES)
+                    .setInputData(data)
+                    .addTag(config.label)
+                    .setConstraints(constraints)
+                    .build();
+                workManager.enqueueUniqueWork(config.label, ExistingWorkPolicy.REPLACE, work);
+            } else {
+                final PeriodicWorkRequest work = new PeriodicWorkRequest.Builder(workerClass, config.interval, TimeUnit.MINUTES)
+                    .setInitialDelay(config.interval, TimeUnit.MINUTES)
+                    .setInputData(data)
+                    .addTag(config.label)
+                    .setConstraints(constraints)
+                    .build();
+                workManager.enqueueUniquePeriodicWork(config.label, ExistingPeriodicWorkPolicy.UPDATE, work);
+            }
+
+            logger.info("Rescheduled Background Runner work after bundle switch.");
+        } catch (ClassNotFoundException ignored) {
+            logger.debug("Background Runner plugin not installed, skipping reschedule.");
+        } catch (Exception e) {
+            logger.warn("Failed to reschedule Background Runner work after bundle switch.");
+            logger.debug("Background Runner reschedule error: " + e.getMessage());
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -174,7 +174,9 @@ public class DownloadService extends Worker {
     }
 
     static File resolveManifestBuiltinFile(final File builtinFolder, final String fileName) throws IOException {
-        return CapgoUpdater.resolvePathInsideDirectory(builtinFolder, fileName);
+        final boolean isBrotli = fileName.endsWith(".br");
+        final String resolvedName = isBrotli ? fileName.substring(0, fileName.length() - 3) : fileName;
+        return CapgoUpdater.resolvePathInsideDirectory(builtinFolder, resolvedName);
     }
 
     private String getInputString(String key, String fallback) {
@@ -642,13 +644,28 @@ public class DownloadService extends Worker {
     }
 
     private void copyFile(File source, File dest) throws IOException {
+        final File parent = dest.getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            throw new IOException("Failed to create parent directory: " + parent.getAbsolutePath());
+        }
+
+        final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
         try (
             FileInputStream inStream = new FileInputStream(source);
-            FileOutputStream outStream = new FileOutputStream(dest);
+            FileOutputStream outStream = new FileOutputStream(tempFile);
             FileChannel inChannel = inStream.getChannel();
             FileChannel outChannel = outStream.getChannel()
         ) {
             inChannel.transferTo(0, inChannel.size(), outChannel);
+        }
+
+        try {
+            Files.move(tempFile.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            if (tempFile.exists()) {
+                tempFile.delete();
+            }
+            throw e;
         }
     }
 

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -1432,6 +1432,22 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void testGetBackgroundRunnerWorkConfigFromConfigParsesScheduleFields() {
+        final String config =
+            "{\"plugins\":{\"BackgroundRunner\":{\"label\":\"com.example.runner\",\"src\":\"runner.js\",\"event\":\"myEvent\",\"autoStart\":true,\"repeat\":true,\"interval\":15}}}";
+
+        final CapgoUpdater.BackgroundRunnerWorkConfig parsed = CapgoUpdater.getBackgroundRunnerWorkConfigFromConfig(config);
+
+        assertNotNull(parsed);
+        assertEquals("com.example.runner", parsed.label);
+        assertEquals("runner.js", parsed.src);
+        assertEquals("myEvent", parsed.event);
+        assertTrue(parsed.autoStart);
+        assertTrue(parsed.repeat);
+        assertEquals(15, parsed.interval);
+    }
+
+    @Test
     public void testGetBundleInfoBuiltinReturnsVersionBuildWhenPresent() {
         CapgoUpdater updater = new CapgoUpdater(null);
         updater.versionBuild = "1.2.3";
@@ -2928,6 +2944,17 @@ public class CapacitorUpdaterUnitTest {
 
         assertThrows(IOException.class, () -> invokeUnzip(updater, "bundle-id", zipPath, "bundle"));
         assertFalse(Files.exists(escapedPath));
+    }
+
+    @Test
+    public void testManifestBuiltinStripsBrotliSuffixBeforeResolvingPath() throws Exception {
+        final Path builtinFolder = Files.createTempDirectory("capgo-builtin");
+        try {
+            final File resolved = DownloadService.resolveManifestBuiltinFile(builtinFolder.toFile(), "background-runner.js.br");
+            assertEquals("background-runner.js", resolved.getName());
+        } finally {
+            Files.deleteIfExists(builtinFolder);
+        }
     }
 
     @Test

--- a/api.md
+++ b/api.md
@@ -293,7 +293,9 @@ For multi-file delta updates, provide the `manifest` array.
 **Android Background Runner note:** `@capacitor/background-runner` loads its
 configured runner script from native APK assets. Live updates cannot replace
 that runner script. Keep it stable across OTA updates and ship a native app
-update when the runner code changes.
+update when the runner code changes. When a bundle switch happens, Capacitor
+Updater cancels and reschedules configured Background Runner WorkManager jobs
+and syncs the bundled runner script into native `public/` storage when present.
 
 **Parameters**
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -533,7 +533,9 @@ export interface CapacitorUpdaterPlugin {
    * **Android Background Runner note:** `@capacitor/background-runner` loads its
    * configured runner script from native APK assets. Live updates cannot replace
    * that runner script. Keep it stable across OTA updates and ship a native app
-   * update when the runner code changes.
+   * update when the runner code changes. When a bundle switch happens, Capacitor
+   * Updater cancels and reschedules configured Background Runner WorkManager jobs
+   * and syncs the bundled runner script into native `public/` storage when present.
    *
    * @example
    * const bundle = await CapacitorUpdater.download({


### PR DESCRIPTION
## Summary
- Reschedule configured `@capacitor/background-runner` WorkManager jobs after cancelling them during bundle switches so direct OTA reloads do not leave runner work stopped forever.
- Sync the bundled runner script into native `public/` storage when the active bundle contains it.
- Replace manifest delta copies atomically and resolve brotli builtin paths without the `.br` suffix.

Fixes #643

## Test plan
- [x] `bun run verify`
- [ ] Manual: app with Background Runner + OTA update, confirm runner keeps working after direct update reload


Made with [Cursor](https://cursor.com)