### PR TITLE
fix(updater): avoid duplicate hashing and caching in populateDeltaCache

### DIFF
--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -707,13 +707,33 @@ import UIKit
         }
     }
 
-    private func populateDeltaCacheAsync(for id: String) {
+    private func populateDeltaCacheAsync(for id: String, manifest: [ManifestEntry]? = nil, sessionKey: String = "") {
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            self?.populateDeltaCache(for: id)
+            self?.populateDeltaCache(for: id, manifest: manifest, sessionKey: sessionKey)
         }
     }
 
-    private func populateDeltaCache(for id: String) {
+    /// Keys are stripped of the `.br` suffix so they match the extracted file names on
+    /// disk, not the manifest's (possibly brotli-compressed) original file names.
+    func manifestHashLookup(manifest: [ManifestEntry]?, sessionKey: String) -> [String: String] {
+        guard let manifest else {
+            return [:]
+        }
+        var lookup: [String: String] = [:]
+        for entry in manifest {
+            guard let fileName = entry.file_name,
+                  let hash = resolveManifestFileHash(entry: entry, sessionKey: sessionKey) else {
+                continue
+            }
+            let destFileName = fileName.hasSuffix(".br") ? String(fileName.dropLast(3)) : fileName
+            lookup[destFileName] = hash
+        }
+        return lookup
+    }
+
+    /// `manifest` must only contain entries the caller already checksum-verified
+    /// (as `downloadManifest` does) — the hashes are trusted as-is, not re-checked.
+    func populateDeltaCache(for id: String, manifest: [ManifestEntry]? = nil, sessionKey: String = "") {
         let bundleDir = self.getBundleDirectory(id: id)
         let fileManager = FileManager.default
 
@@ -733,14 +753,28 @@ import UIKit
             return
         }
 
+        let knownHashes = manifestHashLookup(manifest: manifest, sessionKey: sessionKey)
+        let builtinFolder = self.builtinFolderURL()
+
         for case let fileURL as URL in enumerator {
             let resourceValues = try? fileURL.resourceValues(forKeys: [.isDirectoryKey])
             if resourceValues?.isDirectory == true {
                 continue
             }
 
-            let checksum = CryptoCipher.calcChecksum(filePath: fileURL)
+            let relativePath = String(fileURL.path.dropFirst(bundleDir.path.count + 1))
+
+            let checksum = knownHashes[relativePath] ?? CryptoCipher.calcChecksum(filePath: fileURL)
             if checksum.isEmpty {
+                continue
+            }
+
+            // Builtin is already a permanent reuse source (see isManifestEntryAvailableLocally),
+            // so there's no need to also duplicate this file into the delta cache.
+            let builtinFilePath = builtinFolder.appendingPathComponent(relativePath)
+            let isBuiltinOrigin = fileManager.fileExists(atPath: builtinFilePath.path) &&
+                verifyChecksum(file: builtinFilePath, expectedHash: checksum)
+            if isBuiltinOrigin {
                 continue
             }
 
@@ -931,6 +965,12 @@ import UIKit
         return actualHash == expectedHash
     }
 
+    /// Overridable so tests can point it at a writable directory instead of the
+    /// real (read-only) app bundle.
+    func builtinFolderURL() -> URL {
+        Bundle.main.bundleURL.appendingPathComponent("public")
+    }
+
     private func resolveManifestFileHash(entry: ManifestEntry, sessionKey: String) -> String? {
         guard var fileHash = entry.file_hash, !fileHash.isEmpty else {
             return nil
@@ -953,7 +993,7 @@ import UIKit
             return false
         }
 
-        let builtinFolder = Bundle.main.bundleURL.appendingPathComponent("public")
+        let builtinFolder = self.builtinFolderURL()
         let builtinFilePath = builtinFolder.appendingPathComponent(fileName)
         if FileManager.default.fileExists(atPath: builtinFilePath.path) && verifyChecksum(file: builtinFilePath, expectedHash: fileHash) {
             return true
@@ -1066,7 +1106,7 @@ import UIKit
         let id = self.randomString(length: 10)
         logger.info("downloadManifest start \(id)")
         let destFolder = self.getBundleDirectory(id: id)
-        let builtinFolder = Bundle.main.bundleURL.appendingPathComponent("public")
+        let builtinFolder = self.builtinFolderURL()
 
         // Check disk space before starting manifest download (estimate 100KB per file, minimum 50MB)
         let estimatedSize = Int64(max(manifest.count * 100 * 1024, 50 * 1024 * 1024))
@@ -1252,6 +1292,8 @@ import UIKit
 
         // Send stats for manifest download complete
         self.sendStats(action: "download_manifest_complete", versionName: version)
+
+        self.populateDeltaCacheAsync(for: id, manifest: manifest, sessionKey: sessionKey)
 
         self.notifyDownload(id: id, percent: 100, bundle: updatedBundle)
         logger.info("downloadManifest done \(id)")

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -713,20 +713,29 @@ import UIKit
         }
     }
 
+    struct ManifestLookupEntry {
+        let hash: String
+        /// The manifest's own file name, `.br` suffix included when present. The
+        /// built-in bundle stores files under this exact name (see
+        /// isManifestEntryAvailableLocally), unlike the extracted/cached copy which
+        /// is always named without the suffix.
+        let originalFileName: String
+    }
+
     /// Keys are stripped of the `.br` suffix so they match the extracted file names on
     /// disk, not the manifest's (possibly brotli-compressed) original file names.
-    func manifestHashLookup(manifest: [ManifestEntry]?, sessionKey: String) -> [String: String] {
+    func manifestHashLookup(manifest: [ManifestEntry]?, sessionKey: String) -> [String: ManifestLookupEntry] {
         guard let manifest else {
             return [:]
         }
-        var lookup: [String: String] = [:]
+        var lookup: [String: ManifestLookupEntry] = [:]
         for entry in manifest {
             guard let fileName = entry.file_name,
                   let hash = resolveManifestFileHash(entry: entry, sessionKey: sessionKey) else {
                 continue
             }
             let destFileName = fileName.hasSuffix(".br") ? String(fileName.dropLast(3)) : fileName
-            lookup[destFileName] = hash
+            lookup[destFileName] = ManifestLookupEntry(hash: hash, originalFileName: fileName)
         }
         return lookup
     }
@@ -753,7 +762,7 @@ import UIKit
             return
         }
 
-        let knownHashes = manifestHashLookup(manifest: manifest, sessionKey: sessionKey)
+        let knownEntries = manifestHashLookup(manifest: manifest, sessionKey: sessionKey)
         let builtinFolder = self.builtinFolderURL()
 
         for case let fileURL as URL in enumerator {
@@ -763,15 +772,17 @@ import UIKit
             }
 
             let relativePath = String(fileURL.path.dropFirst(bundleDir.path.count + 1))
+            let knownEntry = knownEntries[relativePath]
 
-            let checksum = knownHashes[relativePath] ?? CryptoCipher.calcChecksum(filePath: fileURL)
+            let checksum = knownEntry?.hash ?? CryptoCipher.calcChecksum(filePath: fileURL)
             if checksum.isEmpty {
                 continue
             }
 
             // Builtin is already a permanent reuse source (see isManifestEntryAvailableLocally),
-            // so there's no need to also duplicate this file into the delta cache.
-            let builtinFilePath = builtinFolder.appendingPathComponent(relativePath)
+            // so there's no need to also duplicate this file into the delta cache
+            let builtinRelativePath = knownEntry?.originalFileName ?? relativePath
+            let builtinFilePath = builtinFolder.appendingPathComponent(builtinRelativePath)
             let isBuiltinOrigin = fileManager.fileExists(atPath: builtinFilePath.path) &&
                 verifyChecksum(file: builtinFilePath, expectedHash: checksum)
             if isBuiltinOrigin {

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import XCTest
+@testable import CapacitorUpdaterPlugin
+
+/// Overrides builtinFolderURL() with a writable temp directory — the real app
+/// bundle (Bundle.main) is read-only at test-runtime, so tests can't write
+/// fixture files there directly.
+private final class TestableCapgoUpdater: CapgoUpdater {
+    var builtinFolderOverride = FileManager.default.temporaryDirectory.appendingPathComponent("populate-delta-cache-builtin-\(UUID().uuidString)")
+
+    override func builtinFolderURL() -> URL {
+        builtinFolderOverride
+    }
+}
+
+final class PopulateDeltaCacheTests: XCTestCase {
+    private var implementation: TestableCapgoUpdater!
+    private var bundleId: String!
+    private var bundleDir: URL!
+    private let cacheFolder = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("capgo_downloads")
+    private var builtinFolder: URL {
+        implementation.builtinFolderOverride
+    }
+
+    // Loaded from the same RSA fixture native-contract-tests/crypto-rsa.json uses
+    // (see RsaContractTests.swift), so the encrypted-manifest path is exercised
+    // against real contract data rather than an invented key/ciphertext pair.
+    private enum Fixture {
+        static let contract: [String: Any] = {
+            guard let url = try? locateContractFile(),
+                  let data = try? Data(contentsOf: url),
+                  let value = try? JSONSerialization.jsonObject(with: data),
+                  let dict = value as? [String: Any] else {
+                XCTFail("Unable to load RSA contract fixture")
+                return [:]
+            }
+            return dict
+        }()
+
+        static var publicKeyPem: String {
+            contract["publicKeyPem"] as? String ?? ""
+        }
+
+        static var firstDecryptChecksumCase: (checksumHex: String, decryptedHex: String) {
+            guard let cases = contract["decryptChecksum"] as? [[String: Any]],
+                  let first = cases.first,
+                  let input = first["input"] as? [String: Any],
+                  let expect = first["expect"] as? [String: Any],
+                  let checksumHex = input["checksumHex"] as? String,
+                  let decryptedHex = expect["decryptedHex"] as? String else {
+                XCTFail("Missing decryptChecksum fixture case")
+                return ("", "")
+            }
+            return (checksumHex, decryptedHex)
+        }
+
+        private static func locateContractFile() throws -> URL {
+            let fileManager = FileManager.default
+            let roots = [
+                URL(fileURLWithPath: fileManager.currentDirectoryPath),
+                URL(fileURLWithPath: #filePath)
+            ]
+            for root in roots {
+                var current = root
+                while current.path != "/" {
+                    let candidate = current
+                        .appendingPathComponent("native-contract-tests")
+                        .appendingPathComponent("crypto-rsa.json")
+                    if fileManager.fileExists(atPath: candidate.path) {
+                        return candidate
+                    }
+                    current.deleteLastPathComponent()
+                }
+            }
+            throw NSError(domain: "PopulateDeltaCacheTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "crypto-rsa.json not found"])
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+        CryptoCipher.setLogger(Logger(withTag: "PopulateDeltaCacheTests", options: Logger.Options(level: .silent)))
+        implementation = TestableCapgoUpdater()
+        bundleId = "delta-cache-\(UUID().uuidString)"
+        bundleDir = implementation.getBundleDirectory(id: bundleId)
+        try? FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: bundleDir)
+        try? FileManager.default.removeItem(at: builtinFolder)
+        implementation = nil
+        super.tearDown()
+    }
+
+    private func write(_ content: String, named name: String, in directory: URL) -> URL {
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(name)
+        try? content.data(using: .utf8)?.write(to: url)
+        return url
+    }
+
+    private func cacheFile(hash: String, name: String) -> URL {
+        cacheFolder.appendingPathComponent("\(hash)_\(name)")
+    }
+
+    // MARK: - manifestHashLookup
+
+    func testManifestHashLookupStripsBrotliSuffixAndReturnsPlainHash() {
+        let manifest = [
+            ManifestEntry(file_name: "assets/app.js.br", file_hash: "plainhash", download_url: nil)
+        ]
+
+        let lookup = implementation.manifestHashLookup(manifest: manifest, sessionKey: "")
+
+        XCTAssertEqual(lookup["assets/app.js"], "plainhash")
+        XCTAssertNil(lookup["assets/app.js.br"])
+    }
+
+    func testManifestHashLookupDecryptsEncryptedManifestHashes() {
+        let (checksumHex, decryptedHex) = Fixture.firstDecryptChecksumCase
+        implementation.setPublicKey(Fixture.publicKeyPem)
+        let manifest = [
+            ManifestEntry(file_name: "index.html", file_hash: checksumHex, download_url: nil)
+        ]
+
+        let lookup = implementation.manifestHashLookup(manifest: manifest, sessionKey: "session-key")
+
+        XCTAssertEqual(lookup["index.html"], decryptedHex)
+    }
+
+    func testManifestHashLookupSkipsEntriesMissingFileNameOrHash() {
+        let manifest = [
+            ManifestEntry(file_name: nil, file_hash: "hash", download_url: nil),
+            ManifestEntry(file_name: "no-hash.js", file_hash: nil, download_url: nil)
+        ]
+
+        XCTAssertTrue(implementation.manifestHashLookup(manifest: manifest, sessionKey: "").isEmpty)
+    }
+
+    // MARK: - populateDeltaCache: (a) reuse manifest hashes instead of re-hashing
+
+    func testPopulateDeltaCacheReusesManifestHashInsteadOfRecomputing() {
+        let fileURL = write("hello world", named: "app.js", in: bundleDir)
+        let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
+        let manifestHash = "deliberately-different-\(realHash)"
+        let manifest = [
+            ManifestEntry(file_name: "app.js", file_hash: manifestHash, download_url: nil)
+        ]
+
+        implementation.populateDeltaCache(for: bundleId, manifest: manifest, sessionKey: "")
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: manifestHash, name: "app.js").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "app.js").path))
+
+        try? FileManager.default.removeItem(at: cacheFile(hash: manifestHash, name: "app.js"))
+    }
+
+    func testPopulateDeltaCacheFallsBackToRealHashWhenNoManifestEntry() {
+        let fileURL = write("hello world", named: "app.js", in: bundleDir)
+        let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
+
+        implementation.populateDeltaCache(for: bundleId)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "app.js").path))
+
+        try? FileManager.default.removeItem(at: cacheFile(hash: realHash, name: "app.js"))
+    }
+
+    // MARK: - populateDeltaCache: (b) skip caching builtin-origin files
+
+    func testPopulateDeltaCacheSkipsFilesAlreadyAvailableFromBuiltin() {
+        let content = "shared builtin content"
+        let fileURL = write(content, named: "shared.js", in: bundleDir)
+        let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
+        _ = write(content, named: "shared.js", in: builtinFolder)
+        let expectedCacheFile = cacheFile(hash: realHash, name: "shared.js")
+        // Guard against a stale cache entry left over from an unrelated run
+        // (content/hash is deterministic, so the path can collide across runs).
+        try? FileManager.default.removeItem(at: expectedCacheFile)
+
+        implementation.populateDeltaCache(for: bundleId)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expectedCacheFile.path))
+
+        try? FileManager.default.removeItem(at: expectedCacheFile)
+    }
+
+    func testPopulateDeltaCacheStillCachesFilesNotPresentInBuiltin() {
+        let fileURL = write("only in this bundle", named: "new.js", in: bundleDir)
+        let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
+
+        implementation.populateDeltaCache(for: bundleId)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "new.js").path))
+
+        try? FileManager.default.removeItem(at: cacheFile(hash: realHash, name: "new.js"))
+    }
+}

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -166,7 +166,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     // MARK: - populateDeltaCache: (a) reuse manifest hashes instead of re-hashing
 
     func testPopulateDeltaCacheReusesManifestHashInsteadOfRecomputing() throws {
-        let fileURL = try write("hello world", named: "app.js", in: bundleDir)
+        let fileURL = try write("hello world \(bundleId!)", named: "app.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
         let manifestHash = "deliberately-different-\(realHash)"
         let manifest = [
@@ -182,7 +182,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     }
 
     func testPopulateDeltaCacheFallsBackToRealHashWhenNoManifestEntry() throws {
-        let fileURL = try write("hello world", named: "app.js", in: bundleDir)
+        let fileURL = try write("hello world \(bundleId!)", named: "app.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
         let realCacheFile = expectedCacheFile(hash: realHash, name: "app.js")
 
@@ -194,7 +194,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     // MARK: - populateDeltaCache: (b) skip caching builtin-origin files
 
     func testPopulateDeltaCacheSkipsFilesAlreadyAvailableFromBuiltin() throws {
-        let content = "shared builtin content"
+        let content = "shared builtin content \(bundleId!)"
         let fileURL = try write(content, named: "shared.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
         try write(content, named: "shared.js", in: builtinFolder)
@@ -206,7 +206,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     }
 
     func testPopulateDeltaCacheStillCachesFilesNotPresentInBuiltin() throws {
-        let fileURL = try write("only in this bundle", named: "new.js", in: bundleDir)
+        let fileURL = try write("only in this bundle \(bundleId!)", named: "new.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
         let cacheFile = expectedCacheFile(hash: realHash, name: "new.js")
 
@@ -221,7 +221,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     /// manifest's original name, not the extracted file's own path, or this match
     /// silently never fires for any compressed asset.
     func testPopulateDeltaCacheSkipsBrotliFilesAlreadyAvailableFromBuiltin() throws {
-        let content = "shared builtin content"
+        let content = "shared builtin content \(bundleId!)"
         let extractedFileURL = try write(content, named: "app.js", in: bundleDir.appendingPathComponent("assets"))
         let realHash = CryptoCipher.calcChecksum(filePath: extractedFileURL)
         try write(content, named: "app.js.br", in: builtinFolder.appendingPathComponent("assets"))

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -112,7 +112,10 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
         let lookup = implementation.manifestHashLookup(manifest: manifest, sessionKey: "")
 
-        XCTAssertEqual(lookup["assets/app.js"], "plainhash")
+        XCTAssertEqual(lookup["assets/app.js"]?.hash, "plainhash")
+        // The original (unstripped) manifest name must be preserved — it's what the
+        // built-in bundle actually stores the file under.
+        XCTAssertEqual(lookup["assets/app.js"]?.originalFileName, "assets/app.js.br")
         XCTAssertNil(lookup["assets/app.js.br"])
     }
 
@@ -125,7 +128,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
         let lookup = implementation.manifestHashLookup(manifest: manifest, sessionKey: "session-key")
 
-        XCTAssertEqual(lookup["index.html"], decryptedHex)
+        XCTAssertEqual(lookup["index.html"]?.hash, decryptedHex)
     }
 
     func testManifestHashLookupSkipsEntriesMissingFileNameOrHash() {
@@ -194,5 +197,28 @@ final class PopulateDeltaCacheTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "new.js").path))
 
         try? FileManager.default.removeItem(at: cacheFile(hash: realHash, name: "new.js"))
+    }
+
+    /// Regression test: the built-in bundle stores brotli manifest entries under
+    /// their original (`.br`-suffixed) name, while the extracted bundle file on disk
+    /// is always named without it. The builtin lookup must resolve against the
+    /// manifest's original name, not the extracted file's own path, or this match
+    /// silently never fires for any compressed asset.
+    func testPopulateDeltaCacheSkipsBrotliFilesAlreadyAvailableFromBuiltin() {
+        let content = "shared builtin content"
+        let extractedFileURL = write(content, named: "app.js", in: bundleDir.appendingPathComponent("assets"))
+        let realHash = CryptoCipher.calcChecksum(filePath: extractedFileURL)
+        _ = write(content, named: "app.js.br", in: builtinFolder.appendingPathComponent("assets"))
+        let manifest = [
+            ManifestEntry(file_name: "assets/app.js.br", file_hash: realHash, download_url: nil)
+        ]
+        let expectedCacheFile = cacheFile(hash: realHash, name: "app.js")
+        try? FileManager.default.removeItem(at: expectedCacheFile)
+
+        implementation.populateDeltaCache(for: bundleId, manifest: manifest, sessionKey: "")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expectedCacheFile.path))
+
+        try? FileManager.default.removeItem(at: expectedCacheFile)
     }
 }

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -17,6 +17,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     private var implementation: TestableCapgoUpdater!
     private var bundleId: String!
     private var bundleDir: URL!
+    private var registeredCacheFiles: [URL] = []
     private let cacheFolder = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("capgo_downloads")
     private var builtinFolder: URL {
         implementation.builtinFolderOverride
@@ -88,19 +89,41 @@ final class PopulateDeltaCacheTests: XCTestCase {
     override func tearDown() {
         try? FileManager.default.removeItem(at: bundleDir)
         try? FileManager.default.removeItem(at: builtinFolder)
+        for file in registeredCacheFiles {
+            try? FileManager.default.removeItem(at: file)
+        }
+        registeredCacheFiles = []
         implementation = nil
+        // CryptoCipher's logger is shared/static with no getter to snapshot the prior
+        // value, so restore a normal (non-silent) default rather than leaving other
+        // test suites silenced by this one.
+        CryptoCipher.setLogger(Logger(withTag: "TestLogger"))
         super.tearDown()
     }
 
-    private func write(_ content: String, named name: String, in directory: URL) -> URL {
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    private enum FixtureError: Error {
+        case writeFailed(String)
+    }
+
+    @discardableResult
+    private func write(_ content: String, named name: String, in directory: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let url = directory.appendingPathComponent(name)
-        try? content.data(using: .utf8)?.write(to: url)
+        guard let data = content.data(using: .utf8) else {
+            throw FixtureError.writeFailed("Could not encode fixture content for \(name)")
+        }
+        try data.write(to: url)
         return url
     }
 
-    private func cacheFile(hash: String, name: String) -> URL {
-        cacheFolder.appendingPathComponent("\(hash)_\(name)")
+    /// Computes the cache path for (hash, name), clears any stale entry left over from
+    /// an unrelated run (content/hash is deterministic, so paths can collide across
+    /// runs), and registers it for teardown cleanup regardless of test outcome.
+    private func expectedCacheFile(hash: String, name: String) -> URL {
+        let file = cacheFolder.appendingPathComponent("\(hash)_\(name)")
+        try? FileManager.default.removeItem(at: file)
+        registeredCacheFiles.append(file)
+        return file
     }
 
     // MARK: - manifestHashLookup
@@ -142,61 +165,54 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
     // MARK: - populateDeltaCache: (a) reuse manifest hashes instead of re-hashing
 
-    func testPopulateDeltaCacheReusesManifestHashInsteadOfRecomputing() {
-        let fileURL = write("hello world", named: "app.js", in: bundleDir)
+    func testPopulateDeltaCacheReusesManifestHashInsteadOfRecomputing() throws {
+        let fileURL = try write("hello world", named: "app.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
         let manifestHash = "deliberately-different-\(realHash)"
         let manifest = [
             ManifestEntry(file_name: "app.js", file_hash: manifestHash, download_url: nil)
         ]
+        let manifestCacheFile = expectedCacheFile(hash: manifestHash, name: "app.js")
+        let realCacheFile = expectedCacheFile(hash: realHash, name: "app.js")
 
         implementation.populateDeltaCache(for: bundleId, manifest: manifest, sessionKey: "")
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: manifestHash, name: "app.js").path))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "app.js").path))
-
-        try? FileManager.default.removeItem(at: cacheFile(hash: manifestHash, name: "app.js"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: manifestCacheFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: realCacheFile.path))
     }
 
-    func testPopulateDeltaCacheFallsBackToRealHashWhenNoManifestEntry() {
-        let fileURL = write("hello world", named: "app.js", in: bundleDir)
+    func testPopulateDeltaCacheFallsBackToRealHashWhenNoManifestEntry() throws {
+        let fileURL = try write("hello world", named: "app.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
+        let realCacheFile = expectedCacheFile(hash: realHash, name: "app.js")
 
         implementation.populateDeltaCache(for: bundleId)
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "app.js").path))
-
-        try? FileManager.default.removeItem(at: cacheFile(hash: realHash, name: "app.js"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: realCacheFile.path))
     }
 
     // MARK: - populateDeltaCache: (b) skip caching builtin-origin files
 
-    func testPopulateDeltaCacheSkipsFilesAlreadyAvailableFromBuiltin() {
+    func testPopulateDeltaCacheSkipsFilesAlreadyAvailableFromBuiltin() throws {
         let content = "shared builtin content"
-        let fileURL = write(content, named: "shared.js", in: bundleDir)
+        let fileURL = try write(content, named: "shared.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
-        _ = write(content, named: "shared.js", in: builtinFolder)
-        let expectedCacheFile = cacheFile(hash: realHash, name: "shared.js")
-        // Guard against a stale cache entry left over from an unrelated run
-        // (content/hash is deterministic, so the path can collide across runs).
-        try? FileManager.default.removeItem(at: expectedCacheFile)
+        try write(content, named: "shared.js", in: builtinFolder)
+        let cacheFile = expectedCacheFile(hash: realHash, name: "shared.js")
 
         implementation.populateDeltaCache(for: bundleId)
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: expectedCacheFile.path))
-
-        try? FileManager.default.removeItem(at: expectedCacheFile)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile.path))
     }
 
-    func testPopulateDeltaCacheStillCachesFilesNotPresentInBuiltin() {
-        let fileURL = write("only in this bundle", named: "new.js", in: bundleDir)
+    func testPopulateDeltaCacheStillCachesFilesNotPresentInBuiltin() throws {
+        let fileURL = try write("only in this bundle", named: "new.js", in: bundleDir)
         let realHash = CryptoCipher.calcChecksum(filePath: fileURL)
+        let cacheFile = expectedCacheFile(hash: realHash, name: "new.js")
 
         implementation.populateDeltaCache(for: bundleId)
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile(hash: realHash, name: "new.js").path))
-
-        try? FileManager.default.removeItem(at: cacheFile(hash: realHash, name: "new.js"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheFile.path))
     }
 
     /// Regression test: the built-in bundle stores brotli manifest entries under
@@ -204,21 +220,18 @@ final class PopulateDeltaCacheTests: XCTestCase {
     /// is always named without it. The builtin lookup must resolve against the
     /// manifest's original name, not the extracted file's own path, or this match
     /// silently never fires for any compressed asset.
-    func testPopulateDeltaCacheSkipsBrotliFilesAlreadyAvailableFromBuiltin() {
+    func testPopulateDeltaCacheSkipsBrotliFilesAlreadyAvailableFromBuiltin() throws {
         let content = "shared builtin content"
-        let extractedFileURL = write(content, named: "app.js", in: bundleDir.appendingPathComponent("assets"))
+        let extractedFileURL = try write(content, named: "app.js", in: bundleDir.appendingPathComponent("assets"))
         let realHash = CryptoCipher.calcChecksum(filePath: extractedFileURL)
-        _ = write(content, named: "app.js.br", in: builtinFolder.appendingPathComponent("assets"))
+        try write(content, named: "app.js.br", in: builtinFolder.appendingPathComponent("assets"))
         let manifest = [
             ManifestEntry(file_name: "assets/app.js.br", file_hash: realHash, download_url: nil)
         ]
-        let expectedCacheFile = cacheFile(hash: realHash, name: "app.js")
-        try? FileManager.default.removeItem(at: expectedCacheFile)
+        let cacheFile = expectedCacheFile(hash: realHash, name: "app.js")
 
         implementation.populateDeltaCache(for: bundleId, manifest: manifest, sessionKey: "")
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: expectedCacheFile.path))
-
-        try? FileManager.default.removeItem(at: expectedCacheFile)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile.path))
     }
 }


### PR DESCRIPTION
## Why
Even when nothing or almost nothing needs to be downloaded, the first launch can still process every file twice. This adds local CPU/disk work and contributes to the update pause.

## What
1. Skip re-hashing in `populateDeltaCache` by reusing the manifest hashes.
2. Skip caching files that already come from the built-in app bundle, because built-in is already a permanent reuse source.

## How
- New `manifestHashLookup(manifest:sessionKey:)` builds a `[path: hash]` map from the manifest (handles the encrypted-manifest path via the existing `resolveManifestFileHash`).
- `populateDeltaCache` looks up the hash there first, falls back to `calcChecksum` only when no manifest entry exists (legacy zip path, unchanged).
- Before caching, checks if an identical file exists in `builtinFolderURL()` (extracted from 3 duplicated inline expressions); skips if so.
- `downloadManifest` now calls `populateDeltaCacheAsync`, so manifest-based updates prime the delta cache too (previously only the full-zip `download()` path did — meaning this never ran at all for manifest updates before).
- No verification is weakened: the reused hashes are the same ones already checksum-verified earlier in the same call chain.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster update processing by reusing manifest-provided hashes and minimizing redundant checksum calculations.
  * Reduced delta-cache duplication by avoiding caching files already present in built-in assets when hashes match.
  * Improved handling of brotli-compressed asset names to ensure correct cache matching.
* **Reliability**
  * Enhanced delta-cache population to correctly handle encrypted manifest hashes.
  * Updated delta-cache population to run after manifest download completes for more consistent results.
* **Tests**
  * Added automated test coverage for hash mapping, encrypted hash behavior, and delta-cache edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->