### PR TITLE
fix(updater): honour Retry-After for all 429s, queue stats while blocked

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Android example app Maestro smoke / ${{ matrix.scenario }}
+    env:
+      CAPGO_MAESTRO_SUCCESS_MARKER: ${{ github.workspace }}/maestro-android-smoke.pass
     strategy:
       fail-fast: false
       matrix:
@@ -308,14 +310,18 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      # Same emulator teardown hazard as the live update job: bound the step below the job cap
+      # and let the success marker decide the result.
       - name: Run Maestro smoke tests
+        timeout-minutes: 8
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2.38.0 # NOSONAR version tag required by repo policy
         with:
           api-level: 30
           arch: x86_64
           profile: pixel_7
           disable-animations: true
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -no-metrics
           script: >-
             CAPGO_MAESTRO_SKIP_BUILD=1
             CAPGO_MAESTRO_SKIP_BUNDLE_BUILD=1
@@ -325,7 +331,14 @@ jobs:
             CAPGO_MAESTRO_APP_LAUNCH_RETRIES=2
             MAESTRO_DRIVER_STARTUP_TIMEOUT=300000
             CAPGO_MAESTRO_SMOKE_SCENARIO=${{ matrix.scenario }}
-            bun run test:maestro:android
+            bun run test:maestro:android && : > "$CAPGO_MAESTRO_SUCCESS_MARKER"
+      - name: Verify smoke scenario passed
+        run: |
+          if [[ ! -f "$CAPGO_MAESTRO_SUCCESS_MARKER" ]]; then
+            echo "Android smoke Maestro scenario '${{ matrix.scenario }}' did not pass."
+            exit 1
+          fi
+          echo "Android smoke Maestro scenario '${{ matrix.scenario }}' passed."
       - name: Upload Maestro artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -502,6 +515,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: maestro_android / ${{ matrix.scenario }}
+    env:
+      CAPGO_MAESTRO_SUCCESS_MARKER: ${{ github.workspace }}/maestro-android-live-update.pass
     strategy:
       fail-fast: false
       matrix:
@@ -552,23 +567,36 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      # The runner action tears the emulator down inside this step, and that teardown can hang
+      # for minutes after the flow already passed (an orphaned crashpad_handler keeps the pipe
+      # open). Bound the step below the job cap and let the success marker decide the result,
+      # so a hung teardown cannot burn the whole 10 minutes or fail a passing scenario.
       - name: Run live update Maestro flow
+        timeout-minutes: 8
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2.38.0 # NOSONAR version tag required by repo policy
         with:
           api-level: 30
           arch: x86_64
           profile: pixel_7
           disable-animations: true
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -no-metrics
           script: >-
             CAPGO_MAESTRO_SKIP_BUILD=1
             CAPGO_MAESTRO_SKIP_BUNDLE_BUILD=1
-            CAPGO_MAESTRO_FLOW_TIMEOUT_SECONDS=600
+            MAESTRO_FLOW_TIMEOUT_SECONDS=300
             CAPGO_MAESTRO_FLOW_RETRIES=2
             CAPGO_MAESTRO_SPLIT_RETRIES=2
             CAPGO_MAESTRO_UI_STATE_TIMEOUT_SECONDS=180
             CAPGO_MAESTRO_DIRECT_UPDATE_SETTLE_TIMEOUT_SECONDS=180
             bash ./scripts/maestro/run-android-live-update-ci.sh "${{ matrix.scenario }}"
+      - name: Verify live update scenario passed
+        run: |
+          if [[ ! -f "$CAPGO_MAESTRO_SUCCESS_MARKER" ]]; then
+            echo "Android live update Maestro scenario '${{ matrix.scenario }}' did not pass."
+            exit 1
+          fi
+          echo "Android live update Maestro scenario '${{ matrix.scenario }}' passed."
 
   maestro_android:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,7 +315,7 @@ jobs:
       - name: Run Maestro smoke tests
         timeout-minutes: 8
         continue-on-error: true
-        uses: reactivecircus/android-emulator-runner@v2.38.0 # NOSONAR version tag required by repo policy
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # tag=v2.38.0 NOSONAR hash pin required by zizmor
         with:
           api-level: 30
           arch: x86_64
@@ -574,7 +574,7 @@ jobs:
       - name: Run live update Maestro flow
         timeout-minutes: 8
         continue-on-error: true
-        uses: reactivecircus/android-emulator-runner@v2.38.0 # NOSONAR version tag required by repo policy
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # tag=v2.38.0 NOSONAR hash pin required by zizmor
         with:
           api-level: 30
           arch: x86_64

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -112,11 +112,10 @@ public class CapgoUpdater {
     // Cached key ID calculated once from publicKey
     private String cachedKeyId = "";
 
-    // Sticky block for on_premise_app 429s — stops stats/channel/getLatest until process restart.
-    private static volatile boolean rateLimitExceeded = false;
-
-    // Temporary too_many_requests block until this epoch ms (Retry-After / rateLimitResetAt).
+    // Temporary 429 block until this epoch ms (Retry-After / rateLimitResetAt). No sticky latch.
     private static volatile long rateLimitBlockedUntilMs = 0L;
+    private static volatile String rateLimitBlockedError = "too_many_requests";
+    private static volatile String rateLimitBlockedMessage = "Too many requests";
 
     // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
     private static volatile boolean rateLimitStatisticSent = false;
@@ -1929,9 +1928,8 @@ public class CapgoUpdater {
     }
 
     /**
-     * Handle HTTP 429 responses.
-     * - on_premise_app: sticky latch until process restart
-     * - too_many_requests: temporary block honouring Retry-After / rateLimitResetAt
+     * Handle HTTP 429 responses by honouring Retry-After / rateLimitResetAt.
+     * All 429s use the same temporary client block — no sticky latch until restart.
      */
     private RemoteBlockResult checkAndHandleRateLimitResponse(Response response, String responseData) {
         if (response == null || response.code() != 429) {
@@ -1943,18 +1941,14 @@ public class CapgoUpdater {
         final String errorCode = parsedError.isEmpty() ? "too_many_requests" : parsedError;
         final String message = parsedMessage.isEmpty() ? "Too many requests" : parsedMessage;
 
-        if ("on_premise_app".equals(errorCode)) {
-            if (!rateLimitExceeded) {
-                rateLimitExceeded = true;
-                rateLimitBlockedUntilMs = 0L;
-                logger.warn("On-premise app detected (429). Stopping stats, channel, and getLatest requests until app restart.");
-            }
-            return new RemoteBlockResult(true, errorCode, message);
-        }
-
         final long retryUntilMs = resolveRateLimitBlockedUntilMs(response, responseData);
         if (retryUntilMs > rateLimitBlockedUntilMs) {
             rateLimitBlockedUntilMs = retryUntilMs;
+            rateLimitBlockedError = errorCode;
+            rateLimitBlockedMessage = message;
+        } else if (rateLimitBlockedUntilMs <= 0L) {
+            rateLimitBlockedError = errorCode;
+            rateLimitBlockedMessage = message;
         }
 
         if ("too_many_requests".equals(errorCode)) {
@@ -1962,12 +1956,11 @@ public class CapgoUpdater {
                 rateLimitStatisticSent = true;
                 sendRateLimitStatistic();
             }
-            final long retryAfter = Math.max(0L, (Math.max(retryUntilMs, System.currentTimeMillis()) - System.currentTimeMillis() + 999L) / 1000L);
-            logger.warn("Rate limit exceeded (429 too_many_requests). Retry after " + retryAfter + "s.");
-            return new RemoteBlockResult(true, errorCode, message);
         }
 
-        logger.warn("Received 429 (" + errorCode + "). Honouring retry window when provided; not sticky-latching.");
+        final long nowMs = System.currentTimeMillis();
+        final long retryAfter = Math.max(0L, (Math.max(retryUntilMs, nowMs) - nowMs + 999L) / 1000L);
+        logger.warn("Received 429 (" + errorCode + "). Honouring Retry-After: " + retryAfter + "s.");
         return new RemoteBlockResult(true, errorCode, message);
     }
 
@@ -2046,9 +2039,6 @@ public class CapgoUpdater {
     }
 
     private boolean isRemoteBlocked() {
-        if (rateLimitExceeded) {
-            return true;
-        }
         final long until = rateLimitBlockedUntilMs;
         if (until <= 0L) {
             return false;
@@ -2062,10 +2052,7 @@ public class CapgoUpdater {
     }
 
     private RemoteBlockResult remoteBlockedClientError() {
-        if (rateLimitExceeded) {
-            return new RemoteBlockResult(true, "on_premise_app", "On-premise app detected");
-        }
-        return new RemoteBlockResult(true, "too_many_requests", "Too many requests");
+        return new RemoteBlockResult(true, rateLimitBlockedError, rateLimitBlockedMessage);
     }
 
     /**
@@ -2696,11 +2683,6 @@ public class CapgoUpdater {
             return;
         }
 
-        if (isRemoteBlocked()) {
-            logger.debug("Skipping sendStats due to remote block.");
-            return;
-        }
-
         String statsUrl = this.statsUrl;
         if (statsUrl == null || statsUrl.isEmpty()) {
             return;
@@ -2742,6 +2724,12 @@ public class CapgoUpdater {
             return;
         }
 
+        // While Retry-After is active, keep stats queued and skip the network call.
+        if (isRemoteBlocked()) {
+            logger.debug("Deferring stats flush until Retry-After expires.");
+            return;
+        }
+
         String statsUrl = this.statsUrl;
         if (statsUrl == null || statsUrl.isEmpty()) {
             statsQueue.clear();
@@ -2773,6 +2761,8 @@ public class CapgoUpdater {
             new okhttp3.Callback() {
                 @Override
                 public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                    // Keep events for a later flush attempt.
+                    requeueStatsEvents(eventsToSend);
                     logger.error("Failed to send stats batch");
                     logger.debug("Error: " + e.getMessage());
                 }
@@ -2782,6 +2772,7 @@ public class CapgoUpdater {
                     try (ResponseBody responseBody = response.body()) {
                         final String responseData = responseBody != null ? responseBody.string() : "";
                         if (checkAndHandleRateLimitResponse(response, responseData).blocked) {
+                            requeueStatsEvents(eventsToSend);
                             return;
                         }
 
@@ -2790,6 +2781,7 @@ public class CapgoUpdater {
                             logger.debug("Sent " + eventCount + " events");
                             runStatsCallbacks(eventsToSend);
                         } else {
+                            requeueStatsEvents(eventsToSend);
                             logger.error("Error sending stats batch");
                             logger.debug("Response code: " + response.code());
                         }
@@ -2797,6 +2789,16 @@ public class CapgoUpdater {
                 }
             }
         );
+    }
+
+    private void requeueStatsEvents(final List<QueuedStatsEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return;
+        }
+        synchronized (statsQueue) {
+            statsQueue.addAll(0, events);
+        }
+        ensureStatsTimerStarted();
     }
 
     private void runStatsCallbacks(final List<QueuedStatsEvent> sentEvents) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -113,12 +113,17 @@ public class CapgoUpdater {
     private String cachedKeyId = "";
 
     // Temporary 429 block until this epoch ms (Retry-After / rateLimitResetAt). No sticky latch.
-    private static volatile long rateLimitBlockedUntilMs = 0L;
-    private static volatile String rateLimitBlockedError = "too_many_requests";
-    private static volatile String rateLimitBlockedMessage = "Too many requests";
+    // Guarded by rateLimitStateLock so concurrent 429s cannot shorten the window or mix metadata.
+    private static final Object rateLimitStateLock = new Object();
+    private static long rateLimitBlockedUntilMs = 0L;
+    private static String rateLimitBlockedError = "too_many_requests";
+    private static String rateLimitBlockedMessage = "Too many requests";
 
     // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
-    private static volatile boolean rateLimitStatisticSent = false;
+    private static boolean rateLimitStatisticSent = false;
+
+    // Upper bound for a client-side 429 block, so a bogus Retry-After cannot block the app for days.
+    private static final long MAX_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000L;
 
     // Stats batching - queue events and send max once per second
     private final List<QueuedStatsEvent> statsQueue = new CopyOnWriteArrayList<>();
@@ -1916,6 +1921,7 @@ public class CapgoUpdater {
     }
 
     private static final class RemoteBlockResult {
+
         final boolean blocked;
         final String error;
         final String message;
@@ -1942,20 +1948,20 @@ public class CapgoUpdater {
         final String message = parsedMessage.isEmpty() ? "Too many requests" : parsedMessage;
 
         final long retryUntilMs = resolveRateLimitBlockedUntilMs(response, responseData);
-        if (retryUntilMs > rateLimitBlockedUntilMs) {
-            rateLimitBlockedUntilMs = retryUntilMs;
-            rateLimitBlockedError = errorCode;
-            rateLimitBlockedMessage = message;
-        } else if (rateLimitBlockedUntilMs <= 0L) {
-            rateLimitBlockedError = errorCode;
-            rateLimitBlockedMessage = message;
+        synchronized (rateLimitStateLock) {
+            if (retryUntilMs > rateLimitBlockedUntilMs) {
+                rateLimitBlockedUntilMs = retryUntilMs;
+                rateLimitBlockedError = errorCode;
+                rateLimitBlockedMessage = message;
+            } else if (rateLimitBlockedUntilMs <= 0L) {
+                rateLimitBlockedError = errorCode;
+                rateLimitBlockedMessage = message;
+            }
         }
 
-        if ("too_many_requests".equals(errorCode)) {
-            if (!this.previewSession && !rateLimitStatisticSent) {
-                rateLimitStatisticSent = true;
-                sendRateLimitStatistic();
-            }
+        if ("too_many_requests".equals(errorCode) && !this.previewSession && claimRateLimitStatistic()) {
+            // sendRateLimitStatistic() blocks on execute(); keep this callback thread free.
+            io.execute(this::sendRateLimitStatistic);
         }
 
         final long nowMs = System.currentTimeMillis();
@@ -1990,13 +1996,21 @@ public class CapgoUpdater {
 
     private long resolveRateLimitBlockedUntilMs(final Response response, final String responseData) {
         final long nowMs = System.currentTimeMillis();
+        final double candidate = rawRateLimitDeadlineMs(response, responseData, nowMs);
+        // NaN and past deadlines mean "no client-side block"; anything further out is capped.
+        if (!(candidate > nowMs)) {
+            return 0L;
+        }
+        return (long) Math.min(candidate, (double) nowMs + MAX_RATE_LIMIT_WINDOW_MS);
+    }
 
+    private double rawRateLimitDeadlineMs(final Response response, final String responseData, final long nowMs) {
         final String header = response.header("Retry-After");
         if (header != null) {
             try {
                 final double seconds = Double.parseDouble(header.trim());
                 if (seconds >= 0) {
-                    return nowMs + (long) (seconds * 1000L);
+                    return nowMs + seconds * 1000d;
                 }
             } catch (NumberFormatException ignored) {
                 // Fall through to body fields
@@ -2010,24 +2024,18 @@ public class CapgoUpdater {
                 if (moreInfo != null && moreInfo.has("retryAfterSeconds")) {
                     final double retryAfter = moreInfo.getDouble("retryAfterSeconds");
                     if (retryAfter >= 0) {
-                        return nowMs + (long) (retryAfter * 1000L);
+                        return nowMs + retryAfter * 1000d;
                     }
                 } else if (json.has("retryAfterSeconds")) {
                     final double retryAfter = json.getDouble("retryAfterSeconds");
                     if (retryAfter >= 0) {
-                        return nowMs + (long) (retryAfter * 1000L);
+                        return nowMs + retryAfter * 1000d;
                     }
                 }
                 if (moreInfo != null && moreInfo.has("rateLimitResetAt")) {
-                    final long resetAt = moreInfo.getLong("rateLimitResetAt");
-                    if (resetAt > nowMs) {
-                        return resetAt;
-                    }
+                    return moreInfo.getDouble("rateLimitResetAt");
                 } else if (json.has("rateLimitResetAt")) {
-                    final long resetAt = json.getLong("rateLimitResetAt");
-                    if (resetAt > nowMs) {
-                        return resetAt;
-                    }
+                    return json.getDouble("rateLimitResetAt");
                 }
             } catch (JSONException ignored) {
                 // No retry hint
@@ -2035,28 +2043,41 @@ public class CapgoUpdater {
         }
 
         // No retry hint — do not hold a client-side block; allow immediate retry to the worker
-        return 0L;
+        return 0d;
+    }
+
+    private static boolean claimRateLimitStatistic() {
+        synchronized (rateLimitStateLock) {
+            if (rateLimitStatisticSent) {
+                return false;
+            }
+            rateLimitStatisticSent = true;
+            return true;
+        }
     }
 
     private boolean isRemoteBlocked() {
-        final long until = rateLimitBlockedUntilMs;
-        if (until <= 0L) {
-            return false;
+        synchronized (rateLimitStateLock) {
+            if (rateLimitBlockedUntilMs <= 0L) {
+                return false;
+            }
+            if (System.currentTimeMillis() >= rateLimitBlockedUntilMs) {
+                rateLimitBlockedUntilMs = 0L;
+                return false;
+            }
+            return true;
         }
-        final long nowMs = System.currentTimeMillis();
-        if (nowMs >= until) {
-            rateLimitBlockedUntilMs = 0L;
-            return false;
-        }
-        return true;
     }
 
     private RemoteBlockResult remoteBlockedClientError() {
-        return new RemoteBlockResult(true, rateLimitBlockedError, rateLimitBlockedMessage);
+        synchronized (rateLimitStateLock) {
+            return new RemoteBlockResult(true, rateLimitBlockedError, rateLimitBlockedMessage);
+        }
     }
 
     /**
-     * Send a synchronous statistic about rate limiting
+     * Send a statistic about rate limiting.
+     * Blocks on the calling thread, so it must be dispatched to the io executor.
      */
     private void sendRateLimitStatistic() {
         String statsUrl = this.statsUrl;
@@ -2076,7 +2097,6 @@ public class CapgoUpdater {
                 .post(RequestBody.create(json.toString(), MediaType.get("application/json")))
                 .build();
 
-            // Send synchronously to ensure it goes out before the flag is set
             // User-Agent header is automatically added by DownloadService.sharedClient interceptor
             try (Response response = DownloadService.sharedClient.newCall(request).execute()) {
                 if (response.isSuccessful()) {
@@ -2127,8 +2147,14 @@ public class CapgoUpdater {
                             if (statusCode == 429) {
                                 final RemoteBlockResult rateLimit = checkAndHandleRateLimitResponse(response, responseData);
                                 Map<String, Object> retError = new HashMap<>();
-                                retError.put("error", rateLimit.error.isEmpty() ? jsonResponse.optString("error", "too_many_requests") : rateLimit.error);
-                                retError.put("message", rateLimit.message.isEmpty() ? jsonResponse.optString("message", "Too many requests") : rateLimit.message);
+                                retError.put(
+                                    "error",
+                                    rateLimit.error.isEmpty() ? jsonResponse.optString("error", "too_many_requests") : rateLimit.error
+                                );
+                                retError.put(
+                                    "message",
+                                    rateLimit.message.isEmpty() ? jsonResponse.optString("message", "Too many requests") : rateLimit.message
+                                );
                                 if (jsonResponse.has("kind") && !jsonResponse.isNull("kind")) {
                                     retError.put("kind", jsonResponse.getString("kind"));
                                 } else {
@@ -2704,7 +2730,10 @@ public class CapgoUpdater {
             return;
         }
 
-        statsQueue.add(new QueuedStatsEvent(json, onSent));
+        // Same lock as the flush transaction, so an event added mid-flush is never dropped.
+        synchronized (statsQueue) {
+            statsQueue.add(new QueuedStatsEvent(json, onSent));
+        }
         ensureStatsTimerStarted();
     }
 
@@ -2732,7 +2761,9 @@ public class CapgoUpdater {
 
         String statsUrl = this.statsUrl;
         if (statsUrl == null || statsUrl.isEmpty()) {
-            statsQueue.clear();
+            synchronized (statsQueue) {
+                statsQueue.clear();
+            }
             return;
         }
 
@@ -2780,15 +2811,26 @@ public class CapgoUpdater {
                             logger.info("Stats batch sent successfully");
                             logger.debug("Sent " + eventCount + " events");
                             runStatsCallbacks(eventsToSend);
-                        } else {
+                        } else if (isTransientStatsFailure(response.code())) {
                             requeueStatsEvents(eventsToSend);
                             logger.error("Error sending stats batch");
+                            logger.debug("Retrying later, response code: " + response.code());
+                        } else {
+                            // Permanent rejection: retrying would loop forever and block the queue.
+                            logger.error("Dropping stats batch after permanent error");
                             logger.debug("Response code: " + response.code());
                         }
                     }
                 }
             }
         );
+    }
+
+    /**
+     * Only 429, request timeout and 5xx are worth retrying; other 4xx are permanent rejections.
+     */
+    private static boolean isTransientStatsFailure(final int statusCode) {
+        return statusCode == 429 || statusCode == 408 || statusCode >= 500;
     }
 
     private void requeueStatsEvents(final List<QueuedStatsEvent> events) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1960,7 +1960,9 @@ public class CapgoUpdater {
             }
         }
 
-        if ("too_many_requests".equals(errorCode) && !this.previewSession && claimRateLimitStatistic()) {
+        // Claim last, and only when there is somewhere to send it, so a 429 burst with no
+        // stats URL does not claim and release the latch once per response.
+        if ("too_many_requests".equals(errorCode) && !this.previewSession && this.hasStatsUrl() && claimRateLimitStatistic()) {
             sendRateLimitStatistic();
         }
 
@@ -2065,6 +2067,11 @@ public class CapgoUpdater {
         }
     }
 
+    private boolean hasStatsUrl() {
+        final String url = this.statsUrl;
+        return url != null && !url.isEmpty();
+    }
+
     private boolean isRemoteBlocked() {
         synchronized (rateLimitStateLock) {
             if (rateLimitBlockedUntilMs <= 0L) {
@@ -2091,6 +2098,7 @@ public class CapgoUpdater {
     private void sendRateLimitStatistic() {
         String statsUrl = this.statsUrl;
         if (statsUrl == null || statsUrl.isEmpty()) {
+            // The URL was cleared after the claim was taken; nothing went out, so hand it back.
             releaseRateLimitStatisticClaim();
             return;
         }

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -2127,7 +2127,8 @@ public class CapgoUpdater {
 
                     @Override
                     public void onResponse(@NonNull Call call, @NonNull Response response) {
-                        try (ResponseBody responseBody = response.body()) {
+                        // The body is unused here; closing the Response closes it.
+                        try (response) {
                             if (response.isSuccessful()) {
                                 logger.info("Rate limit statistic sent");
                             } else {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -112,8 +112,11 @@ public class CapgoUpdater {
     // Cached key ID calculated once from publicKey
     private String cachedKeyId = "";
 
-    // Flag to track if we received a 429 response - stops requests until app restart
+    // Sticky block for on_premise_app 429s — stops stats/channel/getLatest until process restart.
     private static volatile boolean rateLimitExceeded = false;
+
+    // Temporary too_many_requests block until this epoch ms (Retry-After / rateLimitResetAt).
+    private static volatile long rateLimitBlockedUntilMs = 0L;
 
     // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
     private static volatile boolean rateLimitStatisticSent = false;
@@ -1913,22 +1916,156 @@ public class CapgoUpdater {
         return json;
     }
 
+    private static final class RemoteBlockResult {
+        final boolean blocked;
+        final String error;
+        final String message;
+
+        RemoteBlockResult(final boolean blocked, final String error, final String message) {
+            this.blocked = blocked;
+            this.error = error;
+            this.message = message;
+        }
+    }
+
     /**
-     * Check if a 429 (Too Many Requests) response was received and set the flag
+     * Handle HTTP 429 responses.
+     * - on_premise_app: sticky latch until process restart
+     * - too_many_requests: temporary block honouring Retry-After / rateLimitResetAt
      */
-    private boolean checkAndHandleRateLimitResponse(Response response) {
-        if (response.code() == 429) {
-            // Send a statistic about the rate limit BEFORE setting the flag
-            // Only send once to prevent infinite loop if the stat request itself gets rate limited
-            if (!this.previewSession && !rateLimitExceeded && !rateLimitStatisticSent) {
+    private RemoteBlockResult checkAndHandleRateLimitResponse(Response response, String responseData) {
+        if (response == null || response.code() != 429) {
+            return new RemoteBlockResult(false, "", "");
+        }
+
+        final String parsedError = parseRemoteError(responseData);
+        final String parsedMessage = parseRemoteMessage(responseData);
+        final String errorCode = parsedError.isEmpty() ? "too_many_requests" : parsedError;
+        final String message = parsedMessage.isEmpty() ? "Too many requests" : parsedMessage;
+
+        if ("on_premise_app".equals(errorCode)) {
+            if (!rateLimitExceeded) {
+                rateLimitExceeded = true;
+                rateLimitBlockedUntilMs = 0L;
+                logger.warn("On-premise app detected (429). Stopping stats, channel, and getLatest requests until app restart.");
+            }
+            return new RemoteBlockResult(true, errorCode, message);
+        }
+
+        final long retryUntilMs = resolveRateLimitBlockedUntilMs(response, responseData);
+        if (retryUntilMs > rateLimitBlockedUntilMs) {
+            rateLimitBlockedUntilMs = retryUntilMs;
+        }
+
+        if ("too_many_requests".equals(errorCode)) {
+            if (!this.previewSession && !rateLimitStatisticSent) {
                 rateLimitStatisticSent = true;
                 sendRateLimitStatistic();
             }
-            rateLimitExceeded = true;
-            logger.warn("Rate limit exceeded (429). Stopping all stats and channel requests until app restart.");
+            final long retryAfter = Math.max(0L, (Math.max(retryUntilMs, System.currentTimeMillis()) - System.currentTimeMillis() + 999L) / 1000L);
+            logger.warn("Rate limit exceeded (429 too_many_requests). Retry after " + retryAfter + "s.");
+            return new RemoteBlockResult(true, errorCode, message);
+        }
+
+        logger.warn("Received 429 (" + errorCode + "). Honouring retry window when provided; not sticky-latching.");
+        return new RemoteBlockResult(true, errorCode, message);
+    }
+
+    private String parseRemoteError(final String responseData) {
+        if (responseData == null || responseData.isEmpty()) {
+            return "";
+        }
+        try {
+            final JSONObject json = new JSONObject(responseData);
+            return json.optString("error", "");
+        } catch (JSONException ignored) {
+            return "";
+        }
+    }
+
+    private String parseRemoteMessage(final String responseData) {
+        if (responseData == null || responseData.isEmpty()) {
+            return "";
+        }
+        try {
+            final JSONObject json = new JSONObject(responseData);
+            return json.optString("message", "");
+        } catch (JSONException ignored) {
+            return "";
+        }
+    }
+
+    private long resolveRateLimitBlockedUntilMs(final Response response, final String responseData) {
+        final long nowMs = System.currentTimeMillis();
+
+        final String header = response.header("Retry-After");
+        if (header != null) {
+            try {
+                final double seconds = Double.parseDouble(header.trim());
+                if (seconds >= 0) {
+                    return nowMs + (long) (seconds * 1000L);
+                }
+            } catch (NumberFormatException ignored) {
+                // Fall through to body fields
+            }
+        }
+
+        if (responseData != null && !responseData.isEmpty()) {
+            try {
+                final JSONObject json = new JSONObject(responseData);
+                final JSONObject moreInfo = json.optJSONObject("moreInfo");
+                if (moreInfo != null && moreInfo.has("retryAfterSeconds")) {
+                    final double retryAfter = moreInfo.getDouble("retryAfterSeconds");
+                    if (retryAfter >= 0) {
+                        return nowMs + (long) (retryAfter * 1000L);
+                    }
+                } else if (json.has("retryAfterSeconds")) {
+                    final double retryAfter = json.getDouble("retryAfterSeconds");
+                    if (retryAfter >= 0) {
+                        return nowMs + (long) (retryAfter * 1000L);
+                    }
+                }
+                if (moreInfo != null && moreInfo.has("rateLimitResetAt")) {
+                    final long resetAt = moreInfo.getLong("rateLimitResetAt");
+                    if (resetAt > nowMs) {
+                        return resetAt;
+                    }
+                } else if (json.has("rateLimitResetAt")) {
+                    final long resetAt = json.getLong("rateLimitResetAt");
+                    if (resetAt > nowMs) {
+                        return resetAt;
+                    }
+                }
+            } catch (JSONException ignored) {
+                // No retry hint
+            }
+        }
+
+        // No retry hint — do not hold a client-side block; allow immediate retry to the worker
+        return 0L;
+    }
+
+    private boolean isRemoteBlocked() {
+        if (rateLimitExceeded) {
             return true;
         }
-        return false;
+        final long until = rateLimitBlockedUntilMs;
+        if (until <= 0L) {
+            return false;
+        }
+        final long nowMs = System.currentTimeMillis();
+        if (nowMs >= until) {
+            rateLimitBlockedUntilMs = 0L;
+            return false;
+        }
+        return true;
+    }
+
+    private RemoteBlockResult remoteBlockedClientError() {
+        if (rateLimitExceeded) {
+            return new RemoteBlockResult(true, "on_premise_app", "On-premise app detected");
+        }
+        return new RemoteBlockResult(true, "too_many_requests", "Too many requests");
     }
 
     /**
@@ -2001,7 +2138,21 @@ public class CapgoUpdater {
 
                         if (jsonResponse != null && (jsonResponse.has("error") || jsonResponse.has("kind"))) {
                             if (statusCode == 429) {
-                                checkAndHandleRateLimitResponse(response);
+                                final RemoteBlockResult rateLimit = checkAndHandleRateLimitResponse(response, responseData);
+                                Map<String, Object> retError = new HashMap<>();
+                                retError.put("error", rateLimit.error.isEmpty() ? jsonResponse.optString("error", "too_many_requests") : rateLimit.error);
+                                retError.put("message", rateLimit.message.isEmpty() ? jsonResponse.optString("message", "Too many requests") : rateLimit.message);
+                                if (jsonResponse.has("kind") && !jsonResponse.isNull("kind")) {
+                                    retError.put("kind", jsonResponse.getString("kind"));
+                                } else {
+                                    retError.put("kind", "failed");
+                                }
+                                if (jsonResponse.has("version") && !jsonResponse.isNull("version")) {
+                                    retError.put("version", jsonResponse.getString("version"));
+                                }
+                                retError.put("statusCode", statusCode);
+                                callback.callback(retError);
+                                return;
                             }
                             Map<String, Object> retError = new HashMap<>();
                             if (jsonResponse.has("error") && !jsonResponse.isNull("error")) {
@@ -2023,11 +2174,12 @@ public class CapgoUpdater {
                             return;
                         }
 
-                        // Check for 429 rate limit
-                        if (checkAndHandleRateLimitResponse(response)) {
+                        // Check for 429 rate limit without JSON body
+                        final RemoteBlockResult rateLimit = checkAndHandleRateLimitResponse(response, responseData);
+                        if (rateLimit.blocked) {
                             Map<String, Object> retError = new HashMap<>();
-                            retError.put("message", "Rate limit exceeded");
-                            retError.put("error", "rate_limit_exceeded");
+                            retError.put("message", rateLimit.message);
+                            retError.put("error", rateLimit.error);
                             retError.put("kind", "failed");
                             retError.put("statusCode", statusCode);
                             callback.callback(retError);
@@ -2080,6 +2232,16 @@ public class CapgoUpdater {
     }
 
     public void getLatest(final String updateUrl, final String channel, final String appIdOverride, final Callback callback) {
+        if (isRemoteBlocked()) {
+            final RemoteBlockResult blocked = remoteBlockedClientError();
+            logger.debug("Skipping getLatest due to remote block (" + blocked.error + ").");
+            final Map<String, Object> retError = new HashMap<>();
+            retError.put("message", blocked.message);
+            retError.put("error", blocked.error);
+            retError.put("kind", "failed");
+            callback.callback(retError);
+            return;
+        }
         JSONObject json;
         try {
             json = this.createInfoObject(appIdOverride);
@@ -2149,12 +2311,12 @@ public class CapgoUpdater {
             return;
         }
 
-        // Check if rate limit was exceeded
-        if (rateLimitExceeded) {
-            logger.debug("Skipping setChannel due to rate limit (429). Requests will resume after app restart.");
+        if (isRemoteBlocked()) {
+            final RemoteBlockResult blocked = remoteBlockedClientError();
+            logger.debug("Skipping setChannel due to remote block (" + blocked.error + ").");
             final Map<String, Object> retError = new HashMap<>();
-            retError.put("message", "Rate limit exceeded");
-            retError.put("error", "rate_limit_exceeded");
+            retError.put("message", blocked.message);
+            retError.put("error", blocked.error);
             callback.callback(retError);
             return;
         }
@@ -2208,12 +2370,12 @@ public class CapgoUpdater {
     }
 
     public void getChannel(final Callback callback, final SharedPreferences.Editor editor, final String defaultChannelKey) {
-        // Check if rate limit was exceeded
-        if (rateLimitExceeded) {
-            logger.debug("Skipping getChannel due to rate limit (429). Requests will resume after app restart.");
+        if (isRemoteBlocked()) {
+            final RemoteBlockResult blocked = remoteBlockedClientError();
+            logger.debug("Skipping getChannel due to remote block (" + blocked.error + ").");
             final Map<String, Object> retError = new HashMap<>();
-            retError.put("message", "Rate limit exceeded");
-            retError.put("error", "rate_limit_exceeded");
+            retError.put("message", blocked.message);
+            retError.put("error", blocked.error);
             callback.callback(retError);
             return;
         }
@@ -2258,25 +2420,18 @@ public class CapgoUpdater {
                 @Override
                 public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                     try (ResponseBody responseBody = response.body()) {
-                        // Check for 429 rate limit
-                        if (checkAndHandleRateLimitResponse(response)) {
+                        final String responseData = responseBody != null ? responseBody.string() : "";
+                        final RemoteBlockResult rateLimit = checkAndHandleRateLimitResponse(response, responseData);
+                        if (rateLimit.blocked) {
                             Map<String, Object> retError = new HashMap<>();
-                            retError.put("message", "Rate limit exceeded");
-                            retError.put("error", "rate_limit_exceeded");
+                            retError.put("message", rateLimit.message);
+                            retError.put("error", rateLimit.error);
                             callback.callback(retError);
                             return;
                         }
 
                         if (response.code() == 400) {
-                            if (responseBody == null) {
-                                Map<String, Object> retError = new HashMap<>();
-                                retError.put("message", "Empty response body");
-                                retError.put("error", "no_response_body");
-                                callback.callback(retError);
-                                return;
-                            }
-                            String data = responseBody.string();
-                            if (data.contains("channel_not_found") && !defaultChannel.isEmpty()) {
+                            if (responseData.contains("channel_not_found") && !defaultChannel.isEmpty()) {
                                 Map<String, Object> ret = new HashMap<>();
                                 ret.put("channel", defaultChannel);
                                 ret.put("status", "default");
@@ -2294,14 +2449,13 @@ public class CapgoUpdater {
                             return;
                         }
 
-                        if (responseBody == null) {
+                        if (responseData.isEmpty()) {
                             Map<String, Object> retError = new HashMap<>();
                             retError.put("message", "Empty response body");
                             retError.put("error", "no_response_body");
                             callback.callback(retError);
                             return;
                         }
-                        String responseData = responseBody.string();
                         JSONObject jsonResponse = new JSONObject(responseData);
 
                         // Check for server-side errors first
@@ -2359,12 +2513,12 @@ public class CapgoUpdater {
     }
 
     public void listChannels(final Callback callback) {
-        // Check if rate limit was exceeded
-        if (rateLimitExceeded) {
-            logger.debug("Skipping listChannels due to rate limit (429). Requests will resume after app restart.");
+        if (isRemoteBlocked()) {
+            final RemoteBlockResult blocked = remoteBlockedClientError();
+            logger.debug("Skipping listChannels due to remote block (" + blocked.error + ").");
             final Map<String, Object> retError = new HashMap<>();
-            retError.put("message", "Rate limit exceeded");
-            retError.put("error", "rate_limit_exceeded");
+            retError.put("message", blocked.message);
+            retError.put("error", blocked.error);
             callback.callback(retError);
             return;
         }
@@ -2423,11 +2577,12 @@ public class CapgoUpdater {
                 @Override
                 public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                     try (ResponseBody responseBody = response.body()) {
-                        // Check for 429 rate limit
-                        if (checkAndHandleRateLimitResponse(response)) {
+                        final String data = responseBody != null ? responseBody.string() : "";
+                        final RemoteBlockResult rateLimit = checkAndHandleRateLimitResponse(response, data);
+                        if (rateLimit.blocked) {
                             Map<String, Object> retError = new HashMap<>();
-                            retError.put("message", "Rate limit exceeded");
-                            retError.put("error", "rate_limit_exceeded");
+                            retError.put("message", rateLimit.message);
+                            retError.put("error", rateLimit.error);
                             callback.callback(retError);
                             return;
                         }
@@ -2440,14 +2595,13 @@ public class CapgoUpdater {
                             return;
                         }
 
-                        if (responseBody == null) {
+                        if (data.isEmpty()) {
                             Map<String, Object> retError = new HashMap<>();
                             retError.put("message", "Empty response body");
                             retError.put("error", "no_response_body");
                             callback.callback(retError);
                             return;
                         }
-                        String data = responseBody.string();
 
                         try {
                             Map<String, Object> ret = parseListChannelsResponse(data);
@@ -2542,9 +2696,8 @@ public class CapgoUpdater {
             return;
         }
 
-        // Check if rate limit was exceeded
-        if (rateLimitExceeded) {
-            logger.debug("Skipping sendStats due to rate limit (429). Stats will resume after app restart.");
+        if (isRemoteBlocked()) {
+            logger.debug("Skipping sendStats due to remote block.");
             return;
         }
 
@@ -2627,8 +2780,8 @@ public class CapgoUpdater {
                 @Override
                 public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                     try (ResponseBody responseBody = response.body()) {
-                        // Check for 429 rate limit
-                        if (checkAndHandleRateLimitResponse(response)) {
+                        final String responseData = responseBody != null ? responseBody.string() : "";
+                        if (checkAndHandleRateLimitResponse(response, responseData).blocked) {
                             return;
                         }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1960,8 +1960,7 @@ public class CapgoUpdater {
         }
 
         if ("too_many_requests".equals(errorCode) && !this.previewSession && claimRateLimitStatistic()) {
-            // sendRateLimitStatistic() blocks on execute(); keep this callback thread free.
-            io.execute(this::sendRateLimitStatistic);
+            sendRateLimitStatistic();
         }
 
         final long nowMs = System.currentTimeMillis();
@@ -2077,7 +2076,7 @@ public class CapgoUpdater {
 
     /**
      * Send a statistic about rate limiting.
-     * Blocks on the calling thread, so it must be dispatched to the io executor.
+     * Dispatched through OkHttp so no caller thread waits on the request.
      */
     private void sendRateLimitStatistic() {
         String statsUrl = this.statsUrl;
@@ -2098,14 +2097,27 @@ public class CapgoUpdater {
                 .build();
 
             // User-Agent header is automatically added by DownloadService.sharedClient interceptor
-            try (Response response = DownloadService.sharedClient.newCall(request).execute()) {
-                if (response.isSuccessful()) {
-                    logger.info("Rate limit statistic sent");
-                } else {
-                    logger.error("Error sending rate limit statistic");
-                    logger.debug("Response code: " + response.code());
+            DownloadService.sharedClient.newCall(request).enqueue(
+                new okhttp3.Callback() {
+                    @Override
+                    public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                        logger.error("Failed to send rate limit statistic");
+                        logger.debug("Error: " + e.getMessage());
+                    }
+
+                    @Override
+                    public void onResponse(@NonNull Call call, @NonNull Response response) {
+                        try (ResponseBody responseBody = response.body()) {
+                            if (response.isSuccessful()) {
+                                logger.info("Rate limit statistic sent");
+                            } else {
+                                logger.error("Error sending rate limit statistic");
+                                logger.debug("Response code: " + response.code());
+                            }
+                        }
+                    }
                 }
-            }
+            );
         } catch (final Exception e) {
             logger.error("Failed to send rate limit statistic");
             logger.debug("Error: " + e.getMessage());

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -119,7 +119,8 @@ public class CapgoUpdater {
     private static String rateLimitBlockedError = "too_many_requests";
     private static String rateLimitBlockedMessage = "Too many requests";
 
-    // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
+    // Flag to track if we've already sent the rate limit statistic - prevents infinite loop.
+    // Released again when the send fails, so a later 429 can retry it.
     private static boolean rateLimitStatisticSent = false;
 
     // Upper bound for a client-side 429 block, so a bogus Retry-After cannot block the app for days.
@@ -2055,6 +2056,15 @@ public class CapgoUpdater {
         }
     }
 
+    /**
+     * Give the claim back when the statistic never made it out, so a later 429 can retry it.
+     */
+    private static void releaseRateLimitStatisticClaim() {
+        synchronized (rateLimitStateLock) {
+            rateLimitStatisticSent = false;
+        }
+    }
+
     private boolean isRemoteBlocked() {
         synchronized (rateLimitStateLock) {
             if (rateLimitBlockedUntilMs <= 0L) {
@@ -2081,6 +2091,7 @@ public class CapgoUpdater {
     private void sendRateLimitStatistic() {
         String statsUrl = this.statsUrl;
         if (statsUrl == null || statsUrl.isEmpty()) {
+            releaseRateLimitStatisticClaim();
             return;
         }
 
@@ -2101,6 +2112,7 @@ public class CapgoUpdater {
                 new okhttp3.Callback() {
                     @Override
                     public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                        releaseRateLimitStatisticClaim();
                         logger.error("Failed to send rate limit statistic");
                         logger.debug("Error: " + e.getMessage());
                     }
@@ -2111,6 +2123,7 @@ public class CapgoUpdater {
                             if (response.isSuccessful()) {
                                 logger.info("Rate limit statistic sent");
                             } else {
+                                releaseRateLimitStatisticClaim();
                                 logger.error("Error sending rate limit statistic");
                                 logger.debug("Response code: " + response.code());
                             }
@@ -2119,6 +2132,7 @@ public class CapgoUpdater {
                 }
             );
         } catch (final Exception e) {
+            releaseRateLimitStatisticClaim();
             logger.error("Failed to send rate limit statistic");
             logger.debug("Error: " + e.getMessage());
         }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -3011,7 +3011,7 @@ import UIKit
                 case .success:
                     self.logger.info("Stats batch sent successfully")
                     self.logger.debug("Sent \(eventsToSend.count) events")
-                    queuedEvents.compactMap(\.onSent).forEach { $0() }
+                    self.runStatsCallbacks(queuedEvents)
                 case let .failure(error):
                     self.requeueStatsEvents(queuedEvents)
                     self.logger.error("Error sending stats batch")
@@ -3027,6 +3027,12 @@ import UIKit
     /// Only 429, request timeout and 5xx are worth retrying; other 4xx are permanent rejections.
     private static func isTransientStatsFailure(_ statusCode: Int) -> Bool {
         return statusCode == 429 || statusCode == 408 || statusCode >= 500
+    }
+
+    private func runStatsCallbacks(_ sentEvents: [QueuedStatsEvent]) {
+        for sentEvent in sentEvents {
+            sentEvent.onSent?()
+        }
     }
 
     private func requeueStatsEvents(_ events: [QueuedStatsEvent]) {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -49,8 +49,11 @@ import UIKit
     // Cached key ID calculated once from publicKey
     private var cachedKeyId: String?
 
-    // Flag to track if we received a 429 response - stops requests until app restart
+    // Sticky block for on_premise_app 429s — stops stats/channel/getLatest until process restart.
     private static var rateLimitExceeded = false
+
+    // Temporary too_many_requests block until this epoch ms (Retry-After / rateLimitResetAt).
+    private static var rateLimitBlockedUntilMs: Double = 0
 
     // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
     private static var rateLimitStatisticSent = false
@@ -421,26 +424,118 @@ import UIKit
         }
     }
 
-    /**
-     * Check if a 429 (Too Many Requests) response was received and set the flag
-     */
-    private func checkAndHandleRateLimitResponse(statusCode: Int?) -> Bool {
-        if statusCode == 429 {
-            // Send a statistic about the rate limit BEFORE setting the flag
-            // Only send once to prevent infinite loop if the stat request itself gets rate limited
-            if !previewSession && !CapgoUpdater.rateLimitExceeded && !CapgoUpdater.rateLimitStatisticSent {
-                CapgoUpdater.rateLimitStatisticSent = true
+    private struct RemoteBlockResult {
+        let blocked: Bool
+        let error: String
+        let message: String
+    }
 
-                // Dispatch to background queue to avoid blocking the main thread
+    /**
+     * Handle HTTP 429 responses.
+     * - on_premise_app: sticky latch until process restart
+     * - too_many_requests: temporary block honouring Retry-After / rateLimitResetAt
+     */
+    private func checkAndHandleRateLimitResponse(
+        statusCode: Int?,
+        data: Data? = nil,
+        response: HTTPURLResponse? = nil
+    ) -> RemoteBlockResult {
+        guard statusCode == 429 else {
+            return RemoteBlockResult(blocked: false, error: "", message: "")
+        }
+
+        let parsed = parseRemoteError(from: data)
+        let errorCode = parsed.error.isEmpty ? "too_many_requests" : parsed.error
+        let message = parsed.message.isEmpty ? "Too many requests" : parsed.message
+
+        if errorCode == "on_premise_app" {
+            if !CapgoUpdater.rateLimitExceeded {
+                CapgoUpdater.rateLimitExceeded = true
+                CapgoUpdater.rateLimitBlockedUntilMs = 0
+                logger.warn("On-premise app detected (429). Stopping stats, channel, and getLatest requests until app restart.")
+            }
+            return RemoteBlockResult(blocked: true, error: errorCode, message: message)
+        }
+
+        let retryUntilMs = resolveRateLimitBlockedUntilMs(data: data, response: response)
+        if retryUntilMs > CapgoUpdater.rateLimitBlockedUntilMs {
+            CapgoUpdater.rateLimitBlockedUntilMs = retryUntilMs
+        }
+
+        if errorCode == "too_many_requests" {
+            if !previewSession && !CapgoUpdater.rateLimitStatisticSent {
+                CapgoUpdater.rateLimitStatisticSent = true
                 DispatchQueue.global(qos: .utility).async {
                     self.sendRateLimitStatistic()
                 }
             }
-            CapgoUpdater.rateLimitExceeded = true
-            logger.warn("Rate limit exceeded (429). Stopping all stats and channel requests until app restart.")
+            let retryAfter = max(0, Int(ceil((max(retryUntilMs, Date().timeIntervalSince1970 * 1000) - Date().timeIntervalSince1970 * 1000) / 1000)))
+            logger.warn("Rate limit exceeded (429 too_many_requests). Retry after \(retryAfter)s.")
+            return RemoteBlockResult(blocked: true, error: errorCode, message: message)
+        }
+
+        logger.warn("Received 429 (\(errorCode)). Honouring retry window when provided; not sticky-latching.")
+        return RemoteBlockResult(blocked: true, error: errorCode, message: message)
+    }
+
+    private func parseRemoteError(from data: Data?) -> (error: String, message: String) {
+        guard let data = data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return ("", "")
+        }
+        let error = json["error"] as? String ?? ""
+        let message = json["message"] as? String ?? ""
+        return (error, message)
+    }
+
+    private func resolveRateLimitBlockedUntilMs(data: Data?, response: HTTPURLResponse?) -> Double {
+        let nowMs = Date().timeIntervalSince1970 * 1000
+
+        if let header = response?.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let seconds = Double(header), seconds >= 0 {
+            return nowMs + seconds * 1000
+        }
+
+        if let data = data,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let moreInfo = json["moreInfo"] as? [String: Any]
+            if let retryAfter = (moreInfo?["retryAfterSeconds"] as? NSNumber)?.doubleValue
+                ?? (json["retryAfterSeconds"] as? NSNumber)?.doubleValue,
+               retryAfter >= 0 {
+                return nowMs + retryAfter * 1000
+            }
+            if let resetAt = (moreInfo?["rateLimitResetAt"] as? NSNumber)?.doubleValue
+                ?? (json["rateLimitResetAt"] as? NSNumber)?.doubleValue,
+               resetAt > nowMs {
+                return resetAt
+            }
+        }
+
+        // No retry hint — do not hold a client-side block; allow immediate retry to the worker
+        return 0
+    }
+
+    private func isRemoteBlocked() -> Bool {
+        if CapgoUpdater.rateLimitExceeded {
             return true
         }
-        return false
+        let until = CapgoUpdater.rateLimitBlockedUntilMs
+        if until <= 0 {
+            return false
+        }
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        if nowMs >= until {
+            CapgoUpdater.rateLimitBlockedUntilMs = 0
+            return false
+        }
+        return true
+    }
+
+    private func remoteBlockedClientError() -> (error: String, message: String) {
+        if CapgoUpdater.rateLimitExceeded {
+            return ("on_premise_app", "On-premise app detected")
+        }
+        return ("too_many_requests", "Too many requests")
     }
 
     /**
@@ -825,6 +920,14 @@ import UIKit
 
     public func getLatest(url: URL, channel: String?, appIdOverride: String? = nil) -> AppVersion {
         let latest: AppVersion = AppVersion()
+        if isRemoteBlocked() {
+            let blocked = remoteBlockedClientError()
+            logger.debug("Skipping getLatest due to remote block (\(blocked.error)).")
+            latest.message = blocked.message
+            latest.error = blocked.error
+            latest.kind = "failed"
+            return latest
+        }
         func applyLatestResponse(_ value: AppVersionDec?) {
             if let url = value?.url {
                 latest.url = url
@@ -905,9 +1008,14 @@ import UIKit
             return latest
         }
 
-        if self.checkAndHandleRateLimitResponse(statusCode: latest.statusCode) {
-            latest.message = "Rate limit exceeded"
-            latest.error = "rate_limit_exceeded"
+        let rateLimit = self.checkAndHandleRateLimitResponse(
+            statusCode: latest.statusCode,
+            data: data,
+            response: result.response
+        )
+        if rateLimit.blocked {
+            latest.message = rateLimit.message
+            latest.error = rateLimit.error
             latest.kind = "failed"
             return latest
         }
@@ -2419,11 +2527,11 @@ import UIKit
             return setChannel
         }
 
-        // Check if rate limit was exceeded
-        if CapgoUpdater.rateLimitExceeded {
-            logger.debug("Skipping setChannel due to rate limit (429). Requests will resume after app restart.")
-            setChannel.message = "Rate limit exceeded"
-            setChannel.error = "rate_limit_exceeded"
+        if isRemoteBlocked() {
+            let blocked = remoteBlockedClientError()
+            logger.debug("Skipping setChannel due to remote block (\(blocked.error)).")
+            setChannel.message = blocked.message
+            setChannel.error = blocked.error
             return setChannel
         }
 
@@ -2448,9 +2556,14 @@ import UIKit
 
         let result = performRequest(request, label: "setChannel")
 
-        if self.checkAndHandleRateLimitResponse(statusCode: result.response?.statusCode) {
-            setChannel.message = "Rate limit exceeded"
-            setChannel.error = "rate_limit_exceeded"
+        let rateLimit = self.checkAndHandleRateLimitResponse(
+            statusCode: result.response?.statusCode,
+            data: result.data,
+            response: result.response
+        )
+        if rateLimit.blocked {
+            setChannel.message = rateLimit.message
+            setChannel.error = rateLimit.error
             return setChannel
         }
 
@@ -2509,10 +2622,11 @@ import UIKit
     func getChannel(defaultChannelKey: String? = nil) -> GetChannel {
         let getChannel: GetChannel = GetChannel()
         // Check if rate limit was exceeded
-        if CapgoUpdater.rateLimitExceeded {
-            logger.debug("Skipping getChannel due to rate limit (429). Requests will resume after app restart.")
-            getChannel.message = "Rate limit exceeded"
-            getChannel.error = "rate_limit_exceeded"
+        if isRemoteBlocked() {
+            let blocked = remoteBlockedClientError()
+            logger.debug("Skipping getChannel due to remote block (\(blocked.error)).")
+            getChannel.message = blocked.message
+            getChannel.error = blocked.error
             return getChannel
         }
 
@@ -2536,9 +2650,14 @@ import UIKit
 
         let result = performRequest(request, label: "getChannel")
 
-        if self.checkAndHandleRateLimitResponse(statusCode: result.response?.statusCode) {
-            getChannel.message = "Rate limit exceeded"
-            getChannel.error = "rate_limit_exceeded"
+        let rateLimit = self.checkAndHandleRateLimitResponse(
+            statusCode: result.response?.statusCode,
+            data: result.data,
+            response: result.response
+        )
+        if rateLimit.blocked {
+            getChannel.message = rateLimit.message
+            getChannel.error = rateLimit.error
             return getChannel
         }
 
@@ -2616,9 +2735,10 @@ import UIKit
         let listChannels: ListChannels = ListChannels()
 
         // Check if rate limit was exceeded
-        if CapgoUpdater.rateLimitExceeded {
-            logger.debug("Skipping listChannels due to rate limit (429). Requests will resume after app restart.")
-            listChannels.error = "rate_limit_exceeded"
+        if isRemoteBlocked() {
+            let blocked = remoteBlockedClientError()
+            logger.debug("Skipping listChannels due to remote block (\(blocked.error)).")
+            listChannels.error = blocked.error
             return listChannels
         }
 
@@ -2652,8 +2772,13 @@ import UIKit
 
         let result = performRequest(request, label: "listChannels")
 
-        if self.checkAndHandleRateLimitResponse(statusCode: result.response?.statusCode) {
-            listChannels.error = "rate_limit_exceeded"
+        let rateLimit = self.checkAndHandleRateLimitResponse(
+            statusCode: result.response?.statusCode,
+            data: result.data,
+            response: result.response
+        )
+        if rateLimit.blocked {
+            listChannels.error = rateLimit.error
             return listChannels
         }
 
@@ -2738,8 +2863,8 @@ import UIKit
         }
 
         // Check if rate limit was exceeded
-        if CapgoUpdater.rateLimitExceeded {
-            logger.debug("Skipping sendStats due to rate limit (429). Stats will resume after app restart.")
+        if isRemoteBlocked() {
+            logger.debug("Skipping sendStats due to remote block.")
             return
         }
 
@@ -2819,7 +2944,7 @@ import UIKit
                 requestModifier: { $0.timeoutInterval = self.timeout }
             ).responseData { response in
                 // Check for 429 rate limit
-                if self.checkAndHandleRateLimitResponse(statusCode: response.response?.statusCode) {
+                if self.checkAndHandleRateLimitResponse(statusCode: response.response?.statusCode, data: response.data, response: response.response).blocked {
                     semaphore.signal()
                     return
                 }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -50,12 +50,17 @@ import UIKit
     private var cachedKeyId: String?
 
     // Temporary 429 block until this epoch ms (Retry-After / rateLimitResetAt). No sticky latch.
+    // Guarded by rateLimitStateLock so concurrent 429s cannot shorten the window or mix metadata.
+    private static let rateLimitStateLock = NSLock()
     private static var rateLimitBlockedUntilMs: Double = 0
     private static var rateLimitBlockedError: String = "too_many_requests"
     private static var rateLimitBlockedMessage: String = "Too many requests"
 
     // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
     private static var rateLimitStatisticSent = false
+
+    // Upper bound for a client-side 429 block, so a bogus Retry-After cannot block the app for days.
+    private static let maxRateLimitWindowMs: Double = 24 * 60 * 60 * 1000
 
     // Stats batching - queue events and send max once per second
     private var statsQueue: [QueuedStatsEvent] = []
@@ -447,28 +452,53 @@ import UIKit
         let message = parsed.message.isEmpty ? "Too many requests" : parsed.message
 
         let retryUntilMs = resolveRateLimitBlockedUntilMs(data: data, response: response)
-        if retryUntilMs > CapgoUpdater.rateLimitBlockedUntilMs {
-            CapgoUpdater.rateLimitBlockedUntilMs = retryUntilMs
-            CapgoUpdater.rateLimitBlockedError = errorCode
-            CapgoUpdater.rateLimitBlockedMessage = message
-        } else if CapgoUpdater.rateLimitBlockedUntilMs <= 0 {
-            CapgoUpdater.rateLimitBlockedError = errorCode
-            CapgoUpdater.rateLimitBlockedMessage = message
-        }
+        CapgoUpdater.recordRateLimitBlock(untilMs: retryUntilMs, error: errorCode, message: message)
 
-        if errorCode == "too_many_requests" {
-            if !previewSession && !CapgoUpdater.rateLimitStatisticSent {
-                CapgoUpdater.rateLimitStatisticSent = true
-                DispatchQueue.global(qos: .utility).async {
-                    self.sendRateLimitStatistic()
-                }
+        if errorCode == "too_many_requests" && !previewSession && CapgoUpdater.claimRateLimitStatistic() {
+            DispatchQueue.global(qos: .utility).async {
+                self.sendRateLimitStatistic()
             }
         }
 
         let nowMs = Date().timeIntervalSince1970 * 1000
-        let retryAfter = max(0, Int(ceil((max(retryUntilMs, nowMs) - nowMs) / 1000)))
+        let retryAfter = CapgoUpdater.retryAfterSecondsForLog(untilMs: retryUntilMs, nowMs: nowMs)
         logger.warn("Received 429 (\(errorCode)). Honouring Retry-After: \(retryAfter)s.")
         return RemoteBlockResult(blocked: true, error: errorCode, message: message)
+    }
+
+    /// Stores the block deadline and its metadata together, keeping the longest deadline
+    /// so a concurrent 429 with a shorter window cannot cut the block short.
+    private static func recordRateLimitBlock(untilMs: Double, error: String, message: String) {
+        rateLimitStateLock.lock()
+        defer { rateLimitStateLock.unlock() }
+        if untilMs > rateLimitBlockedUntilMs {
+            rateLimitBlockedUntilMs = untilMs
+            rateLimitBlockedError = error
+            rateLimitBlockedMessage = message
+        } else if rateLimitBlockedUntilMs <= 0 {
+            rateLimitBlockedError = error
+            rateLimitBlockedMessage = message
+        }
+    }
+
+    /// Seconds left in the block, clamped and finite so the Int conversion can never trap.
+    private static func retryAfterSecondsForLog(untilMs: Double, nowMs: Double) -> Int {
+        let seconds = ((untilMs - nowMs) / 1000).rounded(.up)
+        guard seconds.isFinite, seconds > 0 else {
+            return 0
+        }
+        return Int(min(seconds, maxRateLimitWindowMs / 1000))
+    }
+
+    /// Returns true for the first 429 only, so the rate-limit statistic is sent once.
+    private static func claimRateLimitStatistic() -> Bool {
+        rateLimitStateLock.lock()
+        defer { rateLimitStateLock.unlock() }
+        if rateLimitStatisticSent {
+            return false
+        }
+        rateLimitStatisticSent = true
+        return true
     }
 
     private func parseRemoteError(from data: Data?) -> (error: String, message: String) {
@@ -483,7 +513,15 @@ import UIKit
 
     private func resolveRateLimitBlockedUntilMs(data: Data?, response: HTTPURLResponse?) -> Double {
         let nowMs = Date().timeIntervalSince1970 * 1000
+        let candidate = rawRateLimitDeadlineMs(data: data, response: response, nowMs: nowMs)
+        // NaN and past deadlines mean "no client-side block"; anything further out is capped.
+        guard candidate > nowMs else {
+            return 0
+        }
+        return min(candidate, nowMs + CapgoUpdater.maxRateLimitWindowMs)
+    }
 
+    private func rawRateLimitDeadlineMs(data: Data?, response: HTTPURLResponse?, nowMs: Double) -> Double {
         if let header = response?.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespacesAndNewlines),
            let seconds = Double(header), seconds >= 0 {
             return nowMs + seconds * 1000
@@ -498,8 +536,7 @@ import UIKit
                 return nowMs + retryAfter * 1000
             }
             if let resetAt = (moreInfo?["rateLimitResetAt"] as? NSNumber)?.doubleValue
-                ?? (json["rateLimitResetAt"] as? NSNumber)?.doubleValue,
-               resetAt > nowMs {
+                ?? (json["rateLimitResetAt"] as? NSNumber)?.doubleValue {
                 return resetAt
             }
         }
@@ -509,12 +546,12 @@ import UIKit
     }
 
     private func isRemoteBlocked() -> Bool {
-        let until = CapgoUpdater.rateLimitBlockedUntilMs
-        if until <= 0 {
+        CapgoUpdater.rateLimitStateLock.lock()
+        defer { CapgoUpdater.rateLimitStateLock.unlock() }
+        if CapgoUpdater.rateLimitBlockedUntilMs <= 0 {
             return false
         }
-        let nowMs = Date().timeIntervalSince1970 * 1000
-        if nowMs >= until {
+        if Date().timeIntervalSince1970 * 1000 >= CapgoUpdater.rateLimitBlockedUntilMs {
             CapgoUpdater.rateLimitBlockedUntilMs = 0
             return false
         }
@@ -522,6 +559,8 @@ import UIKit
     }
 
     private func remoteBlockedClientError() -> (error: String, message: String) {
+        CapgoUpdater.rateLimitStateLock.lock()
+        defer { CapgoUpdater.rateLimitStateLock.unlock() }
         return (CapgoUpdater.rateLimitBlockedError, CapgoUpdater.rateLimitBlockedMessage)
     }
 
@@ -2937,9 +2976,15 @@ import UIKit
                 }
 
                 if let statusCode = response.response?.statusCode, !(200...299).contains(statusCode) {
-                    self.requeueStatsEvents(queuedEvents)
-                    self.logger.error("Error sending stats batch")
-                    self.logger.debug("Response code: \(statusCode)")
+                    if CapgoUpdater.isTransientStatsFailure(statusCode) {
+                        self.requeueStatsEvents(queuedEvents)
+                        self.logger.error("Error sending stats batch")
+                        self.logger.debug("Retrying later, response code: \(statusCode)")
+                    } else {
+                        // Permanent rejection: retrying would loop forever and block the queue.
+                        self.logger.error("Dropping stats batch after permanent error")
+                        self.logger.debug("Response code: \(statusCode)")
+                    }
                     semaphore.signal()
                     return
                 }
@@ -2959,6 +3004,11 @@ import UIKit
             semaphore.wait()
         }
         operationQueue.addOperation(operation)
+    }
+
+    /// Only 429, request timeout and 5xx are worth retrying; other 4xx are permanent rejections.
+    private static func isTransientStatsFailure(_ statusCode: Int) -> Bool {
+        return statusCode == 429 || statusCode == 408 || statusCode >= 500
     }
 
     private func requeueStatsEvents(_ events: [QueuedStatsEvent]) {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -56,7 +56,8 @@ import UIKit
     private static var rateLimitBlockedError: String = "too_many_requests"
     private static var rateLimitBlockedMessage: String = "Too many requests"
 
-    // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
+    // Flag to track if we've already sent the rate limit statistic - prevents infinite loop.
+    // Released again when the send fails, so a later 429 can retry it.
     private static var rateLimitStatisticSent = false
 
     // Upper bound for a client-side 429 block, so a bogus Retry-After cannot block the app for days.
@@ -501,6 +502,13 @@ import UIKit
         return true
     }
 
+    /// Gives the claim back when the statistic never made it out, so a later 429 can retry it.
+    private static func releaseRateLimitStatisticClaim() {
+        rateLimitStateLock.lock()
+        defer { rateLimitStateLock.unlock() }
+        rateLimitStatisticSent = false
+    }
+
     private func parseRemoteError(from data: Data?) -> (error: String, message: String) {
         guard let data = data,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -571,6 +579,7 @@ import UIKit
      */
     private func sendRateLimitStatistic() {
         guard !statsUrl.isEmpty else {
+            CapgoUpdater.releaseRateLimitStatisticClaim()
             return
         }
 
@@ -589,10 +598,16 @@ import UIKit
             encoding: JSONEncoding.default,
             requestModifier: { $0.timeoutInterval = self.timeout }
         ).responseData { response in
+            let statusCode = response.response?.statusCode
             switch response.result {
-            case .success:
+            case .success where (200...299).contains(statusCode ?? 0):
                 self.logger.info("Rate limit statistic sent")
+            case .success:
+                CapgoUpdater.releaseRateLimitStatisticClaim()
+                self.logger.error("Error sending rate limit statistic")
+                self.logger.debug("Response code: \(statusCode.map(String.init) ?? "nil")")
             case let .failure(error):
+                CapgoUpdater.releaseRateLimitStatisticClaim()
                 self.logger.error("Error sending rate limit statistic")
                 self.logger.debug("Error: \(error.localizedDescription)")
             }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -455,7 +455,9 @@ import UIKit
         let retryUntilMs = resolveRateLimitBlockedUntilMs(data: data, response: response)
         CapgoUpdater.recordRateLimitBlock(untilMs: retryUntilMs, error: errorCode, message: message)
 
-        if errorCode == "too_many_requests" && !previewSession && CapgoUpdater.claimRateLimitStatistic() {
+        // Claim last, and only when there is somewhere to send it, so a 429 burst with no
+        // stats URL does not claim and release the latch once per response.
+        if errorCode == "too_many_requests" && !previewSession && !statsUrl.isEmpty && CapgoUpdater.claimRateLimitStatistic() {
             DispatchQueue.global(qos: .utility).async {
                 self.sendRateLimitStatistic()
             }
@@ -579,6 +581,7 @@ import UIKit
      */
     private func sendRateLimitStatistic() {
         guard !statsUrl.isEmpty else {
+            // The URL was cleared after the claim was taken; nothing went out, so hand it back.
             CapgoUpdater.releaseRateLimitStatisticClaim()
             return
         }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -49,11 +49,10 @@ import UIKit
     // Cached key ID calculated once from publicKey
     private var cachedKeyId: String?
 
-    // Sticky block for on_premise_app 429s — stops stats/channel/getLatest until process restart.
-    private static var rateLimitExceeded = false
-
-    // Temporary too_many_requests block until this epoch ms (Retry-After / rateLimitResetAt).
+    // Temporary 429 block until this epoch ms (Retry-After / rateLimitResetAt). No sticky latch.
     private static var rateLimitBlockedUntilMs: Double = 0
+    private static var rateLimitBlockedError: String = "too_many_requests"
+    private static var rateLimitBlockedMessage: String = "Too many requests"
 
     // Flag to track if we've already sent the rate limit statistic - prevents infinite loop
     private static var rateLimitStatisticSent = false
@@ -431,9 +430,8 @@ import UIKit
     }
 
     /**
-     * Handle HTTP 429 responses.
-     * - on_premise_app: sticky latch until process restart
-     * - too_many_requests: temporary block honouring Retry-After / rateLimitResetAt
+     * Handle HTTP 429 responses by honouring Retry-After / rateLimitResetAt.
+     * All 429s use the same temporary client block — no sticky latch until restart.
      */
     private func checkAndHandleRateLimitResponse(
         statusCode: Int?,
@@ -448,18 +446,14 @@ import UIKit
         let errorCode = parsed.error.isEmpty ? "too_many_requests" : parsed.error
         let message = parsed.message.isEmpty ? "Too many requests" : parsed.message
 
-        if errorCode == "on_premise_app" {
-            if !CapgoUpdater.rateLimitExceeded {
-                CapgoUpdater.rateLimitExceeded = true
-                CapgoUpdater.rateLimitBlockedUntilMs = 0
-                logger.warn("On-premise app detected (429). Stopping stats, channel, and getLatest requests until app restart.")
-            }
-            return RemoteBlockResult(blocked: true, error: errorCode, message: message)
-        }
-
         let retryUntilMs = resolveRateLimitBlockedUntilMs(data: data, response: response)
         if retryUntilMs > CapgoUpdater.rateLimitBlockedUntilMs {
             CapgoUpdater.rateLimitBlockedUntilMs = retryUntilMs
+            CapgoUpdater.rateLimitBlockedError = errorCode
+            CapgoUpdater.rateLimitBlockedMessage = message
+        } else if CapgoUpdater.rateLimitBlockedUntilMs <= 0 {
+            CapgoUpdater.rateLimitBlockedError = errorCode
+            CapgoUpdater.rateLimitBlockedMessage = message
         }
 
         if errorCode == "too_many_requests" {
@@ -469,12 +463,11 @@ import UIKit
                     self.sendRateLimitStatistic()
                 }
             }
-            let retryAfter = max(0, Int(ceil((max(retryUntilMs, Date().timeIntervalSince1970 * 1000) - Date().timeIntervalSince1970 * 1000) / 1000)))
-            logger.warn("Rate limit exceeded (429 too_many_requests). Retry after \(retryAfter)s.")
-            return RemoteBlockResult(blocked: true, error: errorCode, message: message)
         }
 
-        logger.warn("Received 429 (\(errorCode)). Honouring retry window when provided; not sticky-latching.")
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        let retryAfter = max(0, Int(ceil((max(retryUntilMs, nowMs) - nowMs) / 1000)))
+        logger.warn("Received 429 (\(errorCode)). Honouring Retry-After: \(retryAfter)s.")
         return RemoteBlockResult(blocked: true, error: errorCode, message: message)
     }
 
@@ -516,9 +509,6 @@ import UIKit
     }
 
     private func isRemoteBlocked() -> Bool {
-        if CapgoUpdater.rateLimitExceeded {
-            return true
-        }
         let until = CapgoUpdater.rateLimitBlockedUntilMs
         if until <= 0 {
             return false
@@ -532,10 +522,7 @@ import UIKit
     }
 
     private func remoteBlockedClientError() -> (error: String, message: String) {
-        if CapgoUpdater.rateLimitExceeded {
-            return ("on_premise_app", "On-premise app detected")
-        }
-        return ("too_many_requests", "Too many requests")
+        return (CapgoUpdater.rateLimitBlockedError, CapgoUpdater.rateLimitBlockedMessage)
     }
 
     /**
@@ -2862,12 +2849,6 @@ import UIKit
             return
         }
 
-        // Check if rate limit was exceeded
-        if isRemoteBlocked() {
-            logger.debug("Skipping sendStats due to remote block.")
-            return
-        }
-
         guard !statsUrl.isEmpty else {
             return
         }
@@ -2920,6 +2901,12 @@ import UIKit
     }
 
     private func flushStatsQueue() {
+        // While Retry-After is active, keep stats queued and skip the network call.
+        if isRemoteBlocked() {
+            logger.debug("Deferring stats flush until Retry-After expires.")
+            return
+        }
+
         statsQueueLock.lock()
         guard !statsQueue.isEmpty else {
             statsQueueLock.unlock()
@@ -2930,7 +2917,6 @@ import UIKit
         statsQueueLock.unlock()
 
         let eventsToSend = queuedEvents.map(\.event)
-        let onSentCallbacks = queuedEvents.compactMap(\.onSent)
 
         operationQueue.maxConcurrentOperationCount = 1
 
@@ -2943,13 +2929,15 @@ import UIKit
                 encoder: JSONParameterEncoder.default,
                 requestModifier: { $0.timeoutInterval = self.timeout }
             ).responseData { response in
-                // Check for 429 rate limit
+                // Check for 429 rate limit — requeue so events are not lost.
                 if self.checkAndHandleRateLimitResponse(statusCode: response.response?.statusCode, data: response.data, response: response.response).blocked {
+                    self.requeueStatsEvents(queuedEvents)
                     semaphore.signal()
                     return
                 }
 
                 if let statusCode = response.response?.statusCode, !(200...299).contains(statusCode) {
+                    self.requeueStatsEvents(queuedEvents)
                     self.logger.error("Error sending stats batch")
                     self.logger.debug("Response code: \(statusCode)")
                     semaphore.signal()
@@ -2960,8 +2948,9 @@ import UIKit
                 case .success:
                     self.logger.info("Stats batch sent successfully")
                     self.logger.debug("Sent \(eventsToSend.count) events")
-                    onSentCallbacks.forEach { $0() }
+                    queuedEvents.compactMap(\.onSent).forEach { $0() }
                 case let .failure(error):
+                    self.requeueStatsEvents(queuedEvents)
                     self.logger.error("Error sending stats batch")
                     self.logger.debug("Response: \(response.value?.debugDescription ?? "nil"), Error: \(error.localizedDescription)")
                 }
@@ -2970,6 +2959,14 @@ import UIKit
             semaphore.wait()
         }
         operationQueue.addOperation(operation)
+    }
+
+    private func requeueStatsEvents(_ events: [QueuedStatsEvent]) {
+        guard !events.isEmpty else { return }
+        statsQueueLock.lock()
+        statsQueue.insert(contentsOf: events, at: 0)
+        statsQueueLock.unlock()
+        ensureStatsTimerStarted()
     }
 
     public func getBundleInfo(id: String?) -> BundleInfo {

--- a/scripts/maestro/run-android-live-update-ci.sh
+++ b/scripts/maestro/run-android-live-update-ci.sh
@@ -21,3 +21,9 @@ if [[ "${CAPGO_MAESTRO_CLEANUP_ANDROID_EMULATOR_ON_EXIT:-0}" == "1" ]]; then
 fi
 
 "$(dirname "$0")/run-android-live-update.sh" "$@"
+
+# set -e means we only get here when the flow passed. The marker lets CI tell a passing
+# flow from a hung emulator teardown, which the runner action performs after this script.
+if [[ -n "${CAPGO_MAESTRO_SUCCESS_MARKER:-}" ]]; then
+  : > "${CAPGO_MAESTRO_SUCCESS_MARKER}"
+fi

--- a/scripts/maestro/run-android-live-update-ci.sh
+++ b/scripts/maestro/run-android-live-update-ci.sh
@@ -25,5 +25,7 @@ fi
 # set -e means we only get here when the flow passed. The marker lets CI tell a passing
 # flow from a hung emulator teardown, which the runner action performs after this script.
 if [[ -n "${CAPGO_MAESTRO_SUCCESS_MARKER:-}" ]]; then
+  # Create the parent first: under set -e a failed redirect would report a passing flow as failed.
+  mkdir -p "$(dirname "${CAPGO_MAESTRO_SUCCESS_MARKER}")"
   : > "${CAPGO_MAESTRO_SUCCESS_MARKER}"
 fi


### PR DESCRIPTION
## Summary (AI generated)

- Remove sticky `on_premise_app` latch — all HTTP 429s honour `Retry-After` / `rateLimitResetAt` / `moreInfo`
- While the Retry-After window is active: **queue stats** (flush after window); **reject** getLatest / channel ops as rate-limited
- Requeue stats batches on 429 / network failure so events are not dropped

## Motivation (AI generated)

Backend now returns a long `Retry-After` on `on_premise_app`. The plugin should trust that header instead of latching forever until process restart. Stats must not be lost during the backoff window.

## Business Impact (AI generated)

Fewer permanent client deadlocks after a transient 429. On-prem apps stay quiet for the configured backoff without requiring an app kill. Stats catch up after the window.

## Test Plan (AI generated)

- [ ] 429 with `Retry-After: 5` → getLatest/setChannel rejected for ~5s, then work again
- [ ] 429 `on_premise_app` with long Retry-After → same temporary block (no sticky latch after restart... wait, restart clears in-memory block which is expected)
- [ ] During block, local stats still enqueue and flush after Retry-After expires
- [ ] Channel/getLatest reject with the server error code/message while blocked

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate limits with temporary request blocking and automatic retry timing.
  * Added clearer error details for rate-limited and failed requests.
  * Prevented duplicate statistics submissions and improved recovery after temporary network failures.
  * Ensured update, channel, and statistics requests respond consistently during service interruptions.

* **Tests**
  * Improved Android live-update checks with success verification and more reliable timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->