### PR TITLE
fix: honor preview menu gesture in startup message

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -3990,7 +3990,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
                 new AlertDialog.Builder(getActivity())
                     .setTitle("Preview started")
-                    .setMessage("Shake your device anytime to reload or leave the test app.")
+                    .setMessage("shake".equals(this.shakeMenuGesture) ? "Shake to open menu." : "Three-finger pinch to open menu.")
                     .setPositiveButton("Got it", (dialog, which) -> dialog.dismiss())
                     .show();
             } catch (final Exception e) {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -2754,7 +2754,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
             let alert = UIAlertController(
                 title: "Preview started",
-                message: "Shake your device anytime to reload or leave the test app.",
+                message: self.shakeMenuGesture == Self.shakeMenuGestureThreeFingerPinch ? "Three-finger pinch to open menu." : "Shake to open menu.",
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: "Got it", style: .default))


### PR DESCRIPTION
## What
- Make the native preview-started message reflect the configured `shakeMenuGesture` on Android and iOS.

## Why
- The message always instructed users to shake, even when the configured gesture was `threeFingerPinch`.

## How
- Use one inline conditional expression per platform to select the matching instruction.
- Keep the implementation to exactly two changed source lines.
- This pull request was prepared with Codex.

## Testing
- `bun run verify:android`
- `bun run verify:web`
- `bun run eslint`
- `bun run prettier -- --check`
- `swiftc -parse ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift`
- `git diff --check`

## Not Tested
- Full iOS verification was not run locally because the active developer directory contains Command Line Tools rather than full Xcode. CI will run `bun run verify:ios`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789134693&installation_model_id=430928&pr_number=849&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F849&signature=52336f7ba380cda205d9fedd70927d6d8415a7989081453eacd412dd130a68db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated preview-session alerts to show the correct gesture instructions based on the configured shake-menu setting.
  * Added three-finger pinch guidance when configured, while retaining shake instructions for other configurations.
  * Removed generic reload and test-app messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->