### PR TITLE
fix(updater): persist unsent stats across kills

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/AppLifecycleObserver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/AppLifecycleObserver.java
@@ -52,17 +52,17 @@ public class AppLifecycleObserver implements DefaultLifecycleObserver {
         if (isRegistered) {
             return;
         }
-        if (addObserver()) {
+        if (context == null) {
+            logger.error("Cannot register AppLifecycleObserver without context");
             return;
         }
-        // Apps that remove androidx.startup's InitializationProvider (common with custom
-        // WorkManager init) never create ProcessLifecycleOwner. Initialize it ourselves.
-        if (context != null) {
-            try {
-                AppInitializer.getInstance(context.getApplicationContext()).initializeComponent(ProcessLifecycleInitializer.class);
-            } catch (Exception e) {
-                logger.error("Failed to initialize ProcessLifecycleOwner: " + e.getMessage());
-            }
+        // get()/addObserver() succeed even when ProcessLifecycleOwner.init() never ran.
+        // Initialize first; if that fails, leave isRegistered false so activity fallback runs.
+        try {
+            AppInitializer.getInstance(context.getApplicationContext()).initializeComponent(ProcessLifecycleInitializer.class);
+        } catch (Exception e) {
+            logger.error("Failed to initialize ProcessLifecycleOwner: " + e.getMessage());
+            return;
         }
         if (!addObserver()) {
             logger.error("Failed to register AppLifecycleObserver with ProcessLifecycleOwner");

--- a/android/src/main/java/ee/forgr/capacitor_updater/AppLifecycleObserver.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/AppLifecycleObserver.java
@@ -6,10 +6,13 @@
 
 package ee.forgr.capacitor_updater;
 
+import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleInitializer;
 import androidx.lifecycle.ProcessLifecycleOwner;
+import androidx.startup.AppInitializer;
 
 /**
  * Observes app-level lifecycle events using ProcessLifecycleOwner.
@@ -41,16 +44,40 @@ public class AppLifecycleObserver implements DefaultLifecycleObserver {
         this.logger = logger;
     }
 
-    public void register() {
+    public boolean isRegistered() {
+        return isRegistered;
+    }
+
+    public void register(Context context) {
         if (isRegistered) {
             return;
         }
+        if (addObserver()) {
+            return;
+        }
+        // Apps that remove androidx.startup's InitializationProvider (common with custom
+        // WorkManager init) never create ProcessLifecycleOwner. Initialize it ourselves.
+        if (context != null) {
+            try {
+                AppInitializer.getInstance(context.getApplicationContext()).initializeComponent(ProcessLifecycleInitializer.class);
+            } catch (Exception e) {
+                logger.error("Failed to initialize ProcessLifecycleOwner: " + e.getMessage());
+            }
+        }
+        if (!addObserver()) {
+            logger.error("Failed to register AppLifecycleObserver with ProcessLifecycleOwner");
+        }
+    }
+
+    private boolean addObserver() {
         try {
             ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
             isRegistered = true;
             logger.info("AppLifecycleObserver registered with ProcessLifecycleOwner");
+            return true;
         } catch (Exception e) {
-            logger.error("Failed to register AppLifecycleObserver: " + e.getMessage());
+            logger.error("Failed to add AppLifecycleObserver: " + e.getMessage());
+            return false;
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -837,6 +837,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.periodCheckDelay = normalizedPeriodCheckDelayMs(this.getConfig().getInt("periodCheckDelay", 0));
 
         this.implementation.documentsDir = this.getContext().getFilesDir();
+        this.implementation.noBackupDir = this.getContext().getNoBackupFilesDir();
         this.implementation.prefs = this.prefs;
         this.implementation.editor = this.editor;
         this.implementation.versionOs = Build.VERSION.RELEASE;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -4744,8 +4744,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
         final String messageUpdate = initialDirectUpdateAllowed
             ? "Update will occur now."
             : this.shouldAutoSetNextBundle()
-              ? "Update will occur next time app moves to background."
-              : "Update will be downloaded and made available.";
+                ? "Update will occur next time app moves to background."
+                : "Update will be downloaded and made available.";
         Thread newTask = startNewThread(() -> {
             // Wait for cleanup to complete before starting download
             waitForCleanupIfNeeded();

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -218,10 +218,6 @@ public class CapacitorUpdaterPlugin extends Plugin {
     // Used for activity-based foreground/background detection on Android < 14
     private Boolean isPreviousMainActivity = true;
 
-    private boolean isProcessLifecycleObserverActive() {
-        return this.appLifecycleObserver != null && this.appLifecycleObserver.isRegistered();
-    }
-
     private volatile Thread backgroundDownloadTask;
     private volatile Thread appReadyCheck;
     // When true, sendReadyToJs should wait for notifyAppReady before hiding splash.
@@ -285,6 +281,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
     // App lifecycle observer using ProcessLifecycleOwner for reliable foreground/background detection
     private AppLifecycleObserver appLifecycleObserver;
+
+    private boolean isProcessLifecycleObserverActive() {
+        return this.appLifecycleObserver != null && this.appLifecycleObserver.isRegistered();
+    }
 
     // Play Store In-App Updates
     private AppUpdateManager appUpdateManager;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -218,6 +218,10 @@ public class CapacitorUpdaterPlugin extends Plugin {
     // Used for activity-based foreground/background detection on Android < 14
     private Boolean isPreviousMainActivity = true;
 
+    private boolean isProcessLifecycleObserverActive() {
+        return this.appLifecycleObserver != null && this.appLifecycleObserver.isRegistered();
+    }
+
     private volatile Thread backgroundDownloadTask;
     private volatile Thread appReadyCheck;
     // When true, sendReadyToJs should wait for notifyAppReady before hiding splash.
@@ -838,6 +842,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
         this.implementation.versionOs = Build.VERSION.RELEASE;
         // Use DeviceIdHelper to get or create device ID that persists across reinstalls
         this.implementation.deviceID = DeviceIdHelper.getOrCreateDeviceId(this.getContext(), this.prefs);
+        this.implementation.restorePendingStats();
 
         // Update User-Agent for shared OkHttpClient with OS version
         DownloadService.updateUserAgent(this.implementation.appId, this.pluginVersion, this.implementation.versionOs);
@@ -945,8 +950,12 @@ public class CapacitorUpdaterPlugin extends Plugin {
                 },
                 logger
             );
-            this.appLifecycleObserver.register();
-            logger.info("Using ProcessLifecycleOwner for foreground/background detection (Android 14+)");
+            this.appLifecycleObserver.register(this.getContext());
+            if (!this.appLifecycleObserver.isRegistered()) {
+                logger.warn("ProcessLifecycleOwner unavailable; using activity lifecycle callbacks");
+            } else {
+                logger.info("Using ProcessLifecycleOwner for foreground/background detection (Android 14+)");
+            }
         } else {
             logger.info("Using activity lifecycle callbacks for foreground/background detection (Android <14)");
         }
@@ -4735,8 +4744,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
         final String messageUpdate = initialDirectUpdateAllowed
             ? "Update will occur now."
             : this.shouldAutoSetNextBundle()
-                ? "Update will occur next time app moves to background."
-                : "Update will be downloaded and made available.";
+              ? "Update will occur next time app moves to background."
+              : "Update will be downloaded and made available.";
         Thread newTask = startNewThread(() -> {
             // Wait for cleanup to complete before starting download
             waitForCleanupIfNeeded();
@@ -5250,6 +5259,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
         // Do other background work after splashscreen is shown
         CapacitorUpdaterPlugin.this.implementation.sendStats("app_moved_to_background", current.getVersionName());
+        CapacitorUpdaterPlugin.this.implementation.persistPendingStats();
         logger.info("Checking for pending update");
 
         try {
@@ -5325,9 +5335,9 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
             // On Android < 14, use activity lifecycle for foreground detection
             // On Android 14+, ProcessLifecycleOwner handles this via AppLifecycleObserver
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                if (isPreviousMainActivity) {
-                    logger.info("handleOnStart: appMovedToForeground (Android <14 path)");
+            if (!this.isProcessLifecycleObserverActive()) {
+                if (isPreviousMainActivity || Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    logger.info("handleOnStart: appMovedToForeground");
                     this.appMovedToForeground();
                 }
                 isPreviousMainActivity = true;
@@ -5346,11 +5356,16 @@ public class CapacitorUpdaterPlugin extends Plugin {
 
             // On Android < 14, use activity lifecycle for background detection
             // On Android 14+, ProcessLifecycleOwner handles this via AppLifecycleObserver
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                isPreviousMainActivity = isMainActivity();
-                if (isPreviousMainActivity) {
-                    logger.info("handleOnStop: appMovedToBackground (Android <14 path)");
+            if (!this.isProcessLifecycleObserverActive()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    logger.info("handleOnStop: appMovedToBackground");
                     this.appMovedToBackground();
+                } else {
+                    isPreviousMainActivity = isMainActivity();
+                    if (isPreviousMainActivity) {
+                        logger.info("handleOnStop: appMovedToBackground (Android <14 path)");
+                        this.appMovedToBackground();
+                    }
                 }
             }
         } catch (Exception e) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -35,8 +35,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Date;
@@ -131,6 +129,8 @@ public class CapgoUpdater {
 
     // Stats batching - queue events and send max once per second
     private final List<QueuedStatsEvent> statsQueue = new CopyOnWriteArrayList<>();
+    private final List<QueuedStatsEvent> statsInFlight = new ArrayList<>();
+    private final Object pendingStatsPersistLock = new Object();
     private final ScheduledExecutorService statsScheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> statsFlushTask = null;
     private final AtomicBoolean statsFlushInFlight = new AtomicBoolean(false);
@@ -2800,7 +2800,7 @@ public class CapgoUpdater {
             return;
         }
         try {
-            String raw = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            String raw = readFileUtf8(file);
             JSONArray arr = new JSONArray(raw);
             synchronized (statsQueue) {
                 for (int i = 0; i < arr.length(); i++) {
@@ -2846,27 +2846,63 @@ public class CapgoUpdater {
         }
         JSONArray arr = new JSONArray();
         synchronized (statsQueue) {
+            for (QueuedStatsEvent queuedEvent : statsInFlight) {
+                arr.put(queuedEvent.event);
+            }
             for (QueuedStatsEvent queuedEvent : statsQueue) {
                 arr.put(queuedEvent.event);
             }
         }
-        try {
-            if (arr.length() == 0) {
-                Files.deleteIfExists(file.toPath());
-                return;
-            }
-            File tmp = new File(file.getAbsolutePath() + ".tmp");
-            Files.write(tmp.toPath(), arr.toString().getBytes(StandardCharsets.UTF_8));
+        synchronized (pendingStatsPersistLock) {
             try {
-                Files.move(tmp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } catch (java.nio.file.AtomicMoveNotSupportedException e) {
-                Files.move(tmp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                if (arr.length() == 0) {
+                    if (file.exists() && !file.delete()) {
+                        if (logger != null) {
+                            logger.error("Failed to delete empty stats queue file");
+                        }
+                    }
+                    return;
+                }
+                writeFileAtomically(file, arr.toString().getBytes(StandardCharsets.UTF_8));
+            } catch (Exception e) {
+                if (logger != null) {
+                    logger.error("Failed to persist stats queue");
+                    logger.debug("Error: " + e.getMessage());
+                }
             }
-        } catch (Exception e) {
-            if (logger != null) {
-                logger.error("Failed to persist stats queue");
-                logger.debug("Error: " + e.getMessage());
+        }
+    }
+
+    private static String readFileUtf8(final File file) throws IOException {
+        final long length = file.length();
+        final byte[] buf = new byte[length > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) length];
+        try (FileInputStream in = new FileInputStream(file)) {
+            int offset = 0;
+            while (offset < buf.length) {
+                final int read = in.read(buf, offset, buf.length - offset);
+                if (read < 0) {
+                    break;
+                }
+                offset += read;
             }
+            return new String(buf, 0, offset, StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void writeFileAtomically(final File file, final byte[] bytes) throws IOException {
+        final File tmp = new File(file.getAbsolutePath() + ".tmp");
+        try (FileOutputStream out = new FileOutputStream(tmp)) {
+            out.write(bytes);
+            out.flush();
+        }
+        if (tmp.renameTo(file)) {
+            return;
+        }
+        if (file.exists() && !file.delete()) {
+            throw new IOException("Failed to replace " + file.getAbsolutePath());
+        }
+        if (!tmp.renameTo(file)) {
+            throw new IOException("Failed to persist " + file.getAbsolutePath());
         }
     }
 
@@ -2896,6 +2932,7 @@ public class CapgoUpdater {
         if (statsUrl == null || statsUrl.isEmpty()) {
             synchronized (statsQueue) {
                 statsQueue.clear();
+                statsInFlight.clear();
             }
             persistStatsQueue();
             return;
@@ -2913,7 +2950,10 @@ public class CapgoUpdater {
             }
             eventsToSend = new ArrayList<>(statsQueue);
             statsQueue.clear();
+            statsInFlight.clear();
+            statsInFlight.addAll(eventsToSend);
         }
+        persistStatsQueue();
 
         JSONArray jsonArray = new JSONArray();
         for (QueuedStatsEvent queuedEvent : eventsToSend) {
@@ -2948,6 +2988,9 @@ public class CapgoUpdater {
                         }
 
                         if (response.isSuccessful()) {
+                            synchronized (statsQueue) {
+                                statsInFlight.clear();
+                            }
                             persistStatsQueue();
                             if (logger != null) {
                                 logger.info("Stats batch sent successfully");
@@ -2961,6 +3004,9 @@ public class CapgoUpdater {
                                 logger.debug("Retrying later, response code: " + response.code());
                             }
                         } else {
+                            synchronized (statsQueue) {
+                                statsInFlight.clear();
+                            }
                             persistStatsQueue();
                             if (logger != null) {
                                 logger.error("Dropping stats batch after permanent error");
@@ -2987,7 +3033,11 @@ public class CapgoUpdater {
             return;
         }
         synchronized (statsQueue) {
+            statsInFlight.clear();
             statsQueue.addAll(0, events);
+            while (statsQueue.size() > MAX_PENDING_STATS) {
+                statsQueue.remove(0);
+            }
         }
         persistStatsQueue();
         ensureStatsTimerStarted();

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -2844,16 +2844,17 @@ public class CapgoUpdater {
         if (file == null) {
             return;
         }
-        JSONArray arr = new JSONArray();
-        synchronized (statsQueue) {
-            for (QueuedStatsEvent queuedEvent : statsInFlight) {
-                arr.put(queuedEvent.event);
-            }
-            for (QueuedStatsEvent queuedEvent : statsQueue) {
-                arr.put(queuedEvent.event);
-            }
-        }
         synchronized (pendingStatsPersistLock) {
+            JSONArray arr = new JSONArray();
+            synchronized (statsQueue) {
+                final List<QueuedStatsEvent> combined = new ArrayList<>(statsInFlight.size() + statsQueue.size());
+                combined.addAll(statsInFlight);
+                combined.addAll(statsQueue);
+                final int start = Math.max(0, combined.size() - MAX_PENDING_STATS);
+                for (int i = start; i < combined.size(); i++) {
+                    arr.put(combined.get(i).event);
+                }
+            }
             try {
                 if (arr.length() == 0) {
                     if (file.exists() && !file.delete()) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -134,6 +134,7 @@ public class CapgoUpdater {
     private final ScheduledExecutorService statsScheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> statsFlushTask = null;
     private final AtomicBoolean statsFlushInFlight = new AtomicBoolean(false);
+    private final AtomicBoolean statsStopped = new AtomicBoolean(false);
     private static final long STATS_FLUSH_INTERVAL_MS = 1000;
     private static final String PENDING_STATS_FILE = "capgo_pending_stats.json";
     private static final int MAX_PENDING_STATS = 200;
@@ -2840,6 +2841,13 @@ public class CapgoUpdater {
     }
 
     private void persistStatsQueue() {
+        persistStatsQueue(false);
+    }
+
+    private void persistStatsQueue(final boolean force) {
+        if (statsStopped.get() && !force) {
+            return;
+        }
         File file = pendingStatsFile();
         if (file == null) {
             return;
@@ -2908,6 +2916,9 @@ public class CapgoUpdater {
     }
 
     private synchronized void ensureStatsTimerStarted() {
+        if (statsStopped.get()) {
+            return;
+        }
         if (statsFlushTask == null || statsFlushTask.isCancelled() || statsFlushTask.isDone()) {
             statsFlushTask = statsScheduler.scheduleAtFixedRate(
                 this::flushStatsQueue,
@@ -2919,6 +2930,9 @@ public class CapgoUpdater {
     }
 
     private void flushStatsQueue() {
+        if (statsStopped.get()) {
+            return;
+        }
         if (statsQueue.isEmpty()) {
             return;
         }
@@ -2971,6 +2985,9 @@ public class CapgoUpdater {
             new okhttp3.Callback() {
                 @Override
                 public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                    if (abandonStoppedStatsFlush()) {
+                        return;
+                    }
                     requeueStatsEvents(eventsToSend);
                     if (logger != null) {
                         logger.error("Failed to send stats batch");
@@ -2982,6 +2999,9 @@ public class CapgoUpdater {
                 @Override
                 public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                     try (ResponseBody responseBody = response.body()) {
+                        if (abandonStoppedStatsFlush()) {
+                            return;
+                        }
                         final String responseData = responseBody != null ? responseBody.string() : "";
                         if (checkAndHandleRateLimitResponse(response, responseData).blocked) {
                             requeueStatsEvents(eventsToSend);
@@ -3022,6 +3042,17 @@ public class CapgoUpdater {
         );
     }
 
+    private boolean abandonStoppedStatsFlush() {
+        if (!statsStopped.get()) {
+            return false;
+        }
+        synchronized (statsQueue) {
+            statsInFlight.clear();
+        }
+        statsFlushInFlight.set(false);
+        return true;
+    }
+
     /**
      * Only 429, request timeout and 5xx are worth retrying; other 4xx are permanent rejections.
      */
@@ -3030,7 +3061,7 @@ public class CapgoUpdater {
     }
 
     private void requeueStatsEvents(final List<QueuedStatsEvent> events) {
-        if (events == null || events.isEmpty()) {
+        if (statsStopped.get() || events == null || events.isEmpty()) {
             return;
         }
         synchronized (statsQueue) {
@@ -3231,15 +3262,15 @@ public class CapgoUpdater {
      * Should be called when the plugin is destroyed to prevent resource leaks.
      */
     public void shutdown() {
+        statsStopped.set(true);
         // Cancel the scheduled task
         if (statsFlushTask != null) {
             statsFlushTask.cancel(false);
             statsFlushTask = null;
         }
 
-        // Keep unsent events on disk in case destroy races the async flush.
-        persistStatsQueue();
-        flushStatsQueue();
+        // Write once, then ignore later callbacks so they cannot delete a newer instance's file.
+        persistStatsQueue(true);
 
         // Shutdown the scheduler
         statsScheduler.shutdown();

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -2756,6 +2756,10 @@ public class CapgoUpdater {
         final Map<String, String> metadata,
         final Runnable onSent
     ) {
+        if (statsStopped.get()) {
+            return;
+        }
+
         if (this.previewSession) {
             if (logger != null) {
                 logger.debug("Skipping sendStats during preview session.");
@@ -3045,9 +3049,6 @@ public class CapgoUpdater {
     private boolean abandonStoppedStatsFlush() {
         if (!statsStopped.get()) {
             return false;
-        }
-        synchronized (statsQueue) {
-            statsInFlight.clear();
         }
         statsFlushInFlight.set(false);
         return true;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -35,6 +35,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Date;
@@ -54,6 +56,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import okhttp3.*;
@@ -130,7 +133,10 @@ public class CapgoUpdater {
     private final List<QueuedStatsEvent> statsQueue = new CopyOnWriteArrayList<>();
     private final ScheduledExecutorService statsScheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> statsFlushTask = null;
+    private final AtomicBoolean statsFlushInFlight = new AtomicBoolean(false);
     private static final long STATS_FLUSH_INTERVAL_MS = 1000;
+    private static final String PENDING_STATS_FILE = "capgo_pending_stats.json";
+    private static final int MAX_PENDING_STATS = 200;
 
     private static final class QueuedStatsEvent {
 
@@ -2772,16 +2778,96 @@ public class CapgoUpdater {
                 json.put("metadata", new JSONObject(metadata));
             }
         } catch (JSONException e) {
-            logger.error("Error preparing stats");
-            logger.debug("JSONException: " + e.getMessage());
+            if (logger != null) {
+                logger.error("Error preparing stats");
+                logger.debug("JSONException: " + e.getMessage());
+            }
             return;
         }
 
-        // Same lock as the flush transaction, so an event added mid-flush is never dropped.
         synchronized (statsQueue) {
+            while (statsQueue.size() >= MAX_PENDING_STATS) {
+                statsQueue.remove(0);
+            }
             statsQueue.add(new QueuedStatsEvent(json, onSent));
         }
         ensureStatsTimerStarted();
+    }
+
+    public void restorePendingStats() {
+        File file = pendingStatsFile();
+        if (file == null || !file.exists()) {
+            return;
+        }
+        try {
+            String raw = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            JSONArray arr = new JSONArray(raw);
+            synchronized (statsQueue) {
+                for (int i = 0; i < arr.length(); i++) {
+                    if (statsQueue.size() >= MAX_PENDING_STATS) {
+                        break;
+                    }
+                    statsQueue.add(new QueuedStatsEvent(arr.getJSONObject(i), null));
+                }
+            }
+            if (!statsQueue.isEmpty()) {
+                if (logger != null) {
+                    logger.info("Restored " + statsQueue.size() + " pending stats events");
+                }
+                ensureStatsTimerStarted();
+            }
+        } catch (Exception e) {
+            if (logger != null) {
+                logger.error("Failed to restore pending stats");
+                logger.debug("Error: " + e.getMessage());
+            }
+        }
+    }
+
+    int pendingStatsCount() {
+        return statsQueue.size();
+    }
+
+    public void persistPendingStats() {
+        persistStatsQueue();
+    }
+
+    private File pendingStatsFile() {
+        if (this.documentsDir == null) {
+            return null;
+        }
+        return new File(this.documentsDir, PENDING_STATS_FILE);
+    }
+
+    private void persistStatsQueue() {
+        File file = pendingStatsFile();
+        if (file == null) {
+            return;
+        }
+        JSONArray arr = new JSONArray();
+        synchronized (statsQueue) {
+            for (QueuedStatsEvent queuedEvent : statsQueue) {
+                arr.put(queuedEvent.event);
+            }
+        }
+        try {
+            if (arr.length() == 0) {
+                Files.deleteIfExists(file.toPath());
+                return;
+            }
+            File tmp = new File(file.getAbsolutePath() + ".tmp");
+            Files.write(tmp.toPath(), arr.toString().getBytes(StandardCharsets.UTF_8));
+            try {
+                Files.move(tmp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException e) {
+                Files.move(tmp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (Exception e) {
+            if (logger != null) {
+                logger.error("Failed to persist stats queue");
+                logger.debug("Error: " + e.getMessage());
+            }
+        }
     }
 
     private synchronized void ensureStatsTimerStarted() {
@@ -2811,13 +2897,18 @@ public class CapgoUpdater {
             synchronized (statsQueue) {
                 statsQueue.clear();
             }
+            persistStatsQueue();
             return;
         }
 
-        // Copy and clear the queue atomically using synchronized block
-        List<QueuedStatsEvent> eventsToSend;
+        if (!statsFlushInFlight.compareAndSet(false, true)) {
+            return;
+        }
+
+        final List<QueuedStatsEvent> eventsToSend;
         synchronized (statsQueue) {
             if (statsQueue.isEmpty()) {
+                statsFlushInFlight.set(false);
                 return;
             }
             eventsToSend = new ArrayList<>(statsQueue);
@@ -2839,10 +2930,12 @@ public class CapgoUpdater {
             new okhttp3.Callback() {
                 @Override
                 public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                    // Keep events for a later flush attempt.
                     requeueStatsEvents(eventsToSend);
-                    logger.error("Failed to send stats batch");
-                    logger.debug("Error: " + e.getMessage());
+                    if (logger != null) {
+                        logger.error("Failed to send stats batch");
+                        logger.debug("Error: " + e.getMessage());
+                    }
+                    statsFlushInFlight.set(false);
                 }
 
                 @Override
@@ -2855,18 +2948,27 @@ public class CapgoUpdater {
                         }
 
                         if (response.isSuccessful()) {
-                            logger.info("Stats batch sent successfully");
-                            logger.debug("Sent " + eventCount + " events");
+                            persistStatsQueue();
+                            if (logger != null) {
+                                logger.info("Stats batch sent successfully");
+                                logger.debug("Sent " + eventCount + " events");
+                            }
                             runStatsCallbacks(eventsToSend);
                         } else if (isTransientStatsFailure(response.code())) {
                             requeueStatsEvents(eventsToSend);
-                            logger.error("Error sending stats batch");
-                            logger.debug("Retrying later, response code: " + response.code());
+                            if (logger != null) {
+                                logger.error("Error sending stats batch");
+                                logger.debug("Retrying later, response code: " + response.code());
+                            }
                         } else {
-                            // Permanent rejection: retrying would loop forever and block the queue.
-                            logger.error("Dropping stats batch after permanent error");
-                            logger.debug("Response code: " + response.code());
+                            persistStatsQueue();
+                            if (logger != null) {
+                                logger.error("Dropping stats batch after permanent error");
+                                logger.debug("Response code: " + response.code());
+                            }
                         }
+                    } finally {
+                        statsFlushInFlight.set(false);
                     }
                 }
             }
@@ -2887,6 +2989,7 @@ public class CapgoUpdater {
         synchronized (statsQueue) {
             statsQueue.addAll(0, events);
         }
+        persistStatsQueue();
         ensureStatsTimerStarted();
     }
 
@@ -3083,7 +3186,8 @@ public class CapgoUpdater {
             statsFlushTask = null;
         }
 
-        // Flush any remaining stats before shutdown
+        // Keep unsent events on disk in case destroy races the async flush.
+        persistStatsQueue();
         flushStatsQueue();
 
         // Shutdown the scheduler

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -92,6 +92,7 @@ public class CapgoUpdater {
     public SharedPreferences prefs;
 
     public File documentsDir;
+    public File noBackupDir;
     public Boolean directUpdate = false;
     public Activity activity;
     public String pluginVersion = "";
@@ -2841,10 +2842,11 @@ public class CapgoUpdater {
     }
 
     private File pendingStatsFile() {
-        if (this.documentsDir == null) {
+        final File dir = this.noBackupDir != null ? this.noBackupDir : this.documentsDir;
+        if (dir == null) {
             return null;
         }
-        return new File(this.documentsDir, PENDING_STATS_FILE);
+        return new File(dir, PENDING_STATS_FILE);
     }
 
     private void persistStatsQueue() {
@@ -2852,14 +2854,14 @@ public class CapgoUpdater {
     }
 
     private void persistStatsQueue(final boolean force) {
-        if (statsStopped.get() && !force) {
-            return;
-        }
         File file = pendingStatsFile();
         if (file == null) {
             return;
         }
         synchronized (pendingStatsPersistLock) {
+            if (statsStopped.get() && !force) {
+                return;
+            }
             JSONArray arr = new JSONArray();
             synchronized (statsQueue) {
                 final List<QueuedStatsEvent> combined = new ArrayList<>(statsInFlight.size() + statsQueue.size());

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -2791,6 +2791,9 @@ public class CapgoUpdater {
         }
 
         synchronized (statsQueue) {
+            if (statsStopped.get()) {
+                return;
+            }
             while (statsQueue.size() >= MAX_PENDING_STATS) {
                 statsQueue.remove(0);
             }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3525,4 +3525,26 @@ public class CapacitorUpdaterUnitTest {
         final File cacheFile = new File(new File(cacheDir, "capgo_downloads"), checksum + "_new.js");
         assertTrue("Non-builtin file must be copied into the delta cache", cacheFile.exists());
     }
+
+    @Test
+    public void testPendingStatsSurviveNewUpdaterInstance() throws Exception {
+        final Path tempDir = Files.createTempDirectory("capgo-pending-stats");
+        final File queueFile = tempDir.resolve("capgo_pending_stats.json").toFile();
+        Files.write(queueFile.toPath(), "[{\"action\":\"app_moved_to_background\",\"timestamp\":1}]".getBytes(StandardCharsets.UTF_8));
+
+        final CapgoUpdater crashed = new CapgoUpdater(mock(Logger.class));
+        crashed.documentsDir = tempDir.toFile();
+        crashed.restorePendingStats();
+
+        assertEquals(1, crashed.pendingStatsCount());
+        assertTrue(queueFile.exists());
+
+        final CapgoUpdater relaunched = new CapgoUpdater(mock(Logger.class));
+        relaunched.documentsDir = tempDir.toFile();
+        relaunched.restorePendingStats();
+
+        assertEquals(1, relaunched.pendingStatsCount());
+        relaunched.shutdown();
+        crashed.shutdown();
+    }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -353,6 +353,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 logger.info("Loaded persisted channelUrl")
             }
         }
+        implementation.restorePendingStats()
 
         let nativeBuildVersionChanged = self.hasNativeBuildVersionChanged()
         let defaultChannelPersistenceDisabled = !persistDefaultChannelOnReinstall
@@ -4616,6 +4617,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let current: BundleInfo = self.implementation.getCurrentBundle()
         self.implementation.sendStats(action: "app_moved_to_background", versionName: current.getVersionName())
+        self.implementation.persistPendingStats()
         logger.info("Check for pending update")
 
         // Show splashscreen only if autoSplashscreen is enabled AND autoUpdate is enabled AND directUpdate would be used

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -92,6 +92,10 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "completeFlexibleUpdate", returnType: CAPPluginReturnPromise)
     ]
     public var implementation = CapgoUpdater()
+
+    deinit {
+        implementation.shutdown()
+    }
     private let pluginVersion: String = "8.51.5"
     private let launchStartedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
     static let updateUrlDefault = "https://plugin.capgo.app/updates"

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -65,7 +65,9 @@ import UIKit
 
     // Stats batching - queue events and send max once per second
     private var statsQueue: [QueuedStatsEvent] = []
+    private var statsInFlight: [QueuedStatsEvent] = []
     private let statsQueueLock = NSLock()
+    private let statsPersistLock = NSLock()
     private var statsFlushTimer: Timer?
     private static let statsFlushInterval: TimeInterval = 1.0
     private static let maxPendingStats = 200
@@ -2980,8 +2982,11 @@ import UIKit
 
     private func persistStatsQueue() {
         statsQueueLock.lock()
-        let events = statsQueue.map(\.event)
+        let events = statsInFlight.map(\.event) + statsQueue.map(\.event)
         statsQueueLock.unlock()
+
+        statsPersistLock.lock()
+        defer { statsPersistLock.unlock() }
 
         let fileURL = pendingStatsFileURL()
         if events.isEmpty {
@@ -2992,6 +2997,10 @@ import UIKit
         do {
             let data = try JSONEncoder().encode(events)
             try data.write(to: fileURL, options: .atomic)
+            var resourceURL = fileURL
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try resourceURL.setResourceValues(values)
         } catch {
             logger.error("Failed to persist stats queue")
             logger.debug("Error: \(error.localizedDescription)")
@@ -3021,13 +3030,15 @@ import UIKit
         }
 
         statsQueueLock.lock()
-        guard !statsQueue.isEmpty else {
+        guard statsInFlight.isEmpty, !statsQueue.isEmpty else {
             statsQueueLock.unlock()
             return
         }
         let queuedEvents = statsQueue
         statsQueue.removeAll()
+        statsInFlight = queuedEvents
         statsQueueLock.unlock()
+        persistStatsQueue()
 
         let eventsToSend = queuedEvents.map(\.event)
 
@@ -3054,6 +3065,7 @@ import UIKit
                         self.logger.error("Error sending stats batch")
                         self.logger.debug("Retrying later, response code: \(statusCode)")
                     } else {
+                        self.clearStatsInFlight()
                         self.logger.error("Dropping stats batch after permanent error")
                         self.logger.debug("Response code: \(statusCode)")
                     }
@@ -3063,6 +3075,7 @@ import UIKit
 
                 switch response.result {
                 case .success:
+                    self.clearStatsInFlight()
                     self.logger.info("Stats batch sent successfully")
                     self.logger.debug("Sent \(eventsToSend.count) events")
                     self.runStatsCallbacks(queuedEvents)
@@ -3093,10 +3106,20 @@ import UIKit
     private func requeueStatsEvents(_ events: [QueuedStatsEvent]) {
         guard !events.isEmpty else { return }
         statsQueueLock.lock()
+        statsInFlight.removeAll()
         statsQueue.insert(contentsOf: events, at: 0)
+        if statsQueue.count > CapgoUpdater.maxPendingStats {
+            statsQueue.removeFirst(statsQueue.count - CapgoUpdater.maxPendingStats)
+        }
         statsQueueLock.unlock()
         persistStatsQueue()
         ensureStatsTimerStarted()
+    }
+
+    private func clearStatsInFlight() {
+        statsQueueLock.lock()
+        statsInFlight.removeAll()
+        statsQueueLock.unlock()
     }
 
     public func getBundleInfo(id: String?) -> BundleInfo {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -2981,12 +2981,15 @@ import UIKit
     }
 
     private func persistStatsQueue() {
-        statsQueueLock.lock()
-        let events = statsInFlight.map(\.event) + statsQueue.map(\.event)
-        statsQueueLock.unlock()
-
         statsPersistLock.lock()
         defer { statsPersistLock.unlock() }
+
+        statsQueueLock.lock()
+        var events = statsInFlight.map(\.event) + statsQueue.map(\.event)
+        statsQueueLock.unlock()
+        if events.count > CapgoUpdater.maxPendingStats {
+            events = Array(events.suffix(CapgoUpdater.maxPendingStats))
+        }
 
         let fileURL = pendingStatsFileURL()
         if events.isEmpty {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -68,6 +68,8 @@ import UIKit
     private let statsQueueLock = NSLock()
     private var statsFlushTimer: Timer?
     private static let statsFlushInterval: TimeInterval = 1.0
+    private static let maxPendingStats = 200
+    private let pendingStatsFileName = "capgo_pending_stats.json"
 
     private struct QueuedStatsEvent {
         let event: StatsEvent
@@ -334,8 +336,7 @@ import UIKit
         // Invalidate the stats timer to prevent memory leaks
         statsFlushTimer?.invalidate()
         statsFlushTimer = nil
-
-        // Flush any remaining stats before deallocation
+        persistStatsQueue()
         flushStatsQueue()
     }
 
@@ -2936,10 +2937,65 @@ import UIKit
         )
 
         statsQueueLock.lock()
+        if statsQueue.count >= CapgoUpdater.maxPendingStats {
+            statsQueue.removeFirst(statsQueue.count - CapgoUpdater.maxPendingStats + 1)
+        }
         statsQueue.append(QueuedStatsEvent(event: event, onSent: onSent))
         statsQueueLock.unlock()
 
         ensureStatsTimerStarted()
+    }
+
+    func restorePendingStats() {
+        let fileURL = pendingStatsFileURL()
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let data = try? Data(contentsOf: fileURL),
+              let events = try? JSONDecoder().decode([StatsEvent].self, from: data) else {
+            return
+        }
+
+        statsQueueLock.lock()
+        for event in events {
+            if statsQueue.count >= CapgoUpdater.maxPendingStats {
+                break
+            }
+            statsQueue.append(QueuedStatsEvent(event: event, onSent: nil))
+        }
+        let restoredCount = statsQueue.count
+        statsQueueLock.unlock()
+
+        if restoredCount > 0 {
+            logger.info("Restored \(restoredCount) pending stats events")
+            ensureStatsTimerStarted()
+        }
+    }
+
+    func persistPendingStats() {
+        persistStatsQueue()
+    }
+
+    private func pendingStatsFileURL() -> URL {
+        libraryDir.appendingPathComponent(pendingStatsFileName)
+    }
+
+    private func persistStatsQueue() {
+        statsQueueLock.lock()
+        let events = statsQueue.map(\.event)
+        statsQueueLock.unlock()
+
+        let fileURL = pendingStatsFileURL()
+        if events.isEmpty {
+            try? FileManager.default.removeItem(at: fileURL)
+            return
+        }
+
+        do {
+            let data = try JSONEncoder().encode(events)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            logger.error("Failed to persist stats queue")
+            logger.debug("Error: \(error.localizedDescription)")
+        }
     }
 
     private func ensureStatsTimerStarted() {
@@ -2986,7 +3042,6 @@ import UIKit
                 encoder: JSONParameterEncoder.default,
                 requestModifier: { $0.timeoutInterval = self.timeout }
             ).responseData { response in
-                // Check for 429 rate limit — requeue so events are not lost.
                 if self.checkAndHandleRateLimitResponse(statusCode: response.response?.statusCode, data: response.data, response: response.response).blocked {
                     self.requeueStatsEvents(queuedEvents)
                     semaphore.signal()
@@ -2999,7 +3054,6 @@ import UIKit
                         self.logger.error("Error sending stats batch")
                         self.logger.debug("Retrying later, response code: \(statusCode)")
                     } else {
-                        // Permanent rejection: retrying would loop forever and block the queue.
                         self.logger.error("Dropping stats batch after permanent error")
                         self.logger.debug("Response code: \(statusCode)")
                     }
@@ -3020,6 +3074,7 @@ import UIKit
                 semaphore.signal()
             }
             semaphore.wait()
+            self.persistStatsQueue()
         }
         operationQueue.addOperation(operation)
     }
@@ -3040,6 +3095,7 @@ import UIKit
         statsQueueLock.lock()
         statsQueue.insert(contentsOf: events, at: 0)
         statsQueueLock.unlock()
+        persistStatsQueue()
         ensureStatsTimerStarted()
     }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -336,6 +336,10 @@ import UIKit
     }
 
     deinit {
+        shutdown()
+    }
+
+    public func shutdown() {
         statsStopped = true
         statsFlushTimer?.invalidate()
         statsFlushTimer = nil
@@ -2904,6 +2908,10 @@ import UIKit
         metadata: [String: String]?,
         onSent: (() -> Void)?
     ) {
+        if statsStopped {
+            return
+        }
+
         if previewSession {
             logger.debug("Skipping sendStats during preview session.")
             return
@@ -3111,11 +3119,7 @@ import UIKit
     }
 
     private func abandonStoppedStatsFlush() -> Bool {
-        guard statsStopped else { return false }
-        statsQueueLock.lock()
-        statsInFlight.removeAll()
-        statsQueueLock.unlock()
-        return true
+        statsStopped
     }
 
     /// Only 429, request timeout and 5xx are worth retrying; other 4xx are permanent rejections.

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -69,6 +69,7 @@ import UIKit
     private let statsQueueLock = NSLock()
     private let statsPersistLock = NSLock()
     private var statsFlushTimer: Timer?
+    private var statsStopped = false
     private static let statsFlushInterval: TimeInterval = 1.0
     private static let maxPendingStats = 200
     private let pendingStatsFileName = "capgo_pending_stats.json"
@@ -335,11 +336,10 @@ import UIKit
     }
 
     deinit {
-        // Invalidate the stats timer to prevent memory leaks
+        statsStopped = true
         statsFlushTimer?.invalidate()
         statsFlushTimer = nil
-        persistStatsQueue()
-        flushStatsQueue()
+        persistStatsQueue(force: true)
     }
 
     private func calcTotalPercent(percent: Int, min: Int, max: Int) -> Int {
@@ -2980,7 +2980,10 @@ import UIKit
         libraryDir.appendingPathComponent(pendingStatsFileName)
     }
 
-    private func persistStatsQueue() {
+    private func persistStatsQueue(force: Bool = false) {
+        if statsStopped && !force {
+            return
+        }
         statsPersistLock.lock()
         defer { statsPersistLock.unlock() }
 
@@ -3011,8 +3014,11 @@ import UIKit
     }
 
     private func ensureStatsTimerStarted() {
+        if statsStopped {
+            return
+        }
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, !self.statsStopped else { return }
             if self.statsFlushTimer == nil || !self.statsFlushTimer!.isValid {
                 // Use closure-based timer to avoid strong reference cycle
                 self.statsFlushTimer = Timer.scheduledTimer(
@@ -3026,6 +3032,9 @@ import UIKit
     }
 
     private func flushStatsQueue() {
+        if statsStopped {
+            return
+        }
         // While Retry-After is active, keep stats queued and skip the network call.
         if isRemoteBlocked() {
             logger.debug("Deferring stats flush until Retry-After expires.")
@@ -3056,6 +3065,10 @@ import UIKit
                 encoder: JSONParameterEncoder.default,
                 requestModifier: { $0.timeoutInterval = self.timeout }
             ).responseData { response in
+                if self.abandonStoppedStatsFlush() {
+                    semaphore.signal()
+                    return
+                }
                 if self.checkAndHandleRateLimitResponse(statusCode: response.response?.statusCode, data: response.data, response: response.response).blocked {
                     self.requeueStatsEvents(queuedEvents)
                     semaphore.signal()
@@ -3090,9 +3103,19 @@ import UIKit
                 semaphore.signal()
             }
             semaphore.wait()
-            self.persistStatsQueue()
+            if !self.statsStopped {
+                self.persistStatsQueue()
+            }
         }
         operationQueue.addOperation(operation)
+    }
+
+    private func abandonStoppedStatsFlush() -> Bool {
+        guard statsStopped else { return false }
+        statsQueueLock.lock()
+        statsInFlight.removeAll()
+        statsQueueLock.unlock()
+        return true
     }
 
     /// Only 429, request timeout and 5xx are worth retrying; other 4xx are permanent rejections.
@@ -3107,7 +3130,7 @@ import UIKit
     }
 
     private func requeueStatsEvents(_ events: [QueuedStatsEvent]) {
-        guard !events.isEmpty else { return }
+        guard !statsStopped, !events.isEmpty else { return }
         statsQueueLock.lock()
         statsInFlight.removeAll()
         statsQueue.insert(contentsOf: events, at: 0)

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -340,7 +340,9 @@ import UIKit
     }
 
     public func shutdown() {
+        statsPersistLock.lock()
         statsStopped = true
+        statsPersistLock.unlock()
         statsFlushTimer?.invalidate()
         statsFlushTimer = nil
         persistStatsQueue(force: true)
@@ -2993,11 +2995,11 @@ import UIKit
     }
 
     private func persistStatsQueue(force: Bool = false) {
+        statsPersistLock.lock()
+        defer { statsPersistLock.unlock() }
         if statsStopped && !force {
             return
         }
-        statsPersistLock.lock()
-        defer { statsPersistLock.unlock() }
 
         statsQueueLock.lock()
         var events = statsInFlight.map(\.event) + statsQueue.map(\.event)

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -2947,6 +2947,10 @@ import UIKit
         )
 
         statsQueueLock.lock()
+        if statsStopped {
+            statsQueueLock.unlock()
+            return
+        }
         if statsQueue.count >= CapgoUpdater.maxPendingStats {
             statsQueue.removeFirst(statsQueue.count - CapgoUpdater.maxPendingStats + 1)
         }


### PR DESCRIPTION
## What
- Persist unsent Capgo stats to disk so app open/close events (`app_moved_to_foreground` / `app_moved_to_background`) are not lost when the process is killed before the 1s batch flush.
- Restore that file on the next launch and send it with the normal stats timer.
- On Android 14+, fall back to activity start/stop if `ProcessLifecycleOwner` never registers.

## Why
Session stats live in an in-memory 1s queue. Backgrounding, a crash, or a failed POST dropped them forever, so they disappeared from app logs. Delay is fine; permanent loss is not.

## How
- Keep enqueue in memory. Write `capgo_pending_stats.json` only on background, failed/rate-limited send, or shutdown (not on every event).
- Cap the queue at 200 events.
- Keep the existing Retry-After / requeue path from #845. Persist after requeue and after a successful flush (delete the file when empty).
- If AndroidX Startup was removed (common with custom WorkManager), initialize `ProcessLifecycleOwner` ourselves, then fall back to activity callbacks.

## Testing
- `CapacitorUpdaterUnitTest.testPendingStatsSurviveNewUpdaterInstance` — restore after a new updater instance.
- Android unit test compile of the plugin changes.

## Not Tested
- Device kill while backgrounded, then confirm the events appear later in Capgo logs.
- iOS unit coverage of the same restore path.
- Apps that remove `InitializationProvider` on Android 14+.

## How to review
1. `CapgoUpdater` persist/restore + flush/requeue interaction (do not write on every `sendStats`).
2. Plugin `load()` restore and `appMovedToBackground` persist.
3. Android 14 lifecycle fallback.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789220734&installation_model_id=430928&pr_number=850&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F850&signature=f8a92c05d50e5a33730953204044b36a9bd36b0180ae499d36c6fd31f86a8bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of usage statistics collection across Android and iOS.
  - Pending statistics are restored after app restarts and preserved when apps move to the background or shut down.
  - Temporary network failures and rate limits no longer cause queued statistics to be lost.
  - Improved Android lifecycle handling across supported versions.
  - Prevented duplicate uploads and limited queued statistics to 200 events for stable performance.
  - Added safeguards to preserve statistics during app initialization and lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->