### PR TITLE
fix(android): restore lifecycle compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ repositories {
 
 dependencies {
     def work_version = "2.10.5"
-    def lifecycle_version = "2.11.0"
+    def lifecycle_version = "2.10.0"
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
     implementation "com.google.android.gms:play-services-tasks:18.4.1"

--- a/renovate.json
+++ b/renovate.json
@@ -111,6 +111,16 @@
         "gradle"
       ],
       "enabled": false
+    },
+    // Lifecycle 2.11 requires compileSdk 37 and Android Gradle plugin 9.1 through atomic group alignment
+    {
+      "matchPackageNames": [
+        "androidx.lifecycle:lifecycle-process"
+      ],
+      "matchManagers": [
+        "gradle"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## What
- Restore androidx.lifecycle:lifecycle-process from 2.11.0 to 2.10.0.
- Disable Renovate updates for this dependency until the Android toolchain supports Lifecycle 2.11.

## Why
- Lifecycle 2.11 atomic-group alignment upgrades Compose Lifecycle artifacts in consumer apps.
- Those artifacts require compileSdk 37 and Android Gradle Plugin 9.1, while Capacitor 8 and the updater currently use compileSdk 36 and AGP 8.13.
- This caused the Capgo Android release build to fail during AAR metadata validation.

## How
- Revert the dependency version to the last compatible release.
- Add a Renovate package rule matching the existing frozen WorkManager dependency pattern so the incompatible bump is not recreated automatically.

## Testing
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer bun run fmt
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer bun run verify
- bunx --package renovate renovate-config-validator renovate.json
- Capgo consumer: ./gradlew :app:checkReleaseAarMetadata passes with Lifecycle 2.10.0; the same task fails with 2.11.0.
- git diff --check

## Not Tested
- A published npm package and Google Play AAB upload; those require the post-merge release and downstream Capgo dependency bump.

## Additional validation note
- The optional aggregate bun run lint command reaches SwiftLint but reports 35 serious pre-existing violations in unchanged iOS sources on current main. ESLint and Prettier pass, and this PR changes no Swift files.

This PR was prepared with Codex.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789296101&installation_model_id=430928&pr_number=851&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F851&signature=2613ab018665d14597b648272ef63677754091245b9c2f76b4ece8254547be44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

