### PR TITLE
fix(updater): cut manifest memory without killing download speed

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -475,7 +475,7 @@ public class CapgoUpdater {
 
     private void copyFile(final File source, final File dest) throws IOException {
         try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(dest)) {
-            final byte[] buffer = new byte[64 * 1024];
+            final byte[] buffer = new byte[CryptoCipher.copyBufferBytes()];
             int length;
             while ((length = input.read(buffer)) != -1) {
                 output.write(buffer, 0, length);
@@ -1211,7 +1211,7 @@ public class CapgoUpdater {
 
         final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
         try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
-            final byte[] buffer = new byte[64 * 1024];
+            final byte[] buffer = new byte[CryptoCipher.copyBufferBytes()];
             int length;
             while ((length = input.read(buffer)) != -1) {
                 output.write(buffer, 0, length);

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -523,27 +523,57 @@ public class CapgoUpdater {
         final boolean isBrotli = fileName.endsWith(".br");
         final String fileNameWithoutPath = new File(fileName).getName();
         final String cacheBaseName = isBrotli ? fileNameWithoutPath.substring(0, fileNameWithoutPath.length() - 3) : fileNameWithoutPath;
-        final File cacheFolder = new File(this.activity.getCacheDir(), "capgo_downloads");
-        final File cacheFile = new File(cacheFolder, fileHash + "_" + cacheBaseName);
-        // Cache files are named `{hash}_{filename}` and were checksum-verified
-        // when written. Re-hashing every hit re-reads the whole bundle and
-        // OOMs/janks low-RAM devices during getMissing / delta apply.
-        if (isReusableCacheFile(cacheFile)) {
-            return true;
-        }
+        if (isSafeCacheHash(fileHash)) {
+            final File cacheFolder = new File(this.activity.getCacheDir(), "capgo_downloads");
+            final File cacheFile = new File(cacheFolder, fileHash + "_" + cacheBaseName);
+            // Cache files are named `{hash}_{filename}` and were checksum-verified
+            // when written. Re-hashing every hit re-reads the whole bundle and
+            // OOMs/janks low-RAM devices during getMissing / delta apply.
+            if (isReusableCacheFile(cacheFile, fileHash)) {
+                return true;
+            }
 
-        if (isBrotli) {
-            final File legacyCacheFile = new File(cacheFolder, fileHash + "_" + fileNameWithoutPath);
-            return isReusableCacheFile(legacyCacheFile);
+            if (isBrotli) {
+                final File legacyCacheFile = new File(cacheFolder, fileHash + "_" + fileNameWithoutPath);
+                return isReusableCacheFile(legacyCacheFile, fileHash);
+            }
         }
 
         return false;
     }
 
-    // Hash-named cache files were verified when written. Existence + size
-    // is enough; re-hashing re-reads every reused file on low-RAM devices.
-    private static boolean isReusableCacheFile(final File file) {
-        return file != null && file.isFile() && file.length() > 0;
+    static final String EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    static boolean isSafeCacheHash(final String hash) {
+        if (hash == null) {
+            return false;
+        }
+        final int len = hash.length();
+        if (len != 64 && len != 8) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            final char c = hash.charAt(i);
+            if (
+                !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Hash-named cache files were verified when written. Existence is enough
+    // for non-empty files; empty files are reused only for the empty SHA-256.
+    static boolean isReusableCacheFile(final File file, final String expectedHash) {
+        if (file == null || !file.isFile() || !isSafeCacheHash(expectedHash)) {
+            return false;
+        }
+        final long length = file.length();
+        if (length > 0) {
+            return true;
+        }
+        return length == 0 && EMPTY_SHA256.equalsIgnoreCase(expectedHash);
     }
 
     public JSONArray getMissingBundleFiles(final JSONArray manifest, final String sessionKey) throws JSONException {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -561,10 +561,11 @@ public class CapgoUpdater {
         return true;
     }
 
-    // Hash-named cache files were verified when written. Existence is enough
-    // for non-empty files; empty files are reused only for the empty SHA-256.
+    // SHA-256 hash-named cache files were verified when written. Existence is
+    // enough for non-empty files; empty files are reused only for the empty SHA-256.
+    // CRC32 (8 hex) is too collision-prone to trust without a re-read.
     static boolean isReusableCacheFile(final File file, final String expectedHash) {
-        if (file == null || !file.isFile() || !isSafeCacheHash(expectedHash)) {
+        if (file == null || !file.isFile() || !isSafeCacheHash(expectedHash) || expectedHash.length() != 64) {
             return false;
         }
         final long length = file.length();

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1211,7 +1211,10 @@ public class CapgoUpdater {
 
         final File tempFile = File.createTempFile("capgo-", ".tmp", parent);
         try {
-            try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
+            try (
+                final FileInputStream input = new FileInputStream(source);
+                final FileOutputStream output = new FileOutputStream(tempFile)
+            ) {
                 final byte[] buffer = new byte[CryptoCipher.copyBufferBytes()];
                 int length;
                 while ((length = input.read(buffer)) != -1) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -554,9 +554,7 @@ public class CapgoUpdater {
         }
         for (int i = 0; i < len; i++) {
             final char c = hash.charAt(i);
-            if (
-                !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
-            ) {
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
                 return false;
             }
         }

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1209,7 +1209,7 @@ public class CapgoUpdater {
             throw new IOException("Failed to create parent directory: " + parent.getAbsolutePath());
         }
 
-        final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
+        final File tempFile = File.createTempFile("capgo-", ".tmp", parent);
         try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
             final byte[] buffer = new byte[CryptoCipher.copyBufferBytes()];
             int length;
@@ -1218,11 +1218,13 @@ public class CapgoUpdater {
             }
         }
 
-        if (!tempFile.renameTo(dest)) {
-            if (!dest.delete() || !tempFile.renameTo(dest)) {
+        try {
+            CryptoCipher.replaceFile(tempFile, dest);
+        } catch (IOException e) {
+            if (tempFile.exists()) {
                 tempFile.delete();
-                throw new IOException("Failed to replace file: " + dest.getAbsolutePath());
             }
+            throw e;
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -475,7 +475,7 @@ public class CapgoUpdater {
 
     private void copyFile(final File source, final File dest) throws IOException {
         try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(dest)) {
-            final byte[] buffer = new byte[1024 * 1024];
+            final byte[] buffer = new byte[64 * 1024];
             int length;
             while ((length = input.read(buffer)) != -1) {
                 output.write(buffer, 0, length);
@@ -525,16 +525,25 @@ public class CapgoUpdater {
         final String cacheBaseName = isBrotli ? fileNameWithoutPath.substring(0, fileNameWithoutPath.length() - 3) : fileNameWithoutPath;
         final File cacheFolder = new File(this.activity.getCacheDir(), "capgo_downloads");
         final File cacheFile = new File(cacheFolder, fileHash + "_" + cacheBaseName);
-        if (verifyChecksum(cacheFile, fileHash)) {
+        // Cache files are named `{hash}_{filename}` and were checksum-verified
+        // when written. Re-hashing every hit re-reads the whole bundle and
+        // OOMs/janks low-RAM devices during getMissing / delta apply.
+        if (isReusableCacheFile(cacheFile)) {
             return true;
         }
 
         if (isBrotli) {
             final File legacyCacheFile = new File(cacheFolder, fileHash + "_" + fileNameWithoutPath);
-            return verifyChecksum(legacyCacheFile, fileHash);
+            return isReusableCacheFile(legacyCacheFile);
         }
 
         return false;
+    }
+
+    // Hash-named cache files were verified when written. Existence + size
+    // is enough; re-hashing re-reads every reused file on low-RAM devices.
+    private static boolean isReusableCacheFile(final File file) {
+        return file != null && file.isFile() && file.length() > 0;
     }
 
     public JSONArray getMissingBundleFiles(final JSONArray manifest, final String sessionKey) throws JSONException {
@@ -1173,7 +1182,7 @@ public class CapgoUpdater {
 
         final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
         try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
-            final byte[] buffer = new byte[1024 * 1024];
+            final byte[] buffer = new byte[64 * 1024];
             int length;
             while ((length = input.read(buffer)) != -1) {
                 output.write(buffer, 0, length);

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -1210,21 +1210,19 @@ public class CapgoUpdater {
         }
 
         final File tempFile = File.createTempFile("capgo-", ".tmp", parent);
-        try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
-            final byte[] buffer = new byte[CryptoCipher.copyBufferBytes()];
-            int length;
-            while ((length = input.read(buffer)) != -1) {
-                output.write(buffer, 0, length);
-            }
-        }
-
         try {
+            try (final FileInputStream input = new FileInputStream(source); final FileOutputStream output = new FileOutputStream(tempFile)) {
+                final byte[] buffer = new byte[CryptoCipher.copyBufferBytes()];
+                int length;
+                while ((length = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, length);
+                }
+            }
             CryptoCipher.replaceFile(tempFile, dest);
-        } catch (IOException e) {
+        } finally {
             if (tempFile.exists()) {
                 tempFile.delete();
             }
-            throw e;
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -449,7 +449,7 @@ public class CapgoUpdater {
                 continue;
             }
             try {
-                copyFile(file, cacheFile);
+                copyFileAtomically(file, cacheFile);
             } catch (IOException e) {
                 logger.debug("Delta cache copy failed: " + file.getPath());
             }

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -358,6 +358,10 @@ public class CryptoCipher {
         return ioBufferBytes(physicalRamBytes);
     }
 
+    static int ioBufferBytes() {
+        return ioBufferBytes(physicalRamBytes());
+    }
+
     static int checksumBufferBytes() {
         return ioBufferBytes(physicalRamBytes());
     }

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -309,12 +309,12 @@ public class CryptoCipher {
     private static final long SIX_GIB = 6L * 1024 * 1024 * 1024;
     private static volatile long cachedPhysicalRamBytes = -1;
 
-    // <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB: 1MB. Else original 5MB.
+    // <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB inclusive: 1MB. Else original 5MB.
     static int checksumBufferBytes(long physicalRamBytes) {
         if (physicalRamBytes > 0 && physicalRamBytes < FOUR_GIB) {
             return 64 * 1024;
         }
-        if (physicalRamBytes > 0 && physicalRamBytes < SIX_GIB) {
+        if (physicalRamBytes > 0 && physicalRamBytes <= SIX_GIB) {
             return 1024 * 1024;
         }
         return 5 * 1024 * 1024;

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -199,14 +199,7 @@ public class CryptoCipher {
         if (from.renameTo(to)) {
             return;
         }
-        if (to.exists() && !to.delete()) {
-            from.delete();
-            throw new IOException("Failed to replace file: " + to.getAbsolutePath());
-        }
-        if (!from.renameTo(to)) {
-            from.delete();
-            throw new IOException("Failed to replace file: " + to.getAbsolutePath());
-        }
+        throw new IOException("Failed to replace file: " + to.getAbsolutePath());
     }
 
     private static byte[] hexStringToByteArray(String s) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -13,10 +13,12 @@ package ee.forgr.capacitor_updater;
  */
 import android.util.Base64;
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
@@ -303,10 +305,59 @@ public class CryptoCipher {
         }
     }
 
+    private static final long FOUR_GIB = 4L * 1024 * 1024 * 1024;
+    private static final long SIX_GIB = 6L * 1024 * 1024 * 1024;
+    private static volatile long cachedPhysicalRamBytes = -1;
+
+    // <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB: 1MB. Else original 5MB.
+    static int checksumBufferBytes(long physicalRamBytes) {
+        if (physicalRamBytes > 0 && physicalRamBytes < FOUR_GIB) {
+            return 64 * 1024;
+        }
+        if (physicalRamBytes > 0 && physicalRamBytes < SIX_GIB) {
+            return 1024 * 1024;
+        }
+        return 5 * 1024 * 1024;
+    }
+
+    static int copyBufferBytes(long physicalRamBytes) {
+        if (physicalRamBytes > 0 && physicalRamBytes < FOUR_GIB) {
+            return 64 * 1024;
+        }
+        return 1024 * 1024;
+    }
+
+    static int checksumBufferBytes() {
+        return checksumBufferBytes(physicalRamBytes());
+    }
+
+    static int copyBufferBytes() {
+        return copyBufferBytes(physicalRamBytes());
+    }
+
+    static long physicalRamBytes() {
+        long cached = cachedPhysicalRamBytes;
+        if (cached >= 0) {
+            return cached;
+        }
+        long parsed = 0;
+        try (BufferedReader reader = new BufferedReader(new FileReader("/proc/meminfo"))) {
+            String line = reader.readLine();
+            if (line != null && line.startsWith("MemTotal:")) {
+                String[] parts = line.split("\\s+");
+                if (parts.length >= 2) {
+                    parsed = Long.parseLong(parts[1]) * 1024L;
+                }
+            }
+        } catch (Exception ignored) {
+            parsed = 0;
+        }
+        cachedPhysicalRamBytes = parsed;
+        return parsed;
+    }
+
     public static String calcChecksum(File file) {
-        // 64KB: SHA-256 does not benefit from 5MB reads, and manifest
-        // downloads hash several files at once on low-RAM devices.
-        final int BUFFER_SIZE = 64 * 1024;
+        final int BUFFER_SIZE = checksumBufferBytes();
         MessageDigest digest;
         try {
             digest = MessageDigest.getInstance("SHA-256");

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -12,14 +12,14 @@ package ee.forgr.capacitor_updater;
  * references: http://stackoverflow.com/questions/12471999/rsa-encryption-decryption-in-android
  */
 import android.util.Base64;
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -159,25 +159,42 @@ public class CryptoCipher {
             byte[] decryptedSessionKey = CryptoCipher.decryptRSA(sessionKey, pKey);
 
             SecretKey sKey = CryptoCipher.byteToSessionKey(decryptedSessionKey);
-            byte[] content = new byte[(int) file.length()];
-
-            try (
-                final FileInputStream fis = new FileInputStream(file);
-                final BufferedInputStream bis = new BufferedInputStream(fis);
-                final DataInputStream dis = new DataInputStream(bis)
-            ) {
-                dis.readFully(content);
-                dis.close();
-                byte[] decrypted = CryptoCipher.decryptAES(content, sKey, iv);
-                // write the decrypted string to the file
-                try (final FileOutputStream fos = new FileOutputStream(file.getAbsolutePath())) {
-                    fos.write(decrypted);
-                }
-            }
+            decryptAesFile(file, sKey, iv);
         } catch (GeneralSecurityException e) {
             logger.info("decryptFile fail");
             e.printStackTrace();
             throw new IOException("GeneralSecurityException");
+        }
+    }
+
+    static void decryptAesFile(File file, SecretKey key, byte[] iv) throws IOException, GeneralSecurityException {
+        if (file.length() == 0) {
+            throw new IOException("Empty encrypted data");
+        }
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key.getEncoded(), "AES"), new IvParameterSpec(iv));
+        File tempFile = File.createTempFile("capgo-aes-", ".tmp", file.getParentFile());
+        try {
+            byte[] inBuf = new byte[ioBufferBytes()];
+            try (FileInputStream fis = new FileInputStream(file); FileOutputStream fos = new FileOutputStream(tempFile)) {
+                int n;
+                while ((n = fis.read(inBuf)) != -1) {
+                    byte[] out = cipher.update(inBuf, 0, n);
+                    if (out != null && out.length > 0) {
+                        fos.write(out);
+                    }
+                }
+                byte[] last = cipher.doFinal();
+                if (last != null && last.length > 0) {
+                    fos.write(last);
+                }
+            }
+            Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            tempFile = null;
+        } finally {
+            if (tempFile != null && tempFile.exists()) {
+                tempFile.delete();
+            }
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -18,8 +18,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -162,8 +160,7 @@ public class CryptoCipher {
             decryptAesFile(file, sKey, iv);
         } catch (GeneralSecurityException e) {
             logger.info("decryptFile fail");
-            e.printStackTrace();
-            throw new IOException("GeneralSecurityException");
+            throw new IOException("GeneralSecurityException", e);
         }
     }
 
@@ -189,12 +186,26 @@ public class CryptoCipher {
                     fos.write(last);
                 }
             }
-            Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            replaceFile(tempFile, file);
             tempFile = null;
         } finally {
             if (tempFile != null && tempFile.exists()) {
                 tempFile.delete();
             }
+        }
+    }
+
+    static void replaceFile(File from, File to) throws IOException {
+        if (from.renameTo(to)) {
+            return;
+        }
+        if (to.exists() && !to.delete()) {
+            from.delete();
+            throw new IOException("Failed to replace file: " + to.getAbsolutePath());
+        }
+        if (!from.renameTo(to)) {
+            from.delete();
+            throw new IOException("Failed to replace file: " + to.getAbsolutePath());
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -173,17 +173,20 @@ public class CryptoCipher {
         File tempFile = File.createTempFile("capgo-aes-", ".tmp", file.getParentFile());
         try {
             byte[] inBuf = new byte[ioBufferBytes()];
+            // Reuse one output buffer. cipher.update(in) allocates a new byte[] per chunk
+            // and 64 workers * 5MB was why AES barely won on heap in local benches.
+            byte[] outBuf = new byte[inBuf.length + 16];
             try (FileInputStream fis = new FileInputStream(file); FileOutputStream fos = new FileOutputStream(tempFile)) {
                 int n;
                 while ((n = fis.read(inBuf)) != -1) {
-                    byte[] out = cipher.update(inBuf, 0, n);
-                    if (out != null && out.length > 0) {
-                        fos.write(out);
+                    int outLen = cipher.update(inBuf, 0, n, outBuf, 0);
+                    if (outLen > 0) {
+                        fos.write(outBuf, 0, outLen);
                     }
                 }
-                byte[] last = cipher.doFinal();
-                if (last != null && last.length > 0) {
-                    fos.write(last);
+                int last = cipher.doFinal(outBuf, 0);
+                if (last > 0) {
+                    fos.write(outBuf, 0, last);
                 }
             }
             replaceFile(tempFile, file);

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -304,7 +304,9 @@ public class CryptoCipher {
     }
 
     public static String calcChecksum(File file) {
-        final int BUFFER_SIZE = 1024 * 1024 * 5; // 5 MB buffer size
+        // 64KB: SHA-256 does not benefit from 5MB reads, and manifest
+        // downloads hash several files at once on low-RAM devices.
+        final int BUFFER_SIZE = 64 * 1024;
         MessageDigest digest;
         try {
             digest = MessageDigest.getInstance("SHA-256");

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -305,34 +305,48 @@ public class CryptoCipher {
         }
     }
 
+    private static final long TWO_GIB = 2L * 1024 * 1024 * 1024;
+    private static final long THREE_GIB = 3L * 1024 * 1024 * 1024;
     private static final long FOUR_GIB = 4L * 1024 * 1024 * 1024;
-    private static final long SIX_GIB = 6L * 1024 * 1024 * 1024;
+    private static final long EIGHT_GIB = 8L * 1024 * 1024 * 1024;
+    private static final int FLAGSHIP_IO_BUFFER_BYTES = 5 * 1024 * 1024;
     private static volatile long cachedPhysicalRamBytes = -1;
 
-    // <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB inclusive: 1MB. Else original 5MB.
-    static int checksumBufferBytes(long physicalRamBytes) {
-        if (physicalRamBytes > 0 && physicalRamBytes < FOUR_GIB) {
+    // Checksum and copy share one ladder. 64-wide peak RAM = 64 * buffer.
+    // <2GB: 64KB. <3GB: 256KB. <4GB: 512KB. <8GB: 1MB. Else 5MB (flagship / unknown).
+    static int ioBufferBytes(long physicalRamBytes) {
+        if (physicalRamBytes <= 0) {
+            return FLAGSHIP_IO_BUFFER_BYTES;
+        }
+        if (physicalRamBytes < TWO_GIB) {
             return 64 * 1024;
         }
-        if (physicalRamBytes > 0 && physicalRamBytes <= SIX_GIB) {
+        if (physicalRamBytes < THREE_GIB) {
+            return 256 * 1024;
+        }
+        if (physicalRamBytes < FOUR_GIB) {
+            return 512 * 1024;
+        }
+        if (physicalRamBytes < EIGHT_GIB) {
             return 1024 * 1024;
         }
-        return 5 * 1024 * 1024;
+        return FLAGSHIP_IO_BUFFER_BYTES;
+    }
+
+    static int checksumBufferBytes(long physicalRamBytes) {
+        return ioBufferBytes(physicalRamBytes);
     }
 
     static int copyBufferBytes(long physicalRamBytes) {
-        if (physicalRamBytes > 0 && physicalRamBytes < FOUR_GIB) {
-            return 64 * 1024;
-        }
-        return 1024 * 1024;
+        return ioBufferBytes(physicalRamBytes);
     }
 
     static int checksumBufferBytes() {
-        return checksumBufferBytes(physicalRamBytes());
+        return ioBufferBytes(physicalRamBytes());
     }
 
     static int copyBufferBytes() {
-        return copyBufferBytes(physicalRamBytes());
+        return ioBufferBytes(physicalRamBytes());
     }
 
     static long physicalRamBytes() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -78,8 +79,8 @@ public class DownloadService extends Worker {
     public static final String DEFAULT_CHANNEL = "default_channel";
     public static final String IS_PROD = "is_prod";
     public static final String IS_EMULATOR = "is_emulator";
-    // Cap concurrent manifest file work. 32-64 OOMs low-RAM devices.
-    private static final int MANIFEST_MAX_CONCURRENT_FILES = 4;
+    // Match HTTP dispatcher so 64 workers actually fetch in parallel (HTTP/2 multiplexes).
+    private static final int MANIFEST_MAX_CONCURRENT_FILES = 64;
     private static final String UPDATE_FILE = "update.dat";
 
     // Shared OkHttpClient to prevent resource leaks
@@ -90,7 +91,11 @@ public class DownloadService extends Worker {
 
     // Initialize shared client with User-Agent interceptor
     static {
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequests(MANIFEST_MAX_CONCURRENT_FILES);
+        dispatcher.setMaxRequestsPerHost(MANIFEST_MAX_CONCURRENT_FILES);
         sharedClient = new OkHttpClient.Builder()
+            .dispatcher(dispatcher)
             .protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1))
             .addInterceptor((chain) -> {
                 Request originalRequest = chain.request();
@@ -317,10 +322,8 @@ public class DownloadService extends Worker {
             final AtomicLong completedFiles = new AtomicLong(0);
             final AtomicBoolean hasError = new AtomicBoolean(false);
 
-            // 4 concurrent: 32–64 threads hold ~1MB stacks each plus file
-            // bodies and checksum buffers — that OOMs low-RAM phones. 4 also
-            // matches typical per-host HTTP limits, so extra threads mostly wait.
-            ExecutorService executor = Executors.newFixedThreadPool(MANIFEST_MAX_CONCURRENT_FILES);
+            int maxConcurrent = Math.min(MANIFEST_MAX_CONCURRENT_FILES, Math.max(1, totalFiles));
+            ExecutorService executor = Executors.newFixedThreadPool(maxConcurrent);
             List<Future<?>> futures = new ArrayList<>();
 
             for (int i = 0; i < totalFiles; i++) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -897,7 +897,7 @@ public class DownloadService extends Worker {
      * Atomically write data to a file using OkIO
      */
     private void writeFileAtomic(File targetFile, InputStream inputStream, String expectedChecksum) throws IOException {
-        File tempFile = new File(targetFile.getParent(), targetFile.getName() + ".tmp");
+        File tempFile = new File(targetFile.getParent(), targetFile.getName() + "." + java.util.UUID.randomUUID() + ".tmp");
 
         try {
             // Write to temp file first using OkIO

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -37,11 +37,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.BufferedSource;
-import okio.Okio;
-import okio.Source;
 import org.brotli.dec.BrotliInputStream;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -903,15 +898,20 @@ public class DownloadService extends Worker {
     }
 
     /**
-     * Atomically write data to a file using OkIO
+     * Atomically write a stream to a file using the RAM-ladder IO buffer.
      */
     static void writeFileAtomic(File targetFile, InputStream inputStream, String expectedChecksum) throws IOException {
         File tempFile = File.createTempFile("capgo-", ".tmp", targetFile.getParentFile());
 
         try {
-            // Write to temp file first using OkIO
-            try (BufferedSink sink = Okio.buffer(Okio.sink(tempFile)); BufferedSource source = Okio.buffer(Okio.source(inputStream))) {
-                sink.writeAll(source);
+            // Okio's default segment is 8KB. Copy with the RAM-ladder buffer so
+            // 8MB wrapper unwraps are not 1000 tiny writes.
+            byte[] buffer = new byte[CryptoCipher.ioBufferBytes()];
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                int n;
+                while ((n = inputStream.read(buffer)) != -1) {
+                    fos.write(buffer, 0, n);
+                }
             }
 
             // Verify checksum if provided

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -15,8 +15,6 @@ import java.io.FileInputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -663,7 +661,7 @@ public class DownloadService extends Worker {
         }
 
         try {
-            Files.move(tempFile.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            CryptoCipher.replaceFile(tempFile, dest);
         } catch (IOException e) {
             if (tempFile.exists()) {
                 tempFile.delete();
@@ -919,8 +917,8 @@ public class DownloadService extends Worker {
                 }
             }
 
-            // Atomic rename (on same filesystem)
-            Files.move(tempFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            // Atomic rename (on same filesystem). renameTo works on API 24; Files.move does not.
+            CryptoCipher.replaceFile(tempFile, targetFile);
         } catch (Exception e) {
             // Clean up temp file on error
             if (tempFile.exists()) {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -897,7 +897,7 @@ public class DownloadService extends Worker {
      * Atomically write data to a file using OkIO
      */
     private void writeFileAtomic(File targetFile, InputStream inputStream, String expectedChecksum) throws IOException {
-        File tempFile = new File(targetFile.getParent(), targetFile.getName() + "." + java.util.UUID.randomUUID() + ".tmp");
+        File tempFile = File.createTempFile("capgo-", ".tmp", targetFile.getParentFile());
 
         try {
             // Write to temp file first using OkIO

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -363,8 +363,11 @@ public class DownloadService extends Worker {
                     continue;
                 }
                 String cacheBaseName = new File(isBrotli ? targetFileName : fileName).getName();
-                File cacheFile = new File(cacheFolder, finalFileHash + "_" + cacheBaseName);
-                final File legacyCacheFile = isBrotli ? new File(cacheFolder, finalFileHash + "_" + new File(fileName).getName()) : null;
+                final File cacheFile = CapgoUpdater.isSafeCacheHash(finalFileHash)
+                    ? new File(cacheFolder, finalFileHash + "_" + cacheBaseName)
+                    : null;
+                final File legacyCacheFile =
+                    isBrotli && cacheFile != null ? new File(cacheFolder, finalFileHash + "_" + new File(fileName).getName()) : null;
 
                 // Ensure parent directories of the target file exist
                 if (!Objects.requireNonNull(targetFile.getParentFile()).exists() && !targetFile.getParentFile().mkdirs()) {
@@ -380,8 +383,8 @@ public class DownloadService extends Worker {
                             copyFile(builtinFile, targetFile);
                             logger.debug("using builtin file " + fileName);
                         } else if (
-                            tryCopyFromCache(cacheFile, targetFile) ||
-                            (legacyCacheFile != null && tryCopyFromCache(legacyCacheFile, targetFile))
+                            tryCopyFromCache(cacheFile, targetFile, finalFileHash) ||
+                            (legacyCacheFile != null && tryCopyFromCache(legacyCacheFile, targetFile, finalFileHash))
                         ) {
                             logger.debug("already cached " + fileName);
                         } else {
@@ -623,9 +626,9 @@ public class DownloadService extends Worker {
      * Atomically try to copy a file from cache - returns true if successful, false if file doesn't exist or copy failed.
      * This handles the race condition where OS can delete cache files between exists() check and copy.
      */
-    private boolean tryCopyFromCache(File source, File dest) {
+    private boolean tryCopyFromCache(File source, File dest, String expectedHash) {
         // First quick check - if file doesn't exist or was truncated, don't bother
-        if (!isReusableCacheFile(source)) {
+        if (!CapgoUpdater.isReusableCacheFile(source, expectedHash)) {
             return false;
         }
 
@@ -639,10 +642,6 @@ public class DownloadService extends Worker {
             logger.debug("Cache copy failed (likely OS eviction): " + e.getMessage());
             return false;
         }
-    }
-
-    private static boolean isReusableCacheFile(final File file) {
-        return file != null && file.isFile() && file.length() > 0;
     }
 
     private void copyFile(File source, File dest) throws IOException {
@@ -760,8 +759,10 @@ public class DownloadService extends Worker {
                 // Verify checksum
                 if (calculatedHash.equalsIgnoreCase(expectedHash)) {
                     // Only cache if checksum is correct - use atomic copy
-                    try (FileInputStream fis = new FileInputStream(finalTargetFile)) {
-                        writeFileAtomic(cacheFile, fis, null);
+                    if (cacheFile != null) {
+                        try (FileInputStream fis = new FileInputStream(finalTargetFile)) {
+                            writeFileAtomic(cacheFile, fis, null);
+                        }
                     }
                 } else {
                     finalTargetFile.delete();

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -78,6 +78,8 @@ public class DownloadService extends Worker {
     public static final String DEFAULT_CHANNEL = "default_channel";
     public static final String IS_PROD = "is_prod";
     public static final String IS_EMULATOR = "is_emulator";
+    // Cap concurrent manifest file work. 32-64 OOMs low-RAM devices.
+    private static final int MANIFEST_MAX_CONCURRENT_FILES = 4;
     private static final String UPDATE_FILE = "update.dat";
 
     // Shared OkHttpClient to prevent resource leaks
@@ -203,7 +205,7 @@ public class DownloadService extends Worker {
             if (isManifest) {
                 JSONArray manifest = DataManager.getInstance().getAndClearManifest();
                 if (manifest != null) {
-                    handleManifestDownload(id, documentsDir, dest, version, sessionKey, publicKey, manifest.toString());
+                    handleManifestDownload(id, documentsDir, dest, version, sessionKey, publicKey, manifest);
                     return createSuccessResult(dest, version, sessionKey, checksum, true);
                 } else {
                     logger.error("Manifest is null");
@@ -291,7 +293,7 @@ public class DownloadService extends Worker {
         String version,
         String sessionKey,
         String publicKey,
-        String manifestString
+        JSONArray manifest
     ) {
         try {
             logger.debug("handleManifestDownload");
@@ -299,7 +301,6 @@ public class DownloadService extends Worker {
             // Send stats for manifest download start
             sendStatsAsync("download_manifest_start", version);
 
-            JSONArray manifest = new JSONArray(manifestString);
             File destFolder = new File(documentsDir, dest);
             File cacheFolder = new File(getApplicationContext().getCacheDir(), "capgo_downloads");
             File builtinFolder = new File(getApplicationContext().getFilesDir(), "public");
@@ -316,9 +317,10 @@ public class DownloadService extends Worker {
             final AtomicLong completedFiles = new AtomicLong(0);
             final AtomicBoolean hasError = new AtomicBoolean(false);
 
-            // Use more threads for I/O-bound operations
-            int threadCount = Math.min(64, Math.max(32, totalFiles));
-            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            // 4 concurrent: 32–64 threads hold ~1MB stacks each plus file
+            // bodies and checksum buffers — that OOMs low-RAM phones. 4 also
+            // matches typical per-host HTTP limits, so extra threads mostly wait.
+            ExecutorService executor = Executors.newFixedThreadPool(MANIFEST_MAX_CONCURRENT_FILES);
             List<Future<?>> futures = new ArrayList<>();
 
             for (int i = 0; i < totalFiles; i++) {
@@ -378,8 +380,8 @@ public class DownloadService extends Worker {
                             copyFile(builtinFile, targetFile);
                             logger.debug("using builtin file " + fileName);
                         } else if (
-                            tryCopyFromCache(cacheFile, targetFile, finalFileHash) ||
-                            (legacyCacheFile != null && tryCopyFromCache(legacyCacheFile, targetFile, finalFileHash))
+                            tryCopyFromCache(cacheFile, targetFile) ||
+                            (legacyCacheFile != null && tryCopyFromCache(legacyCacheFile, targetFile))
                         ) {
                             logger.debug("already cached " + fileName);
                         } else {
@@ -621,18 +623,14 @@ public class DownloadService extends Worker {
      * Atomically try to copy a file from cache - returns true if successful, false if file doesn't exist or copy failed.
      * This handles the race condition where OS can delete cache files between exists() check and copy.
      */
-    private boolean tryCopyFromCache(File source, File dest, String expectedHash) {
-        // First quick check - if file doesn't exist, don't bother
-        if (!source.exists()) {
+    private boolean tryCopyFromCache(File source, File dest) {
+        // First quick check - if file doesn't exist or was truncated, don't bother
+        if (!isReusableCacheFile(source)) {
             return false;
         }
 
-        // Verify checksum before copy
-        if (!verifyChecksum(source, expectedHash)) {
-            return false;
-        }
-
-        // Try to copy - if it fails (file deleted by OS between check and copy), return false
+        // Hash is in the cache file name and was verified when written.
+        // Re-hashing here would re-read every reused file on low-RAM devices.
         try {
             copyFile(source, dest);
             return true;
@@ -641,6 +639,10 @@ public class DownloadService extends Worker {
             logger.debug("Cache copy failed (likely OS eviction): " + e.getMessage());
             return false;
         }
+    }
+
+    private static boolean isReusableCacheFile(final File file) {
+        return file != null && file.isFile() && file.length() > 0;
     }
 
     private void copyFile(File source, File dest) throws IOException {
@@ -759,7 +761,7 @@ public class DownloadService extends Worker {
                 if (calculatedHash.equalsIgnoreCase(expectedHash)) {
                     // Only cache if checksum is correct - use atomic copy
                     try (FileInputStream fis = new FileInputStream(finalTargetFile)) {
-                        writeFileAtomic(cacheFile, fis, expectedHash);
+                        writeFileAtomic(cacheFile, fis, null);
                     }
                 } else {
                     finalTargetFile.delete();

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -81,6 +82,8 @@ public class DownloadService extends Worker {
     public static final String IS_EMULATOR = "is_emulator";
     // Match HTTP dispatcher so 64 workers actually fetch in parallel (HTTP/2 multiplexes).
     private static final int MANIFEST_MAX_CONCURRENT_FILES = 64;
+    // Decrypt/brotli still load whole files. Bound that, not HTTP.
+    private static final Semaphore MANIFEST_DECODE_PERMITS = new Semaphore(4);
     private static final String UPDATE_FILE = "update.dat";
 
     // Shared OkHttpClient to prevent resource leaks
@@ -322,8 +325,7 @@ public class DownloadService extends Worker {
             final AtomicLong completedFiles = new AtomicLong(0);
             final AtomicBoolean hasError = new AtomicBoolean(false);
 
-            int maxConcurrent = Math.min(MANIFEST_MAX_CONCURRENT_FILES, Math.max(1, totalFiles));
-            ExecutorService executor = Executors.newFixedThreadPool(maxConcurrent);
+            ExecutorService executor = Executors.newFixedThreadPool(Math.min(MANIFEST_MAX_CONCURRENT_FILES, Math.max(1, totalFiles)));
             List<Future<?>> futures = new ArrayList<>();
 
             for (int i = 0; i < totalFiles; i++) {
@@ -712,44 +714,55 @@ public class DownloadService extends Worker {
                 // Use OkIO for atomic write
                 writeFileAtomic(compressedFile, responseBody.byteStream(), null);
 
-                if (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
-                    logger.debug("Decrypting file " + targetFile.getName());
-                    CryptoCipher.decryptFile(compressedFile, publicKey, sessionKey);
+                boolean needsDecode =
+                    isBrotli || (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty());
+                if (needsDecode) {
+                    MANIFEST_DECODE_PERMITS.acquire();
                 }
+                try {
+                    if (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
+                        logger.debug("Decrypting file " + targetFile.getName());
+                        CryptoCipher.decryptFile(compressedFile, publicKey, sessionKey);
+                    }
 
-                // Only decompress if file has .br extension
-                if (isBrotli) {
-                    // Use new decompression method with atomic write
-                    try (FileInputStream fis = new FileInputStream(compressedFile)) {
-                        byte[] compressedData = new byte[(int) compressedFile.length()];
-                        int offset = 0;
-                        int bytesRead;
-                        while (
-                            offset < compressedData.length &&
-                            (bytesRead = fis.read(compressedData, offset, compressedData.length - offset)) != -1
-                        ) {
-                            offset += bytesRead;
-                        }
-                        byte[] decompressedData;
-                        try {
-                            decompressedData = decompressBrotli(compressedData, targetFile.getName());
-                        } catch (IOException e) {
-                            sendStatsAsync(
-                                "download_manifest_brotli_fail",
-                                getInputData().getString(VERSION) + ":" + finalTargetFile.getName()
-                            );
-                            throw e;
-                        }
+                    // Only decompress if file has .br extension
+                    if (isBrotli) {
+                        // Use new decompression method with atomic write
+                        try (FileInputStream fis = new FileInputStream(compressedFile)) {
+                            byte[] compressedData = new byte[(int) compressedFile.length()];
+                            int offset = 0;
+                            int bytesRead;
+                            while (
+                                offset < compressedData.length &&
+                                (bytesRead = fis.read(compressedData, offset, compressedData.length - offset)) != -1
+                            ) {
+                                offset += bytesRead;
+                            }
+                            byte[] decompressedData;
+                            try {
+                                decompressedData = decompressBrotli(compressedData, targetFile.getName());
+                            } catch (IOException e) {
+                                sendStatsAsync(
+                                    "download_manifest_brotli_fail",
+                                    getInputData().getString(VERSION) + ":" + finalTargetFile.getName()
+                                );
+                                throw e;
+                            }
 
-                        // Write decompressed data atomically
-                        try (java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(decompressedData)) {
-                            writeFileAtomic(finalTargetFile, bais, null);
+                            // Write decompressed data atomically
+                            try (java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(decompressedData)) {
+                                writeFileAtomic(finalTargetFile, bais, null);
+                            }
+                        }
+                    } else {
+                        // Just copy the file without decompression using atomic operation
+                        try (FileInputStream fis = new FileInputStream(compressedFile)) {
+                            writeFileAtomic(finalTargetFile, fis, null);
                         }
                     }
-                } else {
-                    // Just copy the file without decompression using atomic operation
-                    try (FileInputStream fis = new FileInputStream(compressedFile)) {
-                        writeFileAtomic(finalTargetFile, fis, null);
+                } finally {
+                    if (needsDecode) {
+                        MANIFEST_DECODE_PERMITS.release();
                     }
                 }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -651,22 +651,20 @@ public class DownloadService extends Worker {
         }
 
         final File tempFile = File.createTempFile("capgo-", ".tmp", parent);
-        try (
-            FileInputStream inStream = new FileInputStream(source);
-            FileOutputStream outStream = new FileOutputStream(tempFile);
-            FileChannel inChannel = inStream.getChannel();
-            FileChannel outChannel = outStream.getChannel()
-        ) {
-            inChannel.transferTo(0, inChannel.size(), outChannel);
-        }
-
         try {
+            try (
+                FileInputStream inStream = new FileInputStream(source);
+                FileOutputStream outStream = new FileOutputStream(tempFile);
+                FileChannel inChannel = inStream.getChannel();
+                FileChannel outChannel = outStream.getChannel()
+            ) {
+                inChannel.transferTo(0, inChannel.size(), outChannel);
+            }
             CryptoCipher.replaceFile(tempFile, dest);
-        } catch (IOException e) {
+        } finally {
             if (tempFile.exists()) {
                 tempFile.delete();
             }
-            throw e;
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -82,8 +81,6 @@ public class DownloadService extends Worker {
     public static final String IS_EMULATOR = "is_emulator";
     // Match HTTP dispatcher so 64 workers actually fetch in parallel (HTTP/2 multiplexes).
     private static final int MANIFEST_MAX_CONCURRENT_FILES = 64;
-    // Decrypt/brotli still load whole files. Bound that, not HTTP.
-    private static final Semaphore MANIFEST_DECODE_PERMITS = new Semaphore(4);
     private static final String UPDATE_FILE = "update.dat";
 
     // Shared OkHttpClient to prevent resource leaks
@@ -714,55 +711,25 @@ public class DownloadService extends Worker {
                 // Use OkIO for atomic write
                 writeFileAtomic(compressedFile, responseBody.byteStream(), null);
 
-                boolean needsDecode =
-                    isBrotli || (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty());
-                if (needsDecode) {
-                    MANIFEST_DECODE_PERMITS.acquire();
+                if (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
+                    logger.debug("Decrypting file " + targetFile.getName());
+                    CryptoCipher.decryptFile(compressedFile, publicKey, sessionKey);
                 }
-                try {
-                    if (publicKey != null && !publicKey.isEmpty() && sessionKey != null && !sessionKey.isEmpty()) {
-                        logger.debug("Decrypting file " + targetFile.getName());
-                        CryptoCipher.decryptFile(compressedFile, publicKey, sessionKey);
-                    }
 
-                    // Only decompress if file has .br extension
-                    if (isBrotli) {
-                        // Use new decompression method with atomic write
-                        try (FileInputStream fis = new FileInputStream(compressedFile)) {
-                            byte[] compressedData = new byte[(int) compressedFile.length()];
-                            int offset = 0;
-                            int bytesRead;
-                            while (
-                                offset < compressedData.length &&
-                                (bytesRead = fis.read(compressedData, offset, compressedData.length - offset)) != -1
-                            ) {
-                                offset += bytesRead;
-                            }
-                            byte[] decompressedData;
-                            try {
-                                decompressedData = decompressBrotli(compressedData, targetFile.getName());
-                            } catch (IOException e) {
-                                sendStatsAsync(
-                                    "download_manifest_brotli_fail",
-                                    getInputData().getString(VERSION) + ":" + finalTargetFile.getName()
-                                );
-                                throw e;
-                            }
-
-                            // Write decompressed data atomically
-                            try (java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(decompressedData)) {
-                                writeFileAtomic(finalTargetFile, bais, null);
-                            }
-                        }
-                    } else {
-                        // Just copy the file without decompression using atomic operation
-                        try (FileInputStream fis = new FileInputStream(compressedFile)) {
-                            writeFileAtomic(finalTargetFile, fis, null);
-                        }
+                // Only decompress if file has .br extension
+                if (isBrotli) {
+                    try {
+                        decompressBrotli(compressedFile, finalTargetFile, targetFile.getName());
+                    } catch (IOException e) {
+                        sendStatsAsync(
+                            "download_manifest_brotli_fail",
+                            getInputData().getString(VERSION) + ":" + finalTargetFile.getName()
+                        );
+                        throw e;
                     }
-                } finally {
-                    if (needsDecode) {
-                        MANIFEST_DECODE_PERMITS.release();
+                } else {
+                    try (FileInputStream fis = new FileInputStream(compressedFile)) {
+                        writeFileAtomic(finalTargetFile, fis, null);
                     }
                 }
 
@@ -834,69 +801,107 @@ public class DownloadService extends Worker {
         return sb.toString();
     }
 
-    private byte[] decompressBrotli(byte[] data, String fileName) throws IOException {
-        // Validate input
-        if (data == null) {
-            logger.error("Error: Null data received for " + fileName);
-            throw new IOException("Null data received");
+    static void decompressBrotli(File input, File output, String fileName) throws IOException {
+        File parent = output.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        long length = input.length();
+        if (length == 0) {
+            writeFileAtomic(output, new ByteArrayInputStream(new byte[0]), null);
+            return;
         }
 
-        // Handle empty files
-        if (data.length == 0) {
-            return new byte[0];
-        }
-
-        // Handle the special EMPTY_BROTLI_STREAM case
-        if (data.length == 3 && data[0] == 0x1B && data[1] == 0x00 && data[2] == 0x06) {
-            return new byte[0];
-        }
-
-        // For small files, check if it's a minimal Brotli wrapper
-        if (data.length > 3) {
-            try {
-                // Handle our minimal wrapper pattern
-                if (data[0] == 0x1B && data[1] == 0x00 && data[2] == 0x06 && data[data.length - 1] == 0x03) {
-                    return Arrays.copyOfRange(data, 3, data.length - 1);
-                }
-
-                // Handle brotli.compress minimal wrapper (quality 0)
-                if (data[0] == 0x0b && data[1] == 0x02 && data[2] == (byte) 0x80 && data[data.length - 1] == 0x03) {
-                    return Arrays.copyOfRange(data, 3, data.length - 1);
-                }
-            } catch (ArrayIndexOutOfBoundsException e) {
-                logger.error("Error: Malformed data for " + fileName);
-                throw new IOException("Malformed data structure");
+        byte[] head = new byte[(int) Math.min(3, length)];
+        byte last = 0;
+        try (RandomAccessFile raf = new RandomAccessFile(input, "r")) {
+            raf.readFully(head);
+            if (length >= 1) {
+                raf.seek(length - 1);
+                last = raf.readByte();
             }
         }
 
-        // For all other cases, try standard decompression
-        try (
-            ByteArrayInputStream bis = new ByteArrayInputStream(data);
-            BrotliInputStream brotliInputStream = new BrotliInputStream(bis);
-            ByteArrayOutputStream bos = new ByteArrayOutputStream()
-        ) {
-            byte[] buffer = new byte[8192];
-            int len;
-            while ((len = brotliInputStream.read(buffer)) != -1) {
-                bos.write(buffer, 0, len);
+        if (length == 3 && head[0] == 0x1B && head[1] == 0x00 && head[2] == 0x06) {
+            writeFileAtomic(output, new ByteArrayInputStream(new byte[0]), null);
+            return;
+        }
+
+        if (length > 3 && last == 0x03) {
+            boolean emptyWrapper = head[0] == 0x1B && head[1] == 0x00 && head[2] == 0x06;
+            boolean qualityZeroWrapper = head[0] == 0x0b && head[1] == 0x02 && head[2] == (byte) 0x80;
+            if (emptyWrapper || qualityZeroWrapper) {
+                try (FileInputStream fis = new FileInputStream(input)) {
+                    long skipped = 0;
+                    while (skipped < 3) {
+                        long n = fis.skip(3 - skipped);
+                        if (n <= 0) {
+                            break;
+                        }
+                        skipped += n;
+                    }
+                    writeFileAtomic(output, new BoundedInputStream(fis, length - 4), null);
+                }
+                return;
             }
-            return bos.toByteArray();
+        }
+
+        try (FileInputStream fis = new FileInputStream(input); BrotliInputStream brotliInputStream = new BrotliInputStream(fis)) {
+            writeFileAtomic(output, brotliInputStream, null);
         } catch (IOException e) {
             logger.error("Error: Brotli process failed for " + fileName + ". Status: " + e.getMessage());
-            // Add hex dump for debugging
             StringBuilder hexDump = new StringBuilder();
-            for (int i = 0; i < Math.min(32, data.length); i++) {
-                hexDump.append(String.format("%02x ", data[i]));
+            try (FileInputStream peek = new FileInputStream(input)) {
+                byte[] prefix = new byte[(int) Math.min(32, length)];
+                int n = peek.read(prefix);
+                for (int i = 0; i < n; i++) {
+                    hexDump.append(String.format("%02x ", prefix[i]));
+                }
             }
-            logger.error("Error: Raw data (" + fileName + "): " + hexDump.toString());
+            logger.error("Error: Raw data (" + fileName + "): " + hexDump);
             throw e;
+        }
+    }
+
+    private static final class BoundedInputStream extends FilterInputStream {
+
+        private long remaining;
+
+        BoundedInputStream(InputStream in, long remaining) {
+            super(in);
+            this.remaining = remaining;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (remaining <= 0) {
+                return -1;
+            }
+            int value = super.read();
+            if (value >= 0) {
+                remaining--;
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (remaining <= 0) {
+                return -1;
+            }
+            int capped = (int) Math.min(len, remaining);
+            int n = super.read(b, off, capped);
+            if (n > 0) {
+                remaining -= n;
+            }
+            return n;
         }
     }
 
     /**
      * Atomically write data to a file using OkIO
      */
-    private void writeFileAtomic(File targetFile, InputStream inputStream, String expectedChecksum) throws IOException {
+    static void writeFileAtomic(File targetFile, InputStream inputStream, String expectedChecksum) throws IOException {
         File tempFile = File.createTempFile("capgo-", ".tmp", targetFile.getParentFile());
 
         try {

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -650,7 +650,7 @@ public class DownloadService extends Worker {
             throw new IOException("Failed to create parent directory: " + parent.getAbsolutePath());
         }
 
-        final File tempFile = new File(parent, dest.getName() + ".capgo_tmp");
+        final File tempFile = File.createTempFile("capgo-", ".tmp", parent);
         try (
             FileInputStream inStream = new FileInputStream(source);
             FileOutputStream outStream = new FileOutputStream(tempFile);

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -658,7 +658,15 @@ public class DownloadService extends Worker {
                 FileChannel inChannel = inStream.getChannel();
                 FileChannel outChannel = outStream.getChannel()
             ) {
-                inChannel.transferTo(0, inChannel.size(), outChannel);
+                long size = inChannel.size();
+                long pos = 0;
+                while (pos < size) {
+                    long transferred = inChannel.transferTo(pos, size - pos, outChannel);
+                    if (transferred <= 0) {
+                        throw new IOException("Failed to copy file: " + source.getAbsolutePath());
+                    }
+                    pos += transferred;
+                }
             }
             CryptoCipher.replaceFile(tempFile, dest);
         } finally {

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3700,4 +3700,62 @@ public class CapacitorUpdaterUnitTest {
             assertEquals(expected[i], CryptoCipher.copyBufferBytes(ramBytes[i]));
         }
     }
+
+    @Test
+    public void decompressBrotliStreamsEmptyWrapperAndRealPayload() throws Exception {
+        DownloadService.setLogger(mock(Logger.class));
+        final Path dir = Files.createTempDirectory("capgo-brotli");
+        File emptyOut = dir.resolve("empty.txt").toFile();
+        File emptyIn = dir.resolve("empty.br").toFile();
+        Files.write(emptyIn.toPath(), new byte[] { 0x1B, 0x00, 0x06 });
+        DownloadService.decompressBrotli(emptyIn, emptyOut, "empty.br");
+        assertEquals(0, emptyOut.length());
+
+        File wrappedIn = dir.resolve("hello.br").toFile();
+        File wrappedOut = dir.resolve("hello.txt").toFile();
+        byte[] wrapped = new byte[] { 0x0b, 0x02, (byte) 0x80, 'h', 'e', 'l', 'l', 'o', 0x03 };
+        Files.write(wrappedIn.toPath(), wrapped);
+        DownloadService.decompressBrotli(wrappedIn, wrappedOut, "hello.br");
+        assertEquals("hello", Files.readString(wrappedOut.toPath()));
+
+        File realIn = dir.resolve("payload.br").toFile();
+        File realOut = dir.resolve("payload.txt").toFile();
+        Files.write(
+            realIn.toPath(),
+            hexToBytes("1ba702f88d94abed6831a46e4b75213df69d8b08871d5db158a9b062f007672bc101c92bf781d73386bfc50a00")
+        );
+        DownloadService.decompressBrotli(realIn, realOut, "payload.br");
+        String expected = "Capgo stream brotli test payload. ".repeat(20);
+        assertEquals(expected, Files.readString(realOut.toPath()));
+    }
+
+    @Test
+    public void decryptAesFileStreamsRoundTrip() throws Exception {
+        final Path dir = Files.createTempDirectory("capgo-aes");
+        File file = dir.resolve("cipher.bin").toFile();
+        byte[] iv = new byte[16];
+        byte[] keyBytes = new byte[16];
+        for (int i = 0; i < 16; i++) {
+            iv[i] = (byte) i;
+            keyBytes[i] = (byte) (31 - i);
+        }
+        javax.crypto.SecretKey key = new javax.crypto.spec.SecretKeySpec(keyBytes, "AES");
+        byte[] plain = new byte[120_000];
+        for (int i = 0; i < plain.length; i++) {
+            plain[i] = (byte) (i * 31);
+        }
+        javax.crypto.Cipher enc = javax.crypto.Cipher.getInstance("AES/CBC/PKCS5Padding");
+        enc.init(javax.crypto.Cipher.ENCRYPT_MODE, key, new javax.crypto.spec.IvParameterSpec(iv));
+        Files.write(file.toPath(), enc.doFinal(plain));
+        CryptoCipher.decryptAesFile(file, key, iv);
+        assertArrayEquals(plain, Files.readAllBytes(file.toPath()));
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
 }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3527,6 +3527,55 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void getMissingBundleFilesTreatsHashNamedCacheAsReusable() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-cache").toFile();
+        Files.createDirectories(filesDir.toPath().resolve("public"));
+        final File downloads = new File(cacheDir, "capgo_downloads");
+        assertTrue(downloads.mkdirs());
+        final String hash = "abc123cachedhash";
+        // Content does not need to match the hash: the filename is the trust source
+        // (checksum was verified when the cache entry was written).
+        Files.write(new File(downloads, hash + "_app.js").toPath(), "not-the-hashed-bytes".getBytes(StandardCharsets.UTF_8));
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "app.js");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
+        assertEquals(0, missing.length());
+    }
+
+    @Test
+    public void getMissingBundleFilesIgnoresEmptyHashNamedCache() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-empty-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-empty-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-empty-cache").toFile();
+        Files.createDirectories(filesDir.toPath().resolve("public"));
+        final File downloads = new File(cacheDir, "capgo_downloads");
+        assertTrue(downloads.mkdirs());
+        final String hash = "abc123emptyhash";
+        Files.write(new File(downloads, hash + "_app.js").toPath(), new byte[0]);
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "app.js");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
+        assertEquals(1, missing.length());
+        assertEquals("app.js", missing.getJSONObject(0).getString("file_name"));
+    }
+
+    @Test
     public void testPendingStatsSurviveNewUpdaterInstance() throws Exception {
         final Path tempDir = Files.createTempDirectory("capgo-pending-stats");
         final File queueFile = tempDir.resolve("capgo_pending_stats.json").toFile();

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3690,20 +3690,14 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
-    public void checksumBufferStaysSmallOnLowRamAndFullOnFlagship() {
-        assertEquals(64 * 1024, CryptoCipher.checksumBufferBytes(3L * 1024 * 1024 * 1024));
-        assertEquals(1024 * 1024, CryptoCipher.checksumBufferBytes(4L * 1024 * 1024 * 1024));
-        assertEquals(1024 * 1024, CryptoCipher.checksumBufferBytes(6L * 1024 * 1024 * 1024));
-        assertEquals(5 * 1024 * 1024, CryptoCipher.checksumBufferBytes(8L * 1024 * 1024 * 1024));
-        assertEquals(5 * 1024 * 1024, CryptoCipher.checksumBufferBytes(0));
-    }
-
-    @Test
-    public void copyBufferStaysSmallOnLowRamAndFullOnFlagship() {
-        assertEquals(64 * 1024, CryptoCipher.copyBufferBytes(3L * 1024 * 1024 * 1024));
-        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(4L * 1024 * 1024 * 1024));
-        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(6L * 1024 * 1024 * 1024));
-        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(8L * 1024 * 1024 * 1024));
-        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(0));
+    public void ioBuffersFollowFiveRamTiersAndMatchForChecksumAndCopy() {
+        final long gib = 1024L * 1024 * 1024;
+        final long[] ramBytes = { gib, 2 * gib, 3 * gib, 4 * gib, 6 * gib, 8 * gib, 0 };
+        final int[] expected = { 64 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 1024 * 1024, 5 * 1024 * 1024, 5 * 1024 * 1024 };
+        for (int i = 0; i < ramBytes.length; i++) {
+            assertEquals(expected[i], CryptoCipher.ioBufferBytes(ramBytes[i]));
+            assertEquals(expected[i], CryptoCipher.checksumBufferBytes(ramBytes[i]));
+            assertEquals(expected[i], CryptoCipher.copyBufferBytes(ramBytes[i]));
+        }
     }
 }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3740,7 +3740,7 @@ public class CapacitorUpdaterUnitTest {
             keyBytes[i] = (byte) (31 - i);
         }
         javax.crypto.SecretKey key = new javax.crypto.spec.SecretKeySpec(keyBytes, "AES");
-        byte[] plain = new byte[120_000];
+        byte[] plain = new byte[CryptoCipher.ioBufferBytes() * 2 + 1];
         for (int i = 0; i < plain.length; i++) {
             plain[i] = (byte) (i * 31);
         }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3688,4 +3688,19 @@ public class CapacitorUpdaterUnitTest {
         relaunched.shutdown();
         crashed.shutdown();
     }
+
+    @Test
+    public void checksumBufferStaysSmallOnLowRamAndFullOnFlagship() {
+        assertEquals(64 * 1024, CryptoCipher.checksumBufferBytes(3L * 1024 * 1024 * 1024));
+        assertEquals(1024 * 1024, CryptoCipher.checksumBufferBytes(4L * 1024 * 1024 * 1024));
+        assertEquals(5 * 1024 * 1024, CryptoCipher.checksumBufferBytes(8L * 1024 * 1024 * 1024));
+        assertEquals(5 * 1024 * 1024, CryptoCipher.checksumBufferBytes(0));
+    }
+
+    @Test
+    public void copyBufferStaysSmallOnLowRamAndFullOnFlagship() {
+        assertEquals(64 * 1024, CryptoCipher.copyBufferBytes(3L * 1024 * 1024 * 1024));
+        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(4L * 1024 * 1024 * 1024));
+        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(0));
+    }
 }

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3645,6 +3645,29 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void getMissingBundleFilesTreatsLegacyBrotliCacheNameAsReusable() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-br-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-br-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-br-cache").toFile();
+        Files.createDirectories(filesDir.toPath().resolve("public"));
+        final File downloads = new File(cacheDir, "capgo_downloads");
+        assertTrue(downloads.mkdirs());
+        final String hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        Files.write(new File(downloads, hash + "_app.js.br").toPath(), "legacy-brotli-cache".getBytes(StandardCharsets.UTF_8));
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "app.js.br");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
+        assertEquals(0, missing.length());
+    }
+
+    @Test
     public void testPendingStatsSurviveNewUpdaterInstance() throws Exception {
         final Path tempDir = Files.createTempDirectory("capgo-pending-stats");
         final File queueFile = tempDir.resolve("capgo_pending_stats.json").toFile();

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3622,6 +3622,29 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void getMissingBundleFilesDoesNotTrustCrc32CacheHash() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-crc-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-crc-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-crc-cache").toFile();
+        Files.createDirectories(filesDir.toPath().resolve("public"));
+        final File downloads = new File(cacheDir, "capgo_downloads");
+        assertTrue(downloads.mkdirs());
+        final String hash = "deadbeef";
+        Files.write(new File(downloads, hash + "_app.js").toPath(), "payload".getBytes(StandardCharsets.UTF_8));
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "app.js");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
+        assertEquals(1, missing.length());
+    }
+
+    @Test
     public void testPendingStatsSurviveNewUpdaterInstance() throws Exception {
         final Path tempDir = Files.createTempDirectory("capgo-pending-stats");
         final File queueFile = tempDir.resolve("capgo_pending_stats.json").toFile();

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3716,7 +3716,7 @@ public class CapacitorUpdaterUnitTest {
         byte[] wrapped = new byte[] { 0x0b, 0x02, (byte) 0x80, 'h', 'e', 'l', 'l', 'o', 0x03 };
         Files.write(wrappedIn.toPath(), wrapped);
         DownloadService.decompressBrotli(wrappedIn, wrappedOut, "hello.br");
-        assertEquals("hello", Files.readString(wrappedOut.toPath()));
+        assertEquals("hello", new String(Files.readAllBytes(wrappedOut.toPath()), StandardCharsets.UTF_8));
 
         File realIn = dir.resolve("payload.br").toFile();
         File realOut = dir.resolve("payload.txt").toFile();
@@ -3726,7 +3726,7 @@ public class CapacitorUpdaterUnitTest {
         );
         DownloadService.decompressBrotli(realIn, realOut, "payload.br");
         String expected = "Capgo stream brotli test payload. ".repeat(20);
-        assertEquals(expected, Files.readString(realOut.toPath()));
+        assertEquals(expected, new String(Files.readAllBytes(realOut.toPath()), StandardCharsets.UTF_8));
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3535,7 +3535,7 @@ public class CapacitorUpdaterUnitTest {
         Files.createDirectories(filesDir.toPath().resolve("public"));
         final File downloads = new File(cacheDir, "capgo_downloads");
         assertTrue(downloads.mkdirs());
-        final String hash = "abc123cachedhash";
+        final String hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         // Content does not need to match the hash: the filename is the trust source
         // (checksum was verified when the cache entry was written).
         Files.write(new File(downloads, hash + "_app.js").toPath(), "not-the-hashed-bytes".getBytes(StandardCharsets.UTF_8));
@@ -3560,7 +3560,7 @@ public class CapacitorUpdaterUnitTest {
         Files.createDirectories(filesDir.toPath().resolve("public"));
         final File downloads = new File(cacheDir, "capgo_downloads");
         assertTrue(downloads.mkdirs());
-        final String hash = "abc123emptyhash";
+        final String hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         Files.write(new File(downloads, hash + "_app.js").toPath(), new byte[0]);
 
         final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
@@ -3573,6 +3573,52 @@ public class CapacitorUpdaterUnitTest {
         final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
         assertEquals(1, missing.length());
         assertEquals("app.js", missing.getJSONObject(0).getString("file_name"));
+    }
+
+    @Test
+    public void getMissingBundleFilesReusesEmptyFileForEmptySha256() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-empty-sha-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-empty-sha-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-empty-sha-cache").toFile();
+        Files.createDirectories(filesDir.toPath().resolve("public"));
+        final File downloads = new File(cacheDir, "capgo_downloads");
+        assertTrue(downloads.mkdirs());
+        final String hash = CapgoUpdater.EMPTY_SHA256;
+        Files.write(new File(downloads, hash + "_empty.txt").toPath(), new byte[0]);
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "empty.txt");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
+        assertEquals(0, missing.length());
+    }
+
+    @Test
+    public void getMissingBundleFilesRejectsUnsafeCacheHash() throws Exception {
+        CryptoCipher.setLogger(mock(Logger.class));
+        final Path docsDir = Files.createTempDirectory("capgo-missing-unsafe-docs");
+        final File filesDir = Files.createTempDirectory("capgo-missing-unsafe-files").toFile();
+        final File cacheDir = Files.createTempDirectory("capgo-missing-unsafe-cache").toFile();
+        Files.createDirectories(filesDir.toPath().resolve("public"));
+        final File downloads = new File(cacheDir, "capgo_downloads");
+        assertTrue(downloads.mkdirs());
+        final String hash = "../evil";
+        Files.write(new File(downloads, hash + "_app.js").toPath(), "payload".getBytes(StandardCharsets.UTF_8));
+
+        final CapgoUpdater updater = newDeltaCacheUpdater(docsDir, filesDir, cacheDir);
+        final JSONArray manifest = new JSONArray();
+        final JSONObject entry = new JSONObject();
+        entry.put("file_name", "app.js");
+        entry.put("file_hash", hash);
+        manifest.put(entry);
+
+        final JSONArray missing = updater.getMissingBundleFiles(manifest, "");
+        assertEquals(1, missing.length());
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3693,6 +3693,7 @@ public class CapacitorUpdaterUnitTest {
     public void checksumBufferStaysSmallOnLowRamAndFullOnFlagship() {
         assertEquals(64 * 1024, CryptoCipher.checksumBufferBytes(3L * 1024 * 1024 * 1024));
         assertEquals(1024 * 1024, CryptoCipher.checksumBufferBytes(4L * 1024 * 1024 * 1024));
+        assertEquals(1024 * 1024, CryptoCipher.checksumBufferBytes(6L * 1024 * 1024 * 1024));
         assertEquals(5 * 1024 * 1024, CryptoCipher.checksumBufferBytes(8L * 1024 * 1024 * 1024));
         assertEquals(5 * 1024 * 1024, CryptoCipher.checksumBufferBytes(0));
     }
@@ -3701,6 +3702,8 @@ public class CapacitorUpdaterUnitTest {
     public void copyBufferStaysSmallOnLowRamAndFullOnFlagship() {
         assertEquals(64 * 1024, CryptoCipher.copyBufferBytes(3L * 1024 * 1024 * 1024));
         assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(4L * 1024 * 1024 * 1024));
+        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(6L * 1024 * 1024 * 1024));
+        assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(8L * 1024 * 1024 * 1024));
         assertEquals(1024 * 1024, CryptoCipher.copyBufferBytes(0));
     }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/AES.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/AES.swift
@@ -154,7 +154,7 @@ public struct AES128Key {
                 throw NSError(domain: "AESDecryptError", code: Int(status), userInfo: nil)
             }
             if moved > 0 {
-                output.write(Data(outBuf[0..<moved]))
+                try output.write(contentsOf: Data(outBuf[0..<moved]))
             }
         }
 
@@ -167,7 +167,7 @@ public struct AES128Key {
             throw NSError(domain: "AESDecryptError", code: Int(finalStatus), userInfo: nil)
         }
         if moved > 0 {
-            output.write(Data(outBuf[0..<moved]))
+            try output.write(contentsOf: Data(outBuf[0..<moved]))
         }
         try output.close()
         try input.close()

--- a/ios/Sources/CapacitorUpdaterPlugin/AES.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/AES.swift
@@ -83,4 +83,98 @@ public struct AES128Key {
             return nil
         }
     }
+
+    /// AES-CBC file-to-file. Never holds the whole ciphertext in RAM.
+    func decrypt(from source: URL, to destination: URL) throws {
+        var cryptor: CCCryptorRef?
+        let createStatus: CCCryptorStatus = aes128Key.withUnsafeBytes { keyBytes in
+            initVector.withUnsafeBytes { ivBytes in
+                guard let keyPtr = keyBytes.baseAddress, let ivPtr = ivBytes.baseAddress else {
+                    return CCCryptorStatus(kCCParamError)
+                }
+                return CCCryptorCreate(
+                    CCOperation(kCCDecrypt),
+                    AESConstants.aesAlgorithm,
+                    AESConstants.aesOptions,
+                    keyPtr,
+                    keyBytes.count,
+                    ivPtr,
+                    &cryptor
+                )
+            }
+        }
+        guard createStatus == kCCSuccess, let cryptor else {
+            logger.error("Failed to create AES cryptor")
+            throw NSError(domain: "AESDecryptError", code: Int(createStatus), userInfo: nil)
+        }
+        defer {
+            CCCryptorRelease(cryptor)
+        }
+
+        let input = try FileHandle(forReadingFrom: source)
+        defer {
+            try? input.close()
+        }
+
+        let tempURL = destination.deletingLastPathComponent().appendingPathComponent("capgo-aes-\(UUID().uuidString).tmp")
+        let fileManager = FileManager.default
+        fileManager.createFile(atPath: tempURL.path, contents: nil)
+        let output = try FileHandle(forWritingTo: tempURL)
+        defer {
+            try? output.close()
+            try? fileManager.removeItem(at: tempURL)
+        }
+
+        let bufferSize = CryptoCipher.ioBufferBytes()
+        let outBufSize = bufferSize + kCCBlockSizeAES128
+        var outBuf = [UInt8](repeating: 0, count: outBufSize)
+
+        while true {
+            let chunk = try autoreleasepool { () -> Data in
+                try input.read(upToCount: bufferSize) ?? Data()
+            }
+            if chunk.isEmpty {
+                break
+            }
+            var moved: size_t = 0
+            let status: CCCryptorStatus = outBuf.withUnsafeMutableBytes { outRaw in
+                chunk.withUnsafeBytes { inRaw in
+                    CCCryptorUpdate(
+                        cryptor,
+                        inRaw.baseAddress,
+                        chunk.count,
+                        outRaw.baseAddress,
+                        outBufSize,
+                        &moved
+                    )
+                }
+            }
+            guard status == kCCSuccess else {
+                logger.error("AES stream update failed")
+                throw NSError(domain: "AESDecryptError", code: Int(status), userInfo: nil)
+            }
+            if moved > 0 {
+                output.write(Data(outBuf[0..<moved]))
+            }
+        }
+
+        var moved: size_t = 0
+        let finalStatus: CCCryptorStatus = outBuf.withUnsafeMutableBytes { outRaw in
+            CCCryptorFinal(cryptor, outRaw.baseAddress, outBufSize, &moved)
+        }
+        guard finalStatus == kCCSuccess else {
+            logger.error("AES stream finalize failed")
+            throw NSError(domain: "AESDecryptError", code: Int(finalStatus), userInfo: nil)
+        }
+        if moved > 0 {
+            output.write(Data(outBuf[0..<moved]))
+        }
+        try output.close()
+        try input.close()
+
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.moveItem(at: tempURL, to: destination)
+    }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/AES.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/AES.swift
@@ -172,9 +172,13 @@ public struct AES128Key {
         try output.close()
         try input.close()
 
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
+        do {
+            _ = try fileManager.replaceItemAt(destination, withItemAt: tempURL)
+        } catch {
+            if fileManager.fileExists(atPath: destination.path) {
+                throw error
+            }
+            try fileManager.moveItem(at: tempURL, to: destination)
         }
-        try fileManager.moveItem(at: tempURL, to: destination)
     }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/AES.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/AES.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CommonCrypto
 import CryptoKit
+import Darwin
 
 ///
 /// Constants
@@ -111,9 +112,12 @@ public struct AES128Key {
             CCCryptorRelease(cryptor)
         }
 
-        let input = try FileHandle(forReadingFrom: source)
+        guard let input = InputStream(url: source) else {
+            throw NSError(domain: "AESDecryptError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open AES source"])
+        }
+        input.open()
         defer {
-            try? input.close()
+            input.close()
         }
 
         let tempURL = destination.deletingLastPathComponent().appendingPathComponent("capgo-aes-\(UUID().uuidString).tmp")
@@ -127,22 +131,27 @@ public struct AES128Key {
 
         let bufferSize = CryptoCipher.ioBufferBytes()
         let outBufSize = bufferSize + kCCBlockSizeAES128
+        var inBuf = [UInt8](repeating: 0, count: bufferSize)
         var outBuf = [UInt8](repeating: 0, count: outBufSize)
+        let outFd = output.fileDescriptor
 
         while true {
-            let chunk = try autoreleasepool { () -> Data in
-                try input.read(upToCount: bufferSize) ?? Data()
+            let n = inBuf.withUnsafeMutableBufferPointer { ptr in
+                input.read(ptr.baseAddress!, maxLength: ptr.count)
             }
-            if chunk.isEmpty {
+            if n == 0 {
                 break
             }
+            if n < 0 {
+                throw input.streamError ?? NSError(domain: "AESDecryptError", code: 2, userInfo: [NSLocalizedDescriptionKey: "AES stream read failed"])
+            }
             var moved: size_t = 0
-            let status: CCCryptorStatus = outBuf.withUnsafeMutableBytes { outRaw in
-                chunk.withUnsafeBytes { inRaw in
+            let status: CCCryptorStatus = inBuf.withUnsafeBufferPointer { inRaw in
+                outBuf.withUnsafeMutableBytes { outRaw in
                     CCCryptorUpdate(
                         cryptor,
                         inRaw.baseAddress,
-                        chunk.count,
+                        n,
                         outRaw.baseAddress,
                         outBufSize,
                         &moved
@@ -154,7 +163,7 @@ public struct AES128Key {
                 throw NSError(domain: "AESDecryptError", code: Int(status), userInfo: nil)
             }
             if moved > 0 {
-                try output.write(contentsOf: Data(outBuf[0..<moved]))
+                try Self.writeAll(fd: outFd, buffer: &outBuf, count: moved)
             }
         }
 
@@ -167,10 +176,9 @@ public struct AES128Key {
             throw NSError(domain: "AESDecryptError", code: Int(finalStatus), userInfo: nil)
         }
         if moved > 0 {
-            try output.write(contentsOf: Data(outBuf[0..<moved]))
+            try Self.writeAll(fd: outFd, buffer: &outBuf, count: moved)
         }
         try output.close()
-        try input.close()
 
         do {
             _ = try fileManager.replaceItemAt(destination, withItemAt: tempURL)
@@ -179,6 +187,19 @@ public struct AES128Key {
                 throw error
             }
             try fileManager.moveItem(at: tempURL, to: destination)
+        }
+    }
+
+    private static func writeAll(fd: Int32, buffer: inout [UInt8], count: Int) throws {
+        var offset = 0
+        while offset < count {
+            let written = buffer.withUnsafeBufferPointer { ptr -> Int in
+                Darwin.write(fd, ptr.baseAddress!.advanced(by: offset), count - offset)
+            }
+            if written <= 0 {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [NSLocalizedDescriptionKey: "AES stream write failed"])
+            }
+            offset += written
         }
     }
 }

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -965,7 +965,7 @@ import UIKit
             }
 
             do {
-                try fileManager.copyItem(at: fileURL, to: cacheFile)
+                try copyItemAtomically(from: fileURL, to: cacheFile)
             } catch {
                 logger.debug("Delta cache copy failed: \(fileURL.path)")
             }
@@ -1658,10 +1658,21 @@ import UIKit
             try? fileManager.removeItem(at: tempURL)
         }
         try fileManager.copyItem(at: source, to: tempURL)
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
+        try replaceItemAtomically(at: destination, withItemAt: tempURL)
+    }
+
+    /// One-step replace when dest exists, move when it does not. Avoids the
+    /// fileExists/removeItem race that can fail a verified install.
+    private func replaceItemAtomically(at destination: URL, withItemAt tempURL: URL) throws {
+        let fileManager = FileManager.default
+        do {
+            _ = try fileManager.replaceItemAt(destination, withItemAt: tempURL)
+        } catch {
+            if fileManager.fileExists(atPath: destination.path) {
+                throw error
+            }
+            try fileManager.moveItem(at: tempURL, to: destination)
         }
-        try fileManager.moveItem(at: tempURL, to: destination)
     }
 
     /// Atomically try to copy a file from cache - returns true if successful, false if file doesn't exist or copy failed
@@ -1753,10 +1764,7 @@ import UIKit
             remaining -= UInt64(readCount)
         }
         try output.close()
-        if fileManager.fileExists(atPath: dest.path) {
-            try fileManager.removeItem(at: dest)
-        }
-        try fileManager.moveItem(at: tempURL, to: dest)
+        try replaceItemAtomically(at: dest, withItemAt: tempURL)
     }
 
     private func streamBrotliDecode(from handle: FileHandle, to dest: URL, fileName: String) throws {
@@ -1801,7 +1809,7 @@ import UIKit
                         let chunk = try handle.read(upToCount: chunkSize) ?? Data()
                         if chunk.isEmpty {
                             inputExhausted = true
-                            flags = COMPRESSION_STREAM_FINALIZE.rawValue
+                            flags = Int32(bitPattern: COMPRESSION_STREAM_FINALIZE.rawValue)
                         } else {
                             chunk.copyBytes(to: inBase, count: chunk.count)
                             streamPointer.pointee.src_ptr = UnsafePointer(inBase)
@@ -1835,10 +1843,7 @@ import UIKit
         }
 
         try output.close()
-        if fileManager.fileExists(atPath: dest.path) {
-            try fileManager.removeItem(at: dest)
-        }
-        try fileManager.moveItem(at: tempURL, to: dest)
+        try replaceItemAtomically(at: dest, withItemAt: tempURL)
     }
 
     public func download(url: URL, version: String, sessionKey: String, link: String? = nil, comment: String? = nil) throws -> BundleInfo {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -1630,8 +1630,6 @@ import UIKit
     /// Atomically try to copy a file from cache - returns true if successful, false if file doesn't exist or copy failed
     /// This handles the race condition where OS can delete cache files between exists() check and copy
     private func tryCopyFromCache(from source: URL, to destination: URL) -> Bool {
-        let fileManager = FileManager.default
-
         // First quick check - if file doesn't exist or was truncated, don't bother
         guard isReusableCacheFile(source) else {
             return false
@@ -1639,8 +1637,6 @@ import UIKit
 
         // Hash is in the cache file name and was verified when written.
         // Re-hashing here would re-read every reused file on low-RAM devices.
-
-        // Try to copy - if it fails (file deleted by OS between check and copy), return false
         do {
             try copyItemReplacing(from: source, to: destination)
             return true

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -27,8 +27,6 @@ import UIKit
     private let TEMP_UNZIP_PREFIX: String = "capgo_unzip_"
     /// Match URLSession per-host limit so 64 workers actually fetch in parallel.
     private static let manifestMaxConcurrentFiles = 64
-    /// Decrypt/brotli still load whole files. Bound that, not HTTP.
-    private static let manifestDecodeSemaphore = DispatchSemaphore(value: 4)
     private static let emptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     private let deletePaceSeconds: TimeInterval = 0.075
     private let deleteLock = NSLock()
@@ -1595,37 +1593,25 @@ import UIKit
         }
 
         do {
-            let needsDecode = isBrotli || (!self.publicKey.isEmpty && !sessionKey.isEmpty)
-            if needsDecode {
-                Self.manifestDecodeSemaphore.wait()
+            // Decrypt in place when a session key is present — streamed, not a whole-file copy.
+            if !self.publicKey.isEmpty && !sessionKey.isEmpty {
+                do {
+                    try CryptoCipher.decryptFile(filePath: downloadedFileURL, publicKey: self.publicKey, sessionKey: sessionKey, version: version)
+                } catch {
+                    self.sendStats(action: "decrypt_fail", versionName: version)
+                    throw error
+                }
             }
-            do {
-                defer {
-                    if needsDecode {
-                        Self.manifestDecodeSemaphore.signal()
-                    }
-                }
 
-                // Decrypt in place when a session key is present — avoids a second in-memory copy.
-                if !self.publicKey.isEmpty && !sessionKey.isEmpty {
-                    do {
-                        try CryptoCipher.decryptFile(filePath: downloadedFileURL, publicKey: self.publicKey, sessionKey: sessionKey, version: version)
-                    } catch {
-                        self.sendStats(action: "decrypt_fail", versionName: version)
-                        throw error
-                    }
+            if isBrotli {
+                do {
+                    try decompressBrotli(from: downloadedFileURL, to: destFilePath, fileName: fileName)
+                } catch {
+                    self.sendStats(action: "download_manifest_brotli_fail", versionName: "\(version):\(destFileName)")
+                    throw error
                 }
-
-                if isBrotli {
-                    let compressedData = try Data(contentsOf: downloadedFileURL)
-                    guard let decompressedData = self.decompressBrotli(data: compressedData, fileName: fileName) else {
-                        self.sendStats(action: "download_manifest_brotli_fail", versionName: "\(version):\(destFileName)")
-                        throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to decompress Brotli data for file \(fileName) at url \(downloadUrl)"])
-                    }
-                    try writeDataAtomically(decompressedData, to: destFilePath)
-                } else {
-                    try copyItemReplacing(from: downloadedFileURL, to: destFilePath)
-                }
+            } else {
+                try copyItemReplacing(from: downloadedFileURL, to: destFilePath)
             }
 
             // Always verify checksum when file_hash is present
@@ -1650,11 +1636,6 @@ import UIKit
             self.logger.debug("Bundle: \(bundleId), File: \(fileName), Error: \(error.localizedDescription)")
             throw error
         }
-    }
-
-    /// Atomically write data to a file, replacing any existing file at the destination.
-    private func writeDataAtomically(_ data: Data, to destination: URL) throws {
-        try data.write(to: destination, options: .atomic)
     }
 
     /// Copy a file to the destination, replacing any existing file.
@@ -1703,120 +1684,161 @@ import UIKit
         }
     }
 
-    private func decompressBrotli(data: Data, fileName: String) -> Data? {
-        // Handle empty files
-        if data.count == 0 {
-            return data
+    /// Stream Brotli from disk to disk. Peek only the 3-byte header and last byte
+    /// for the empty/wrapper special cases; never load the whole file.
+    func decompressBrotli(from source: URL, to dest: URL, fileName: String) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+        let length = (try fileManager.attributesOfItem(atPath: source.path)[.size] as? NSNumber)?.uint64Value ?? 0
+        if length == 0 {
+            try Data().write(to: dest, options: .atomic)
+            return
         }
 
-        // Handle the special EMPTY_BROTLI_STREAM case
-        if data.count == 3 && data[0] == 0x1B && data[1] == 0x00 && data[2] == 0x06 {
-            return Data()
+        let handle = try FileHandle(forReadingFrom: source)
+        defer {
+            try? handle.close()
         }
 
-        // For small files, check if it's a minimal Brotli wrapper
-        if data.count > 3 {
-            // Handle our minimal wrapper pattern
-            if data[0] == 0x1B && data[1] == 0x00 && data[2] == 0x06 && data.last == 0x03 {
-                let range = data.index(data.startIndex, offsetBy: 3)..<data.index(data.endIndex, offsetBy: -1)
-                return data[range]
+        let head = try handle.read(upToCount: 3) ?? Data()
+        var last: UInt8 = 0
+        if length >= 1 {
+            try handle.seek(toOffset: length - 1)
+            last = try handle.read(upToCount: 1)?.first ?? 0
+        }
+
+        if length == 3 && head.count == 3 && head[0] == 0x1B && head[1] == 0x00 && head[2] == 0x06 {
+            try Data().write(to: dest, options: .atomic)
+            return
+        }
+
+        if length > 3 && head.count == 3 && last == 0x03 {
+            let isEmptyWrapper = head[0] == 0x1B && head[1] == 0x00 && head[2] == 0x06
+            let isQualityZeroWrapper = head[0] == 0x0b && head[1] == 0x02 && head[2] == 0x80
+            if isEmptyWrapper || isQualityZeroWrapper {
+                try handle.seek(toOffset: 3)
+                try streamCopy(from: handle, count: length - 4, to: dest)
+                return
             }
-
-            // Handle brotli.compress minimal wrapper (quality 0)
-            if data[0] == 0x0b && data[1] == 0x02 && data[2] == 0x80 && data.last == 0x03 {
-                let range = data.index(data.startIndex, offsetBy: 3)..<data.index(data.endIndex, offsetBy: -1)
-                return data[range]
-            }
         }
 
-        // For all other cases, try standard decompression
-        let outputBufferSize = 65536
-        var outputBuffer = [UInt8](repeating: 0, count: outputBufferSize)
-        var decompressedData = Data()
+        try handle.seek(toOffset: 0)
+        try streamBrotliDecode(from: handle, to: dest, fileName: fileName)
+    }
+
+    private func streamCopy(from handle: FileHandle, count: UInt64, to dest: URL) throws {
+        let fileManager = FileManager.default
+        let tempURL = dest.deletingLastPathComponent().appendingPathComponent("capgo-br-\(UUID().uuidString).tmp")
+        fileManager.createFile(atPath: tempURL.path, contents: nil)
+        let output = try FileHandle(forWritingTo: tempURL)
+        defer {
+            try? output.close()
+            try? fileManager.removeItem(at: tempURL)
+        }
+
+        var remaining = count
+        let chunkSize = CryptoCipher.ioBufferBytes()
+        while remaining > 0 {
+            let readCount: Int = try autoreleasepool {
+                let toRead = Int(min(UInt64(chunkSize), remaining))
+                let chunk = try handle.read(upToCount: toRead) ?? Data()
+                if !chunk.isEmpty {
+                    output.write(chunk)
+                }
+                return chunk.count
+            }
+            if readCount == 0 {
+                break
+            }
+            remaining -= UInt64(readCount)
+        }
+        try output.close()
+        if fileManager.fileExists(atPath: dest.path) {
+            try fileManager.removeItem(at: dest)
+        }
+        try fileManager.moveItem(at: tempURL, to: dest)
+    }
+
+    private func streamBrotliDecode(from handle: FileHandle, to dest: URL, fileName: String) throws {
+        let fileManager = FileManager.default
+        let tempURL = dest.deletingLastPathComponent().appendingPathComponent("capgo-br-\(UUID().uuidString).tmp")
+        fileManager.createFile(atPath: tempURL.path, contents: nil)
+        let output = try FileHandle(forWritingTo: tempURL)
+        defer {
+            try? output.close()
+            try? fileManager.removeItem(at: tempURL)
+        }
+
+        let chunkSize = max(CryptoCipher.ioBufferBytes(), 65536)
+        var inputBuffer = [UInt8](repeating: 0, count: chunkSize)
+        var outputBuffer = [UInt8](repeating: 0, count: chunkSize)
 
         let streamPointer = UnsafeMutablePointer<compression_stream>.allocate(capacity: 1)
         var status = compression_stream_init(streamPointer, COMPRESSION_STREAM_DECODE, COMPRESSION_BROTLI)
-
         guard status != COMPRESSION_STATUS_ERROR else {
             logger.error("Failed to initialize Brotli stream")
             logger.debug("File: \(fileName), Status: \(status)")
-            return nil
+            throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to initialize Brotli stream for \(fileName)"])
         }
-
         defer {
             compression_stream_destroy(streamPointer)
             streamPointer.deallocate()
         }
 
-        streamPointer.pointee.src_size = 0
-        streamPointer.pointee.dst_ptr = UnsafeMutablePointer<UInt8>(&outputBuffer)
-        streamPointer.pointee.dst_size = outputBufferSize
+        try inputBuffer.withUnsafeMutableBufferPointer { inBuf in
+            try outputBuffer.withUnsafeMutableBufferPointer { outBuf in
+                guard let inBase = inBuf.baseAddress, let outBase = outBuf.baseAddress else {
+                    throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to get buffer address for \(fileName)"])
+                }
+                streamPointer.pointee.src_size = 0
+                streamPointer.pointee.dst_ptr = outBase
+                streamPointer.pointee.dst_size = chunkSize
 
-        let input = data
+                var flags: Int32 = 0
+                var inputExhausted = false
+                while true {
+                    if streamPointer.pointee.src_size == 0 && !inputExhausted {
+                        let chunk = try handle.read(upToCount: chunkSize) ?? Data()
+                        if chunk.isEmpty {
+                            inputExhausted = true
+                            flags = COMPRESSION_STREAM_FINALIZE
+                        } else {
+                            chunk.copyBytes(to: inBase, count: chunk.count)
+                            streamPointer.pointee.src_ptr = UnsafePointer(inBase)
+                            streamPointer.pointee.src_size = chunk.count
+                        }
+                    }
 
-        while true {
-            if streamPointer.pointee.src_size == 0 {
-                streamPointer.pointee.src_size = input.count
-                input.withUnsafeBytes { rawBufferPointer in
-                    if let baseAddress = rawBufferPointer.baseAddress {
-                        streamPointer.pointee.src_ptr = baseAddress.assumingMemoryBound(to: UInt8.self)
-                    } else {
-                        logger.error("Failed to get base address for Brotli decompression")
+                    status = compression_stream_process(streamPointer, flags)
+                    let have = chunkSize - streamPointer.pointee.dst_size
+                    if have > 0 {
+                        output.write(Data(bytes: outBase, count: have))
+                    }
+                    streamPointer.pointee.dst_ptr = outBase
+                    streamPointer.pointee.dst_size = chunkSize
+
+                    if status == COMPRESSION_STATUS_END {
+                        break
+                    }
+                    if status == COMPRESSION_STATUS_ERROR {
+                        logger.error("Brotli process failed")
+                        logger.debug("File: \(fileName), Status: \(status)")
+                        throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to decompress Brotli data for file \(fileName)"])
+                    }
+                    if inputExhausted && streamPointer.pointee.src_size == 0 && have == 0 {
+                        logger.error("Brotli decompression stalled")
                         logger.debug("File: \(fileName)")
-                        status = COMPRESSION_STATUS_ERROR
-                        return
+                        throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to decompress Brotli data for file \(fileName)"])
                     }
                 }
-            }
-
-            if status == COMPRESSION_STATUS_ERROR {
-                let maxBytes = min(32, data.count)
-                let hexDump = data.prefix(maxBytes).map { String(format: "%02x", $0) }.joined(separator: " ")
-                logger.error("Brotli decompression failed")
-                logger.debug("File: \(fileName), First \(maxBytes) bytes: \(hexDump)")
-                break
-            }
-
-            status = compression_stream_process(streamPointer, 0)
-
-            let have = outputBufferSize - streamPointer.pointee.dst_size
-            if have > 0 {
-                decompressedData.append(outputBuffer, count: have)
-            }
-
-            if status == COMPRESSION_STATUS_END {
-                break
-            } else if status == COMPRESSION_STATUS_ERROR {
-                logger.error("Brotli process failed")
-                logger.debug("File: \(fileName), Status: \(status)")
-                if let text = String(data: data, encoding: .utf8) {
-                    let asciiCount = text.unicodeScalars.filter { $0.isASCII }.count
-                    let totalCount = text.unicodeScalars.count
-                    if totalCount > 0 && Double(asciiCount) / Double(totalCount) >= 0.8 {
-                        logger.debug("Input appears to be plain text: \(text)")
-                    }
-                }
-
-                let maxBytes = min(32, data.count)
-                let hexDump = data.prefix(maxBytes).map { String(format: "%02x", $0) }.joined(separator: " ")
-                logger.debug("Raw data: \(hexDump)")
-
-                return nil
-            }
-
-            if streamPointer.pointee.dst_size == 0 {
-                streamPointer.pointee.dst_ptr = UnsafeMutablePointer<UInt8>(&outputBuffer)
-                streamPointer.pointee.dst_size = outputBufferSize
-            }
-
-            if input.count == 0 {
-                logger.error("Zero input size for Brotli decompression")
-                logger.debug("File: \(fileName)")
-                break
             }
         }
 
-        return status == COMPRESSION_STATUS_END ? decompressedData : nil
+        try output.close()
+        if fileManager.fileExists(atPath: dest.path) {
+            try fileManager.removeItem(at: dest)
+        }
+        try fileManager.moveItem(at: tempURL, to: dest)
     }
 
     public func download(url: URL, version: String, sessionKey: String, link: String? = nil, comment: String? = nil) throws -> BundleInfo {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -315,7 +315,7 @@ import UIKit
             defer {
                 try? input.close()
             }
-            let chunkSize = 64 * 1024
+            let chunkSize = CryptoCipher.copyBufferBytes()
             while true {
                 let done: Bool = try autoreleasepool {
                     let chunk = try input.read(upToCount: chunkSize) ?? Data()

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -27,6 +27,7 @@ import UIKit
     private let TEMP_UNZIP_PREFIX: String = "capgo_unzip_"
     /// Cap concurrent manifest file work. 32–64 OOMs low-RAM devices.
     private static let manifestMaxConcurrentFiles = 4
+    private static let emptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     private let deletePaceSeconds: TimeInterval = 0.075
     private let deleteLock = NSLock()
 
@@ -1194,29 +1195,49 @@ import UIKit
         let fileNameWithoutPath = (fileName as NSString).lastPathComponent
         let isBrotli = fileName.hasSuffix(".br")
         let cacheBaseName = isBrotli ? String(fileNameWithoutPath.dropLast(3)) : fileNameWithoutPath
-        let cacheFilePath = cacheFolder.appendingPathComponent("\(fileHash)_\(cacheBaseName)")
-        // Cache files are named `{hash}_{filename}` and were checksum-verified
-        // when written. Re-hashing every hit re-reads the whole bundle and
-        // OOMs/janks low-RAM devices during getMissing / delta apply.
-        if isReusableCacheFile(cacheFilePath) {
-            return true
-        }
-
-        if isBrotli {
-            let legacyCacheFilePath = cacheFolder.appendingPathComponent("\(fileHash)_\(fileNameWithoutPath)")
-            if isReusableCacheFile(legacyCacheFilePath) {
+        if Self.isSafeCacheHash(fileHash) {
+            let cacheFilePath = cacheFolder.appendingPathComponent("\(fileHash)_\(cacheBaseName)")
+            // Cache files are named `{hash}_{filename}` and were checksum-verified
+            // when written. Re-hashing every hit re-reads the whole bundle and
+            // OOMs/janks low-RAM devices during getMissing / delta apply.
+            if isReusableCacheFile(cacheFilePath, expectedHash: fileHash) {
                 return true
+            }
+
+            if isBrotli {
+                let legacyCacheFilePath = cacheFolder.appendingPathComponent("\(fileHash)_\(fileNameWithoutPath)")
+                if isReusableCacheFile(legacyCacheFilePath, expectedHash: fileHash) {
+                    return true
+                }
             }
         }
 
         return false
     }
 
-    /// Hash-named cache files were verified when written. Existence + size
-    /// is enough; re-hashing re-reads every reused file on low-RAM devices.
-    private func isReusableCacheFile(_ url: URL) -> Bool {
-        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-        return size > 0
+    /// Hash-named cache files were verified when written. Existence is enough
+    /// for non-empty files; empty files are reused only for the empty SHA-256.
+    private func isReusableCacheFile(_ url: URL, expectedHash: String) -> Bool {
+        guard Self.isSafeCacheHash(expectedHash) else {
+            return false
+        }
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
+        if size > 0 {
+            return true
+        }
+        return size == 0 && expectedHash.lowercased() == Self.emptySha256
+    }
+
+    static func isSafeCacheHash(_ hash: String) -> Bool {
+        let count = hash.count
+        guard count == 64 || count == 8 else {
+            return false
+        }
+        return hash.unicodeScalars.allSatisfy { scalar in
+            (0x30...0x39).contains(scalar.value) ||
+                (0x41...0x46).contains(scalar.value) ||
+                (0x61...0x66).contains(scalar.value)
+        }
     }
 
     public func getMissingBundleFiles(manifest: [ManifestEntry], sessionKey: String) -> [ManifestEntry] {
@@ -1400,8 +1421,12 @@ import UIKit
             let fileNameWithoutPath = (fileName as NSString).lastPathComponent
             let isBrotli = fileName.hasSuffix(".br")
             let cacheBaseName = isBrotli ? String(fileNameWithoutPath.dropLast(3)) : fileNameWithoutPath
-            let cacheFilePath = cacheFolder.appendingPathComponent("\(finalFileHash)_\(cacheBaseName)")
-            let legacyCacheFilePath: URL? = isBrotli ? cacheFolder.appendingPathComponent("\(finalFileHash)_\(fileNameWithoutPath)") : nil
+            let cacheFilePath: URL? = Self.isSafeCacheHash(finalFileHash)
+                ? cacheFolder.appendingPathComponent("\(finalFileHash)_\(cacheBaseName)")
+                : nil
+            let legacyCacheFilePath: URL? = isBrotli && cacheFilePath != nil
+                ? cacheFolder.appendingPathComponent("\(finalFileHash)_\(fileNameWithoutPath)")
+                : nil
 
             let destFileName = isBrotli ? String(fileName.dropLast(3)) : fileName
             let destFilePath: URL
@@ -1436,8 +1461,8 @@ import UIKit
                     }
                     // Try cache
                     else if
-                        self.tryCopyFromCache(from: cacheFilePath, to: destFilePath) ||
-                            (legacyCacheFilePath != nil && self.tryCopyFromCache(from: legacyCacheFilePath!, to: destFilePath)) {
+                        (cacheFilePath != nil && self.tryCopyFromCache(from: cacheFilePath!, to: destFilePath, expectedHash: finalFileHash)) ||
+                            (legacyCacheFilePath != nil && self.tryCopyFromCache(from: legacyCacheFilePath!, to: destFilePath, expectedHash: finalFileHash)) {
                         self.logger.info("downloadManifest \(fileName) copy from cache \(id)")
                     }
                     // Download
@@ -1507,7 +1532,7 @@ import UIKit
     private func downloadManifestFile(
         downloadUrl: String,
         destFilePath: URL,
-        cacheFilePath: URL,
+        cacheFilePath: URL?,
         fileHash: String,
         fileName: String,
         destFileName: String,
@@ -1533,6 +1558,11 @@ import UIKit
         }
 
         let result = performDownloadRequest(request, label: "downloadManifestFile \(fileName)")
+        defer {
+            if let fileURL = result.fileURL {
+                try? FileManager.default.removeItem(at: fileURL)
+            }
+        }
 
         if result.timedOut {
             self.sendStats(action: "download_manifest_file_fail", versionName: "\(version):\(fileName)")
@@ -1563,9 +1593,6 @@ import UIKit
                 code: 3,
                 userInfo: [NSLocalizedDescriptionKey: "Manifest file response was empty for \(fileName) at url \(downloadUrl)"]
             )
-        }
-        defer {
-            try? FileManager.default.removeItem(at: downloadedFileURL)
         }
 
         do {
@@ -1601,7 +1628,9 @@ import UIKit
             }
 
             // Save to cache (replace stale cache entries from partial or concurrent downloads)
-            try copyItemReplacing(from: destFilePath, to: cacheFilePath)
+            if let cacheFilePath {
+                try copyItemAtomically(from: destFilePath, to: cacheFilePath)
+            }
 
             self.logger.info("Manifest file downloaded and cached")
             self.logger.debug("Bundle: \(bundleId), File: \(fileName), Brotli: \(isBrotli), Encrypted: \(!self.publicKey.isEmpty && !sessionKey.isEmpty)")
@@ -1627,18 +1656,34 @@ import UIKit
         try fileManager.copyItem(at: source, to: destination)
     }
 
+    /// Copy via a unique temp name then rename, so a crash cannot leave a
+    /// non-empty partial file that `isReusableCacheFile` would trust.
+    private func copyItemAtomically(from source: URL, to destination: URL) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+        let tempURL = destination.deletingLastPathComponent().appendingPathComponent("\(destination.lastPathComponent).\(UUID().uuidString).tmp")
+        defer {
+            try? fileManager.removeItem(at: tempURL)
+        }
+        try fileManager.copyItem(at: source, to: tempURL)
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.moveItem(at: tempURL, to: destination)
+    }
+
     /// Atomically try to copy a file from cache - returns true if successful, false if file doesn't exist or copy failed
     /// This handles the race condition where OS can delete cache files between exists() check and copy
-    private func tryCopyFromCache(from source: URL, to destination: URL) -> Bool {
+    private func tryCopyFromCache(from source: URL, to destination: URL, expectedHash: String) -> Bool {
         // First quick check - if file doesn't exist or was truncated, don't bother
-        guard isReusableCacheFile(source) else {
+        guard isReusableCacheFile(source, expectedHash: expectedHash) else {
             return false
         }
 
         // Hash is in the cache file name and was verified when written.
         // Re-hashing here would re-read every reused file on low-RAM devices.
         do {
-            try copyItemReplacing(from: source, to: destination)
+            try copyItemAtomically(from: source, to: destination)
             return true
         } catch {
             // File was deleted between check and copy, or other IO error - caller should download instead

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -27,6 +27,8 @@ import UIKit
     private let TEMP_UNZIP_PREFIX: String = "capgo_unzip_"
     /// Match URLSession per-host limit so 64 workers actually fetch in parallel.
     private static let manifestMaxConcurrentFiles = 64
+    /// Decrypt/brotli still load whole files. Bound that, not HTTP.
+    private static let manifestDecodeSemaphore = DispatchSemaphore(value: 4)
     private static let emptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     private let deletePaceSeconds: TimeInterval = 0.075
     private let deleteLock = NSLock()
@@ -1216,10 +1218,11 @@ import UIKit
         return false
     }
 
-    /// Hash-named cache files were verified when written. Existence is enough
-    /// for non-empty files; empty files are reused only for the empty SHA-256.
+    /// SHA-256 hash-named cache files were verified when written. Existence is
+    /// enough for non-empty files; empty files are reused only for the empty SHA-256.
+    /// CRC32 (8 hex) is too collision-prone to trust without a re-read.
     private func isReusableCacheFile(_ url: URL, expectedHash: String) -> Bool {
-        guard Self.isSafeCacheHash(expectedHash) else {
+        guard Self.isSafeCacheHash(expectedHash), expectedHash.count == 64 else {
             return false
         }
         let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
@@ -1350,8 +1353,6 @@ import UIKit
         self.notifyDownload(id: id, percent: 0, ignoreMultipleOfTen: true)
 
         let totalFiles = manifest.count
-
-        manifestDownloadQueue.maxConcurrentOperationCount = min(Self.manifestMaxConcurrentFiles, max(1, totalFiles))
 
         // Thread-safe counters for concurrent operations
         let completedFiles = AtomicCounter()
@@ -1594,25 +1595,37 @@ import UIKit
         }
 
         do {
-            // Decrypt in place when a session key is present — avoids a second in-memory copy.
-            if !self.publicKey.isEmpty && !sessionKey.isEmpty {
-                do {
-                    try CryptoCipher.decryptFile(filePath: downloadedFileURL, publicKey: self.publicKey, sessionKey: sessionKey, version: version)
-                } catch {
-                    self.sendStats(action: "decrypt_fail", versionName: version)
-                    throw error
-                }
+            let needsDecode = isBrotli || (!self.publicKey.isEmpty && !sessionKey.isEmpty)
+            if needsDecode {
+                Self.manifestDecodeSemaphore.wait()
             }
-
-            if isBrotli {
-                let compressedData = try Data(contentsOf: downloadedFileURL)
-                guard let decompressedData = self.decompressBrotli(data: compressedData, fileName: fileName) else {
-                    self.sendStats(action: "download_manifest_brotli_fail", versionName: "\(version):\(destFileName)")
-                    throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to decompress Brotli data for file \(fileName) at url \(downloadUrl)"])
+            do {
+                defer {
+                    if needsDecode {
+                        Self.manifestDecodeSemaphore.signal()
+                    }
                 }
-                try writeDataAtomically(decompressedData, to: destFilePath)
-            } else {
-                try copyItemReplacing(from: downloadedFileURL, to: destFilePath)
+
+                // Decrypt in place when a session key is present — avoids a second in-memory copy.
+                if !self.publicKey.isEmpty && !sessionKey.isEmpty {
+                    do {
+                        try CryptoCipher.decryptFile(filePath: downloadedFileURL, publicKey: self.publicKey, sessionKey: sessionKey, version: version)
+                    } catch {
+                        self.sendStats(action: "decrypt_fail", versionName: version)
+                        throw error
+                    }
+                }
+
+                if isBrotli {
+                    let compressedData = try Data(contentsOf: downloadedFileURL)
+                    guard let decompressedData = self.decompressBrotli(data: compressedData, fileName: fileName) else {
+                        self.sendStats(action: "download_manifest_brotli_fail", versionName: "\(version):\(destFileName)")
+                        throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to decompress Brotli data for file \(fileName) at url \(downloadUrl)"])
+                    }
+                    try writeDataAtomically(decompressedData, to: destFilePath)
+                } else {
+                    try copyItemReplacing(from: downloadedFileURL, to: destFilePath)
+                }
             }
 
             // Always verify checksum when file_hash is present
@@ -2936,6 +2949,7 @@ import UIKit
         let queue = OperationQueue()
         queue.name = "com.capgo.manifestDownload"
         queue.qualityOfService = .userInitiated
+        queue.maxConcurrentOperationCount = CapgoUpdater.manifestMaxConcurrentFiles
         return queue
     }()
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -1801,7 +1801,7 @@ import UIKit
                         let chunk = try handle.read(upToCount: chunkSize) ?? Data()
                         if chunk.isEmpty {
                             inputExhausted = true
-                            flags = COMPRESSION_STREAM_FINALIZE
+                            flags = COMPRESSION_STREAM_FINALIZE.rawValue
                         } else {
                             chunk.copyBytes(to: inBase, count: chunk.count)
                             streamPointer.pointee.src_ptr = UnsafePointer(inBase)

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -25,6 +25,8 @@ import UIKit
     private let PENDING_DELETE_IDS: String = "pendingDeleteIds"
     private var unzipPercent = 0
     private let TEMP_UNZIP_PREFIX: String = "capgo_unzip_"
+    /// Cap concurrent manifest file work. 32–64 OOMs low-RAM devices.
+    private static let manifestMaxConcurrentFiles = 4
     private let deletePaceSeconds: TimeInterval = 0.075
     private let deleteLock = NSLock()
 
@@ -300,11 +302,29 @@ import UIKit
     private func storeDownloadedFile(_ downloadedFileURL: URL, at tempPath: URL, existingBytes: Int64, response: HTTPURLResponse?) throws {
         let fileManager = FileManager.default
         if existingBytes > 0 && (response?.statusCode == 206 || response == nil) {
-            let resumedData = try Data(contentsOf: downloadedFileURL)
             let fileHandle = try FileHandle(forWritingTo: tempPath)
+            defer {
+                try? fileHandle.close()
+            }
             fileHandle.seek(toFileOffset: UInt64(existingBytes))
-            fileHandle.write(resumedData)
-            try fileHandle.close()
+            let input = try FileHandle(forReadingFrom: downloadedFileURL)
+            defer {
+                try? input.close()
+            }
+            let chunkSize = 64 * 1024
+            while true {
+                let done: Bool = try autoreleasepool {
+                    let chunk = try input.read(upToCount: chunkSize) ?? Data()
+                    if chunk.isEmpty {
+                        return true
+                    }
+                    fileHandle.write(chunk)
+                    return false
+                }
+                if done {
+                    break
+                }
+            }
             try? fileManager.removeItem(at: downloadedFileURL)
             return
         }
@@ -1175,18 +1195,28 @@ import UIKit
         let isBrotli = fileName.hasSuffix(".br")
         let cacheBaseName = isBrotli ? String(fileNameWithoutPath.dropLast(3)) : fileNameWithoutPath
         let cacheFilePath = cacheFolder.appendingPathComponent("\(fileHash)_\(cacheBaseName)")
-        if FileManager.default.fileExists(atPath: cacheFilePath.path) && verifyChecksum(file: cacheFilePath, expectedHash: fileHash) {
+        // Cache files are named `{hash}_{filename}` and were checksum-verified
+        // when written. Re-hashing every hit re-reads the whole bundle and
+        // OOMs/janks low-RAM devices during getMissing / delta apply.
+        if isReusableCacheFile(cacheFilePath) {
             return true
         }
 
         if isBrotli {
             let legacyCacheFilePath = cacheFolder.appendingPathComponent("\(fileHash)_\(fileNameWithoutPath)")
-            if FileManager.default.fileExists(atPath: legacyCacheFilePath.path) && verifyChecksum(file: legacyCacheFilePath, expectedHash: fileHash) {
+            if isReusableCacheFile(legacyCacheFilePath) {
                 return true
             }
         }
 
         return false
+    }
+
+    /// Hash-named cache files were verified when written. Existence + size
+    /// is enough; re-hashing re-reads every reused file on low-RAM devices.
+    private func isReusableCacheFile(_ url: URL) -> Bool {
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        return size > 0
     }
 
     public func getMissingBundleFiles(manifest: [ManifestEntry], sessionKey: String) -> [ManifestEntry] {
@@ -1299,8 +1329,10 @@ import UIKit
 
         let totalFiles = manifest.count
 
-        // Configure concurrent operation count similar to Android: min(64, max(32, totalFiles))
-        manifestDownloadQueue.maxConcurrentOperationCount = min(64, max(32, totalFiles))
+        // 4 concurrent: 32–64 holds full HTTP bodies, checksum buffers, and
+        // ~1MB thread stacks each — that OOMs low-RAM phones. 4 also matches
+        // typical per-host HTTP limits, so extra threads mostly wait.
+        manifestDownloadQueue.maxConcurrentOperationCount = Self.manifestMaxConcurrentFiles
 
         // Thread-safe counters for concurrent operations
         let completedFiles = AtomicCounter()
@@ -1404,8 +1436,8 @@ import UIKit
                     }
                     // Try cache
                     else if
-                        self.tryCopyFromCache(from: cacheFilePath, to: destFilePath, expectedHash: finalFileHash) ||
-                            (legacyCacheFilePath != nil && self.tryCopyFromCache(from: legacyCacheFilePath!, to: destFilePath, expectedHash: finalFileHash)) {
+                        self.tryCopyFromCache(from: cacheFilePath, to: destFilePath) ||
+                            (legacyCacheFilePath != nil && self.tryCopyFromCache(from: legacyCacheFilePath!, to: destFilePath)) {
                         self.logger.info("downloadManifest \(fileName) copy from cache \(id)")
                     }
                     // Download
@@ -1465,8 +1497,6 @@ import UIKit
         // Send stats for manifest download complete
         self.sendStats(action: "download_manifest_complete", versionName: version)
 
-        self.populateDeltaCacheAsync(for: id, manifest: manifest, sessionKey: sessionKey)
-
         self.notifyDownload(id: id, percent: 100, bundle: updatedBundle)
         logger.info("downloadManifest done \(id)")
         return updatedBundle
@@ -1502,7 +1532,7 @@ import UIKit
             )
         }
 
-        let result = performRequest(request, label: "downloadManifestFile \(fileName)")
+        let result = performDownloadRequest(request, label: "downloadManifestFile \(fileName)")
 
         if result.timedOut {
             self.sendStats(action: "download_manifest_file_fail", versionName: "\(version):\(fileName)")
@@ -1520,7 +1550,13 @@ import UIKit
             throw error
         }
 
-        guard let data = result.data else {
+        let statusCode = result.response?.statusCode ?? 200
+        if statusCode < 200 || statusCode >= 300 {
+            self.sendStats(action: "download_manifest_file_fail", versionName: "\(version):\(fileName)")
+            throw NSError(domain: "StatusCodeError", code: statusCode, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch. Status code (\(statusCode)) invalid for file \(fileName) at url \(downloadUrl)"])
+        }
+
+        guard let downloadedFileURL = result.fileURL, FileManager.default.fileExists(atPath: downloadedFileURL.path) else {
             self.sendStats(action: "download_manifest_file_fail", versionName: "\(version):\(fileName)")
             throw NSError(
                 domain: "ManifestDownloadError",
@@ -1528,44 +1564,31 @@ import UIKit
                 userInfo: [NSLocalizedDescriptionKey: "Manifest file response was empty for \(fileName) at url \(downloadUrl)"]
             )
         }
-
-        let statusCode = result.response?.statusCode ?? 200
-        if statusCode < 200 || statusCode >= 300 {
-            self.sendStats(action: "download_manifest_file_fail", versionName: "\(version):\(fileName)")
-            if let stringData = String(data: data, encoding: .utf8) {
-                throw NSError(domain: "StatusCodeError", code: statusCode, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch. Status code (\(statusCode)) invalid. Data: \(stringData) for file \(fileName) at url \(downloadUrl)"])
-            } else {
-                throw NSError(domain: "StatusCodeError", code: statusCode, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch. Status code (\(statusCode)) invalid for file \(fileName) at url \(downloadUrl)"])
-            }
+        defer {
+            try? FileManager.default.removeItem(at: downloadedFileURL)
         }
 
         do {
-            // Add decryption step if public key is set and sessionKey is provided
-            var finalData = data
+            // Decrypt in place when a session key is present — avoids a second in-memory copy.
             if !self.publicKey.isEmpty && !sessionKey.isEmpty {
-                let tempFile = self.cacheFolder.appendingPathComponent("temp_\(UUID().uuidString)")
-                try finalData.write(to: tempFile)
                 do {
-                    try CryptoCipher.decryptFile(filePath: tempFile, publicKey: self.publicKey, sessionKey: sessionKey, version: version)
+                    try CryptoCipher.decryptFile(filePath: downloadedFileURL, publicKey: self.publicKey, sessionKey: sessionKey, version: version)
                 } catch {
                     self.sendStats(action: "decrypt_fail", versionName: version)
                     throw error
                 }
-                finalData = try Data(contentsOf: tempFile)
-                try FileManager.default.removeItem(at: tempFile)
             }
 
-            // Decompress Brotli if needed
             if isBrotli {
-                guard let decompressedData = self.decompressBrotli(data: finalData, fileName: fileName) else {
+                let compressedData = try Data(contentsOf: downloadedFileURL)
+                guard let decompressedData = self.decompressBrotli(data: compressedData, fileName: fileName) else {
                     self.sendStats(action: "download_manifest_brotli_fail", versionName: "\(version):\(destFileName)")
                     throw NSError(domain: "BrotliDecompressionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to decompress Brotli data for file \(fileName) at url \(downloadUrl)"])
                 }
-                finalData = decompressedData
+                try writeDataAtomically(decompressedData, to: destFilePath)
+            } else {
+                try copyItemReplacing(from: downloadedFileURL, to: destFilePath)
             }
-
-            // Write to destination (replace if leftover from a previous failed download)
-            try writeDataAtomically(finalData, to: destFilePath)
 
             // Always verify checksum when file_hash is present
             let calculatedChecksum = CryptoCipher.calcChecksum(filePath: destFilePath)
@@ -1578,7 +1601,7 @@ import UIKit
             }
 
             // Save to cache (replace stale cache entries from partial or concurrent downloads)
-            try writeDataAtomically(finalData, to: cacheFilePath)
+            try copyItemReplacing(from: destFilePath, to: cacheFilePath)
 
             self.logger.info("Manifest file downloaded and cached")
             self.logger.debug("Bundle: \(bundleId), File: \(fileName), Brotli: \(isBrotli), Encrypted: \(!self.publicKey.isEmpty && !sessionKey.isEmpty)")
@@ -1591,22 +1614,13 @@ import UIKit
 
     /// Atomically write data to a file, replacing any existing file at the destination.
     private func writeDataAtomically(_ data: Data, to destination: URL) throws {
-        let fileManager = FileManager.default
-        let tempURL = destination.deletingLastPathComponent().appendingPathComponent("\(destination.lastPathComponent).\(UUID().uuidString).tmp")
-        defer {
-            try? fileManager.removeItem(at: tempURL)
-        }
-
-        try data.write(to: tempURL, options: .atomic)
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
-        }
-        try fileManager.moveItem(at: tempURL, to: destination)
+        try data.write(to: destination, options: .atomic)
     }
 
     /// Copy a file to the destination, replacing any existing file.
     private func copyItemReplacing(from source: URL, to destination: URL) throws {
         let fileManager = FileManager.default
+        try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
         if fileManager.fileExists(atPath: destination.path) {
             try fileManager.removeItem(at: destination)
         }
@@ -1615,19 +1629,16 @@ import UIKit
 
     /// Atomically try to copy a file from cache - returns true if successful, false if file doesn't exist or copy failed
     /// This handles the race condition where OS can delete cache files between exists() check and copy
-    private func tryCopyFromCache(from source: URL, to destination: URL, expectedHash: String) -> Bool {
+    private func tryCopyFromCache(from source: URL, to destination: URL) -> Bool {
         let fileManager = FileManager.default
 
-        // First quick check - if file doesn't exist, don't bother
-        guard fileManager.fileExists(atPath: source.path) else {
+        // First quick check - if file doesn't exist or was truncated, don't bother
+        guard isReusableCacheFile(source) else {
             return false
         }
 
-        // Verify checksum before copy; remove stale cache entries that would block re-download
-        guard verifyChecksum(file: source, expectedHash: expectedHash) else {
-            try? fileManager.removeItem(at: source)
-            return false
-        }
+        // Hash is in the cache file name and was verified when written.
+        // Re-hashing here would re-read every reused file on low-RAM devices.
 
         // Try to copy - if it fails (file deleted by OS between check and copy), return false
         do {
@@ -1653,8 +1664,6 @@ import UIKit
 
         // For small files, check if it's a minimal Brotli wrapper
         if data.count > 3 {
-            let maxBytes = min(32, data.count)
-            let hexDump = data.prefix(maxBytes).map { String(format: "%02x", $0) }.joined(separator: " ")
             // Handle our minimal wrapper pattern
             if data[0] == 0x1B && data[1] == 0x00 && data[2] == 0x06 && data.last == 0x03 {
                 let range = data.index(data.startIndex, offsetBy: 3)..<data.index(data.endIndex, offsetBy: -1)

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -25,8 +25,8 @@ import UIKit
     private let PENDING_DELETE_IDS: String = "pendingDeleteIds"
     private var unzipPercent = 0
     private let TEMP_UNZIP_PREFIX: String = "capgo_unzip_"
-    /// Cap concurrent manifest file work. 32–64 OOMs low-RAM devices.
-    private static let manifestMaxConcurrentFiles = 4
+    /// Match URLSession per-host limit so 64 workers actually fetch in parallel.
+    private static let manifestMaxConcurrentFiles = 64
     private static let emptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     private let deletePaceSeconds: TimeInterval = 0.075
     private let deleteLock = NSLock()
@@ -175,6 +175,7 @@ import UIKit
         configuration.httpShouldSetCookies = false
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.urlCache = nil
+        configuration.httpMaximumConnectionsPerHost = Self.manifestMaxConcurrentFiles
         return Session(configuration: configuration)
     }()
     private let networkResponseQueue = DispatchQueue(label: "ee.forgr.capacitor-updater.network-response", qos: .utility)
@@ -1350,10 +1351,7 @@ import UIKit
 
         let totalFiles = manifest.count
 
-        // 4 concurrent: 32–64 holds full HTTP bodies, checksum buffers, and
-        // ~1MB thread stacks each — that OOMs low-RAM phones. 4 also matches
-        // typical per-host HTTP limits, so extra threads mostly wait.
-        manifestDownloadQueue.maxConcurrentOperationCount = Self.manifestMaxConcurrentFiles
+        manifestDownloadQueue.maxConcurrentOperationCount = min(Self.manifestMaxConcurrentFiles, max(1, totalFiles))
 
         // Thread-safe counters for concurrent operations
         let completedFiles = AtomicCounter()

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -1754,7 +1754,7 @@ import UIKit
                 let toRead = Int(min(UInt64(chunkSize), remaining))
                 let chunk = try handle.read(upToCount: toRead) ?? Data()
                 if !chunk.isEmpty {
-                    output.write(chunk)
+                    try output.write(contentsOf: chunk)
                 }
                 return chunk.count
             }
@@ -1820,7 +1820,7 @@ import UIKit
                     status = compression_stream_process(streamPointer, flags)
                     let have = chunkSize - streamPointer.pointee.dst_size
                     if have > 0 {
-                        output.write(Data(bytes: outBase, count: have))
+                        try output.write(contentsOf: Data(bytes: outBase, count: have))
                     }
                     streamPointer.pointee.dst_ptr = outBase
                     streamPointer.pointee.dst_size = chunkSize

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -278,41 +278,13 @@ public struct CryptoCipher {
 
             let aesPrivateKey = AES128Key(iv: ivData, aes128Key: sessionKeyDataDecrypted, logger: logger)
 
-            let encryptedData: Data
-            do {
-                encryptedData = try Data(contentsOf: filePath)
-            } catch {
-                logger.error("Failed to read encrypted data")
-                logger.debug("Error: \(error)")
-                throw NSError(domain: "Failed to read encrypted data", code: 3, userInfo: nil)
-            }
-
-            if encryptedData.isEmpty {
+            let encryptedSize = (try FileManager.default.attributesOfItem(atPath: filePath.path)[.size] as? NSNumber)?.uint64Value ?? 0
+            if encryptedSize == 0 {
                 logger.error("Encrypted file data is empty")
                 throw NSError(domain: "Empty encrypted data", code: 6, userInfo: nil)
             }
 
-            guard let decryptedData = aesPrivateKey.decrypt(data: encryptedData) else {
-                logger.error("Failed to decrypt data")
-                throw NSError(domain: "Failed to decrypt data", code: 4, userInfo: nil)
-            }
-
-            if decryptedData.isEmpty {
-                logger.error("Decrypted data is empty")
-                throw NSError(domain: "Empty decrypted data", code: 7, userInfo: nil)
-            }
-
-            do {
-                try decryptedData.write(to: filePath, options: .atomic)
-                if !FileManager.default.fileExists(atPath: filePath.path) {
-                    logger.error("File was not created after write")
-                    throw NSError(domain: "File write failed", code: 8, userInfo: nil)
-                }
-            } catch {
-                logger.error("Error writing decrypted file")
-                logger.debug("Error: \(error)")
-                throw error
-            }
+            try aesPrivateKey.decrypt(from: filePath, to: filePath)
 
         } catch {
             logger.error("File decryption failed")

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -141,25 +141,39 @@ public struct CryptoCipher {
         }
     }
 
+    private static let twoGiB: UInt64 = 2 * 1024 * 1024 * 1024
+    private static let threeGiB: UInt64 = 3 * 1024 * 1024 * 1024
     private static let fourGiB: UInt64 = 4 * 1024 * 1024 * 1024
-    private static let sixGiB: UInt64 = 6 * 1024 * 1024 * 1024
+    private static let eightGiB: UInt64 = 8 * 1024 * 1024 * 1024
+    private static let flagshipIoBufferBytes = 5 * 1024 * 1024
 
-    /// <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB inclusive: 1MB. Else original 5MB.
-    static func checksumBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
-        if physicalRamBytes > 0 && physicalRamBytes < fourGiB {
+    /// Checksum and copy share one ladder. 64-wide peak RAM = 64 * buffer.
+    /// <2GB: 64KB. <3GB: 256KB. <4GB: 512KB. <8GB: 1MB. Else 5MB (flagship / unknown).
+    static func ioBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
+        if physicalRamBytes == 0 {
+            return flagshipIoBufferBytes
+        }
+        if physicalRamBytes < twoGiB {
             return 64 * 1024
         }
-        if physicalRamBytes > 0 && physicalRamBytes <= sixGiB {
+        if physicalRamBytes < threeGiB {
+            return 256 * 1024
+        }
+        if physicalRamBytes < fourGiB {
+            return 512 * 1024
+        }
+        if physicalRamBytes < eightGiB {
             return 1024 * 1024
         }
-        return 5 * 1024 * 1024
+        return flagshipIoBufferBytes
+    }
+
+    static func checksumBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
+        return ioBufferBytes(physicalRamBytes)
     }
 
     static func copyBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
-        if physicalRamBytes > 0 && physicalRamBytes < fourGiB {
-            return 64 * 1024
-        }
-        return 1024 * 1024
+        return ioBufferBytes(physicalRamBytes)
     }
 
     public static func calcChecksum(filePath: URL) -> String {

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -142,7 +142,9 @@ public struct CryptoCipher {
     }
 
     public static func calcChecksum(filePath: URL) -> String {
-        let bufferSize = 1024 * 1024 * 5 // 5 MB
+        // 64KB: SHA-256 does not benefit from 5MB reads, and manifest
+        // downloads hash several files at once on low-RAM devices.
+        let bufferSize = 64 * 1024
         var sha256 = SHA256()
 
         do {

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -285,6 +285,11 @@ public struct CryptoCipher {
             }
 
             try aesPrivateKey.decrypt(from: filePath, to: filePath)
+            let decryptedSize = (try FileManager.default.attributesOfItem(atPath: filePath.path)[.size] as? NSNumber)?.uint64Value ?? 0
+            if decryptedSize == 0 {
+                logger.error("Decrypted data is empty")
+                throw NSError(domain: "Empty decrypted data", code: 7, userInfo: nil)
+            }
 
         } catch {
             logger.error("File decryption failed")

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -141,10 +141,29 @@ public struct CryptoCipher {
         }
     }
 
+    private static let fourGiB: UInt64 = 4 * 1024 * 1024 * 1024
+    private static let sixGiB: UInt64 = 6 * 1024 * 1024 * 1024
+
+    /// <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB: 1MB. Else original 5MB.
+    static func checksumBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
+        if physicalRamBytes > 0 && physicalRamBytes < fourGiB {
+            return 64 * 1024
+        }
+        if physicalRamBytes > 0 && physicalRamBytes < sixGiB {
+            return 1024 * 1024
+        }
+        return 5 * 1024 * 1024
+    }
+
+    static func copyBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
+        if physicalRamBytes > 0 && physicalRamBytes < fourGiB {
+            return 64 * 1024
+        }
+        return 1024 * 1024
+    }
+
     public static func calcChecksum(filePath: URL) -> String {
-        // 64KB: SHA-256 does not benefit from 5MB reads, and manifest
-        // downloads hash several files at once on low-RAM devices.
-        let bufferSize = 64 * 1024
+        let bufferSize = checksumBufferBytes()
         var sha256 = SHA256()
 
         do {

--- a/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CryptoCipher.swift
@@ -144,12 +144,12 @@ public struct CryptoCipher {
     private static let fourGiB: UInt64 = 4 * 1024 * 1024 * 1024
     private static let sixGiB: UInt64 = 6 * 1024 * 1024 * 1024
 
-    /// <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB: 1MB. Else original 5MB.
+    /// <4GB: 64KB so 64-wide hashing cannot OOM. 4–6GB inclusive: 1MB. Else original 5MB.
     static func checksumBufferBytes(_ physicalRamBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int {
         if physicalRamBytes > 0 && physicalRamBytes < fourGiB {
             return 64 * 1024
         }
-        if physicalRamBytes > 0 && physicalRamBytes < sixGiB {
+        if physicalRamBytes > 0 && physicalRamBytes <= sixGiB {
             return 1024 * 1024
         }
         return 5 * 1024 * 1024

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -254,7 +254,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     }
 
     func testGetMissingBundleFilesIgnoresEmptyHashNamedCache() throws {
-        let hash = "abc123emptyhashabc123emptyhashabc123emptyhashabc123emptyhashab"
+        let hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
         try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
         try Data().write(to: cacheFile)
@@ -284,6 +284,20 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
     func testGetMissingBundleFilesRejectsUnsafeCacheHash() throws {
         let hash = "../evil"
+        let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        try "payload".write(to: cacheFile, atomically: true, encoding: .utf8)
+        let manifest = [
+            ManifestEntry(file_name: "app.js", file_hash: hash, download_url: nil)
+        ]
+
+        let missing = implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "")
+
+        XCTAssertEqual(missing.count, 1)
+    }
+
+    func testGetMissingBundleFilesDoesNotTrustCrc32CacheHash() throws {
+        let hash = "deadbeef"
         let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
         try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
         try "payload".write(to: cacheFile, atomically: true, encoding: .utf8)

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -340,17 +340,26 @@ final class IoBufferSizeTests: XCTestCase {
 
 final class StreamDecodeTests: XCTestCase {
     private var updater: CapgoUpdater!
+    private var tempDir: URL!
 
     override func setUp() {
         super.setUp()
         updater = CapgoUpdater()
         updater.setLogger(Logger(withTag: "StreamDecodeTests", options: Logger.Options(level: .silent)))
         CryptoCipher.setLogger(Logger(withTag: "StreamDecodeTests", options: Logger.Options(level: .silent)))
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("capgo-brotli-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        super.tearDown()
     }
 
     func testDecompressBrotliStreamsEmptyWrapperAndRealPayload() throws {
-        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("capgo-brotli-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dir = tempDir!
 
         let emptyIn = dir.appendingPathComponent("empty.br")
         let emptyOut = dir.appendingPathComponent("empty.txt")

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -324,3 +324,18 @@ final class PopulateDeltaCacheTests: XCTestCase {
         XCTAssertTrue(missing.isEmpty)
     }
 }
+
+final class IoBufferSizeTests: XCTestCase {
+    func testChecksumBufferStaysSmallOnLowRamAndFullOnFlagship() {
+        XCTAssertEqual(CryptoCipher.checksumBufferBytes(3 * 1024 * 1024 * 1024), 64 * 1024)
+        XCTAssertEqual(CryptoCipher.checksumBufferBytes(4 * 1024 * 1024 * 1024), 1024 * 1024)
+        XCTAssertEqual(CryptoCipher.checksumBufferBytes(8 * 1024 * 1024 * 1024), 5 * 1024 * 1024)
+        XCTAssertEqual(CryptoCipher.checksumBufferBytes(0), 5 * 1024 * 1024)
+    }
+
+    func testCopyBufferStaysSmallOnLowRamAndFullOnFlagship() {
+        XCTAssertEqual(CryptoCipher.copyBufferBytes(3 * 1024 * 1024 * 1024), 64 * 1024)
+        XCTAssertEqual(CryptoCipher.copyBufferBytes(4 * 1024 * 1024 * 1024), 1024 * 1024)
+        XCTAssertEqual(CryptoCipher.copyBufferBytes(0), 1024 * 1024)
+    }
+}

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -309,4 +309,18 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
         XCTAssertEqual(missing.count, 1)
     }
+
+    func testGetMissingBundleFilesTreatsLegacyBrotliCacheNameAsReusable() throws {
+        let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let cacheFile = expectedCacheFile(hash: hash, name: "app.js.br")
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        try "legacy-brotli-cache".write(to: cacheFile, atomically: true, encoding: .utf8)
+        let manifest = [
+            ManifestEntry(file_name: "app.js.br", file_hash: hash, download_url: nil)
+        ]
+
+        let missing = implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "")
+
+        XCTAssertTrue(missing.isEmpty)
+    }
 }

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -337,3 +337,49 @@ final class IoBufferSizeTests: XCTestCase {
         }
     }
 }
+
+final class StreamDecodeTests: XCTestCase {
+    private var updater: CapgoUpdater!
+
+    override func setUp() {
+        super.setUp()
+        updater = CapgoUpdater()
+        updater.setLogger(Logger(withTag: "StreamDecodeTests", options: Logger.Options(level: .silent)))
+        CryptoCipher.setLogger(Logger(withTag: "StreamDecodeTests", options: Logger.Options(level: .silent)))
+    }
+
+    func testDecompressBrotliStreamsEmptyWrapperAndRealPayload() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("capgo-brotli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let emptyIn = dir.appendingPathComponent("empty.br")
+        let emptyOut = dir.appendingPathComponent("empty.txt")
+        try Data([0x1B, 0x00, 0x06]).write(to: emptyIn)
+        try updater.decompressBrotli(from: emptyIn, to: emptyOut, fileName: "empty.br")
+        XCTAssertEqual(try Data(contentsOf: emptyOut).count, 0)
+
+        let wrappedIn = dir.appendingPathComponent("hello.br")
+        let wrappedOut = dir.appendingPathComponent("hello.txt")
+        try Data([0x0b, 0x02, 0x80, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x03]).write(to: wrappedIn)
+        try updater.decompressBrotli(from: wrappedIn, to: wrappedOut, fileName: "hello.br")
+        XCTAssertEqual(try String(contentsOf: wrappedOut, encoding: .utf8), "hello")
+
+        let realIn = dir.appendingPathComponent("payload.br")
+        let realOut = dir.appendingPathComponent("payload.txt")
+        try dataFromHex("1ba702f88d94abed6831a46e4b75213df69d8b08871d5db158a9b062f007672bc101c92bf781d73386bfc50a00").write(to: realIn)
+        try updater.decompressBrotli(from: realIn, to: realOut, fileName: "payload.br")
+        let expected = String(repeating: "Capgo stream brotli test payload. ", count: 20)
+        XCTAssertEqual(try String(contentsOf: realOut, encoding: .utf8), expected)
+    }
+
+    private func dataFromHex(_ hex: String) -> Data {
+        var data = Data()
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            data.append(UInt8(hex[index..<next], radix: 16)!)
+            index = next
+        }
+        return data
+    }
+}

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -329,6 +329,7 @@ final class IoBufferSizeTests: XCTestCase {
     func testChecksumBufferStaysSmallOnLowRamAndFullOnFlagship() {
         XCTAssertEqual(CryptoCipher.checksumBufferBytes(3 * 1024 * 1024 * 1024), 64 * 1024)
         XCTAssertEqual(CryptoCipher.checksumBufferBytes(4 * 1024 * 1024 * 1024), 1024 * 1024)
+        XCTAssertEqual(CryptoCipher.checksumBufferBytes(6 * 1024 * 1024 * 1024), 1024 * 1024)
         XCTAssertEqual(CryptoCipher.checksumBufferBytes(8 * 1024 * 1024 * 1024), 5 * 1024 * 1024)
         XCTAssertEqual(CryptoCipher.checksumBufferBytes(0), 5 * 1024 * 1024)
     }
@@ -336,6 +337,8 @@ final class IoBufferSizeTests: XCTestCase {
     func testCopyBufferStaysSmallOnLowRamAndFullOnFlagship() {
         XCTAssertEqual(CryptoCipher.copyBufferBytes(3 * 1024 * 1024 * 1024), 64 * 1024)
         XCTAssertEqual(CryptoCipher.copyBufferBytes(4 * 1024 * 1024 * 1024), 1024 * 1024)
+        XCTAssertEqual(CryptoCipher.copyBufferBytes(6 * 1024 * 1024 * 1024), 1024 * 1024)
+        XCTAssertEqual(CryptoCipher.copyBufferBytes(8 * 1024 * 1024 * 1024), 1024 * 1024)
         XCTAssertEqual(CryptoCipher.copyBufferBytes(0), 1024 * 1024)
     }
 }

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -326,19 +326,14 @@ final class PopulateDeltaCacheTests: XCTestCase {
 }
 
 final class IoBufferSizeTests: XCTestCase {
-    func testChecksumBufferStaysSmallOnLowRamAndFullOnFlagship() {
-        XCTAssertEqual(CryptoCipher.checksumBufferBytes(3 * 1024 * 1024 * 1024), 64 * 1024)
-        XCTAssertEqual(CryptoCipher.checksumBufferBytes(4 * 1024 * 1024 * 1024), 1024 * 1024)
-        XCTAssertEqual(CryptoCipher.checksumBufferBytes(6 * 1024 * 1024 * 1024), 1024 * 1024)
-        XCTAssertEqual(CryptoCipher.checksumBufferBytes(8 * 1024 * 1024 * 1024), 5 * 1024 * 1024)
-        XCTAssertEqual(CryptoCipher.checksumBufferBytes(0), 5 * 1024 * 1024)
-    }
-
-    func testCopyBufferStaysSmallOnLowRamAndFullOnFlagship() {
-        XCTAssertEqual(CryptoCipher.copyBufferBytes(3 * 1024 * 1024 * 1024), 64 * 1024)
-        XCTAssertEqual(CryptoCipher.copyBufferBytes(4 * 1024 * 1024 * 1024), 1024 * 1024)
-        XCTAssertEqual(CryptoCipher.copyBufferBytes(6 * 1024 * 1024 * 1024), 1024 * 1024)
-        XCTAssertEqual(CryptoCipher.copyBufferBytes(8 * 1024 * 1024 * 1024), 1024 * 1024)
-        XCTAssertEqual(CryptoCipher.copyBufferBytes(0), 1024 * 1024)
+    func testIoBuffersFollowFiveRamTiersAndMatchForChecksumAndCopy() {
+        let gib: UInt64 = 1024 * 1024 * 1024
+        let ramBytes: [UInt64] = [gib, 2 * gib, 3 * gib, 4 * gib, 6 * gib, 8 * gib, 0]
+        let expected = [64 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 1024 * 1024, 5 * 1024 * 1024, 5 * 1024 * 1024]
+        for i in ramBytes.indices {
+            XCTAssertEqual(CryptoCipher.ioBufferBytes(ramBytes[i]), expected[i])
+            XCTAssertEqual(CryptoCipher.checksumBufferBytes(ramBytes[i]), expected[i])
+            XCTAssertEqual(CryptoCipher.copyBufferBytes(ramBytes[i]), expected[i])
+        }
     }
 }

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -238,7 +238,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     // MARK: - getMissingBundleFiles: trust hash-named cache without re-reading
 
     func testGetMissingBundleFilesTreatsHashNamedCacheAsReusable() throws {
-        let hash = "abc123cachedhash"
+        let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
         try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
         // Content does not need to match the hash: the filename is the trust source
@@ -254,7 +254,7 @@ final class PopulateDeltaCacheTests: XCTestCase {
     }
 
     func testGetMissingBundleFilesIgnoresEmptyHashNamedCache() throws {
-        let hash = "abc123emptyhash"
+        let hash = "abc123emptyhashabc123emptyhashabc123emptyhashabc123emptyhashab"
         let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
         try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
         try Data().write(to: cacheFile)
@@ -266,5 +266,33 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
         XCTAssertEqual(missing.count, 1)
         XCTAssertEqual(missing.first?.file_name, "app.js")
+    }
+
+    func testGetMissingBundleFilesReusesEmptyFileForEmptySha256() throws {
+        let hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        let cacheFile = expectedCacheFile(hash: hash, name: "empty.txt")
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        try Data().write(to: cacheFile)
+        let manifest = [
+            ManifestEntry(file_name: "empty.txt", file_hash: hash, download_url: nil)
+        ]
+
+        let missing = implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "")
+
+        XCTAssertTrue(missing.isEmpty)
+    }
+
+    func testGetMissingBundleFilesRejectsUnsafeCacheHash() throws {
+        let hash = "../evil"
+        let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        try "payload".write(to: cacheFile, atomically: true, encoding: .utf8)
+        let manifest = [
+            ManifestEntry(file_name: "app.js", file_hash: hash, download_url: nil)
+        ]
+
+        let missing = implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "")
+
+        XCTAssertEqual(missing.count, 1)
     }
 }

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -234,4 +234,37 @@ final class PopulateDeltaCacheTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile.path))
     }
+
+    // MARK: - getMissingBundleFiles: trust hash-named cache without re-reading
+
+    func testGetMissingBundleFilesTreatsHashNamedCacheAsReusable() throws {
+        let hash = "abc123cachedhash"
+        let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        // Content does not need to match the hash: the filename is the trust source
+        // (checksum was verified when the cache entry was written).
+        try "not-the-hashed-bytes".write(to: cacheFile, atomically: true, encoding: .utf8)
+        let manifest = [
+            ManifestEntry(file_name: "app.js", file_hash: hash, download_url: nil)
+        ]
+
+        let missing = implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "")
+
+        XCTAssertTrue(missing.isEmpty)
+    }
+
+    func testGetMissingBundleFilesIgnoresEmptyHashNamedCache() throws {
+        let hash = "abc123emptyhash"
+        let cacheFile = expectedCacheFile(hash: hash, name: "app.js")
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        try Data().write(to: cacheFile)
+        let manifest = [
+            ManifestEntry(file_name: "app.js", file_hash: hash, download_url: nil)
+        ]
+
+        let missing = implementation.getMissingBundleFiles(manifest: manifest, sessionKey: "")
+
+        XCTAssertEqual(missing.count, 1)
+        XCTAssertEqual(missing.first?.file_name, "app.js")
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Keep up to 64 concurrent manifest **downloads** (HTTP/2 multiplexed), sized to file count so tiny manifests do not spawn idle threads
- Raise Android OkHttp `maxRequests` / `maxRequestsPerHost` and iOS `httpMaximumConnectionsPerHost` to 64 so those workers actually fetch in parallel
- Stream AES-CBC decrypt and Brotli decompress file-to-file. No 4-wide decode gate — decode runs at the same concurrency as HTTP
- Scale checksum **and** copy buffers with the same five-step RAM ladder. Flagships get 5MB for both. 64KB is only the bottom step, not global
- Keep the iOS shared download queue at 64 so overlapping manifests cannot serialize each other
- Skip re-hashing only for 64-char SHA-256 hash-named cache files; CRC32 names are not trusted without a re-read
- Stream iOS manifest downloads to disk instead of holding each HTTP body in RAM
- Stop cloning the Android manifest `JSONArray` through `toString()` / re-parse
- Drop the redundant post-manifest iOS delta-cache walk (files are already cached on download)
- Reuse one AES output buffer (`cipher.update(in, out)` / `InputStream` + `CCCryptorUpdate`) instead of allocating a new array per chunk
- Copy Brotli unwraps with the RAM-ladder buffer instead of Okio's 8KB segments

## Why
Low-end phones were dying during manifest / delta updates because each worker held a 5MB checksum buffer and often a full file body, then re-hashed every cached file. A global 64KB buffer would make flagships slower. The 4-wide decrypt/brotli cap was a workaround for whole-file loads; Brotli and AES-CBC are streaming codecs, so that cap is gone.

## How
Fast network on every phone. Smaller IO buffers only where RAM is tight:
- `min(64, fileCount)` parallel downloads, HTTP dispatcher/per-host limits matched to 64
- AES decrypt uses `Cipher.update` / `CCCryptorUpdate` into a temp file, then rename (`renameTo` on Android so API 24 works; `Files.move` does not)
- Brotli peeks 3 header bytes + last byte for the empty/wrapper special cases, then streams `BrotliInputStream` / `compression_stream` to disk
- One shared IO buffer size from physical RAM (`/proc/meminfo` on Android, `physicalMemory` on iOS):
  - **< 2 GiB:** 64KB
  - **< 3 GiB:** 256KB
  - **< 4 GiB:** 512KB
  - **< 8 GiB:** 1MB
  - **≥ 8 GiB (or RAM unknown):** 5MB checksum and copy
- Trust write-time checksum for SHA-256 hash-named cache entries; still hash builtin files
- Newly downloaded files are still checksum-verified before they are cached

## Testing
- iOS and Android unit tests: hash-named SHA-256 cache is reusable, empty files are not (unless empty SHA-256), path-traversal hashes are rejected, CRC32 cache names are not trusted, legacy `.br` cache names are reused
- Buffer-size tests: 1GB → 64KB, 2GB → 256KB, 3GB → 512KB, 4GB and 6GB → 1MB, 8GB and unknown RAM → 5MB for both checksum and copy
- Brotli file-to-file: empty stream, quality-0 wrapper, and a real compressed payload
- Android AES file decrypt round-trip across more than one IO buffer
- Local A/B on 15 Aug 2026 (no physical phone plugged in). Workload: 16 concurrent 8 MiB files (128 MiB) for Brotli/AES; 64 files × 2 MiB for cache skip-rehash. Extra RAM = peak minus baseline during the op. iOS = iPhone 17 Simulator RSS of the real plugin. Android = JVM heap of the real `DownloadService` / `CryptoCipher` / `CapgoUpdater` code. `ioBufferBytes` = 5MB on this machine (≥8 GiB RAM).

Round 1 was file-to-file streaming vs whole-file load. Round 2 is the same bench after reusing the AES out buffer and copying Brotli with the RAM-ladder size.

| Path | Extra RAM before → after (round 2) | Time | Extra RAM cut |
|---|---|---|---|
| Android Brotli | 289 → 98 MiB | 263 → 15 ms | 66% |
| Android cache skip-rehash | 393 → 0.5 MiB | 37 → 10 ms | 99.9% |
| Android AES | 441 → 200 MiB | 258 → 27 ms | 55% |
| iOS Brotli | 227 → 34 MiB | 34 → 26 ms | 85% |
| iOS cache skip-rehash | 27 → 0.2 MiB | 19 → 17 ms | 99% |
| iOS AES | 272 → 161 MiB | 37 → 50 ms | 41% |

Follow-up vs round-1 streaming (same workload):
- Android AES extra heap 401 → 200 MiB. `cipher.update(in)` no longer allocates a new `byte[]` per chunk. Leftover ~200 MiB is 16 workers × (5MB in + 5MB out).
- Android Brotli time 338 → 15 ms. Okio 8KB segments replaced with the RAM-ladder copy. Extra heap rose vs Okio (2.5 → 98 MiB) because this host uses 5MB buffers; a <2 GiB phone still uses 64KB.
- iOS Brotli extra RSS 57 → 34 MiB, 33 → 26 ms.
- iOS AES extra RSS stays in the 16 × (in+out) buffer band (~160 MiB on this host). Speed is still a bit slower than whole-file `CCCrypt` because streaming does more syscalls.

## Not Tested
- Live manifest update on a physical low-RAM device (needs a large delta against builtin + cache)
- On-device `dumpsys meminfo` / Instruments (USB empty; API 36 emulator image installed but did not finish cold boot)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5af206b-2474-4295-8d09-3e082bab2de6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5af206b-2474-4295-8d09-3e082bab2de6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-updater/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789310144&installation_model_id=430928&pr_number=854&repository=Cap-go%2Fcapacitor-updater&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-updater%2Fpull%2F854&signature=0985f53738b53f8630ceaac9fe7258cc76bfb03b89ee41e3921f95f374d96408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-updater/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage during downloads, checksum calculation, decryption, and Brotli decompression.
  * Improved concurrent manifest and file download handling.

* **Reliability**
  * Strengthened validation for downloaded files, cache entries, and HTTP responses.
  * Improved streaming decryption, temporary-file cleanup, resumable downloads, and atomic updates.

* **Bug Fixes**
  * Prevented unsafe or invalid cache entries from being reused.
  * Improved empty-file and Brotli handling while preserving legacy cache compatibility.
  * Improved download and cache consistency across Android and iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
