### PR TITLE
fix(updater): keep dest files and bound CI hangs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Generate AI changelog
         id: changelog
         continue-on-error: true
+        timeout-minutes: 2
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -53,10 +53,10 @@ jobs:
           git commit --m "docs: update doc" || true
       - name: Create version bump main
         if: github.ref == 'refs/heads/main'
-        run: bunx capacitor-plugin-standard-version@latest --skip.changelog
+        run: bunx capacitor-plugin-standard-version@2.0.19 --skip.changelog
       - name: Create version bump development
         if: github.ref == 'refs/heads/development'
-        run: bunx capacitor-plugin-standard-version@latest --prerelease alpha --skip.changelog
+        run: bunx capacitor-plugin-standard-version@2.0.19 --prerelease alpha --skip.changelog
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/android/src/main/java/ee/forgr/capacitor_updater/BundleInfo.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/BundleInfo.java
@@ -99,7 +99,7 @@ public class BundleInfo {
     }
 
     public boolean isDownloaded() {
-        return (!this.isBuiltin() && this.downloaded != null && !this.downloaded.isEmpty() && !this.isDeleted() && !this.isDeleting());
+        return !this.isBuiltin() && this.downloaded != null && !this.downloaded.isEmpty() && !this.isDeleted() && !this.isDeleting();
     }
 
     public String getDownloaded() {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -250,6 +250,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private volatile long webViewPageStartedAtMs = 0;
     private volatile boolean launchStartReported = false;
     private volatile boolean launchReadyReported = false;
+    private volatile boolean launchTimeoutReported = false;
     private FrameLayout splashscreenLoaderOverlay;
     private Runnable splashscreenTimeoutRunnable;
     private FrameLayout previewTransitionLoaderOverlay;
@@ -1769,14 +1770,21 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private void reportAppLaunchTimeout(final BundleInfo bundle) {
-        if (this.implementation == null || this.implementation.statsUrl == null || this.implementation.statsUrl.isEmpty()) {
+        if (
+            this.implementation == null ||
+            this.implementation.statsUrl == null ||
+            this.implementation.statsUrl.isEmpty() ||
+            this.launchReadyReported ||
+            this.launchTimeoutReported
+        ) {
             return;
         }
 
+        this.launchTimeoutReported = true;
         final Map<String, String> metadata = new HashMap<>();
         metadata.put("duration_ms", Long.toString(Math.max(0, System.currentTimeMillis() - this.launchStartedAtMs)));
         metadata.put("launch_started_at", Long.toString(this.launchStartedAtMs));
-        metadata.put("timeout_ms", Long.toString(this.appReadyTimeout));
+        metadata.put("timeout_ms", Long.toString(this.resolveAppReadyCheckTimeoutMs()));
         metadata.put("source", "app_ready_timeout");
         this.implementation.sendStats("app_launch_timeout", bundle == null ? "" : bundle.getVersionName(), "", metadata);
     }
@@ -4745,8 +4753,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
         final String messageUpdate = initialDirectUpdateAllowed
             ? "Update will occur now."
             : this.shouldAutoSetNextBundle()
-                ? "Update will occur next time app moves to background."
-                : "Update will be downloaded and made available.";
+              ? "Update will occur next time app moves to background."
+              : "Update will be downloaded and made available.";
         Thread newTask = startNewThread(() -> {
             // Wait for cleanup to complete before starting download
             waitForCleanupIfNeeded();

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -251,6 +251,7 @@ public class CapacitorUpdaterPlugin extends Plugin {
     private volatile boolean launchStartReported = false;
     private volatile boolean launchReadyReported = false;
     private volatile boolean launchTimeoutReported = false;
+    private final Object launchReportLock = new Object();
     private FrameLayout splashscreenLoaderOverlay;
     private Runnable splashscreenTimeoutRunnable;
     private FrameLayout previewTransitionLoaderOverlay;
@@ -1752,16 +1753,18 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private void reportAppLaunchReady(final BundleInfo bundle) {
-        if (
-            this.implementation == null ||
-            this.implementation.statsUrl == null ||
-            this.implementation.statsUrl.isEmpty() ||
-            this.launchReadyReported
-        ) {
-            return;
+        synchronized (this.launchReportLock) {
+            if (
+                this.implementation == null ||
+                this.implementation.statsUrl == null ||
+                this.implementation.statsUrl.isEmpty() ||
+                this.launchReadyReported ||
+                this.launchTimeoutReported
+            ) {
+                return;
+            }
+            this.launchReadyReported = true;
         }
-
-        this.launchReadyReported = true;
         final Map<String, String> metadata = new HashMap<>();
         metadata.put("duration_ms", Long.toString(Math.max(0, System.currentTimeMillis() - this.launchStartedAtMs)));
         metadata.put("launch_started_at", Long.toString(this.launchStartedAtMs));
@@ -1770,17 +1773,18 @@ public class CapacitorUpdaterPlugin extends Plugin {
     }
 
     private void reportAppLaunchTimeout(final BundleInfo bundle) {
-        if (
-            this.implementation == null ||
-            this.implementation.statsUrl == null ||
-            this.implementation.statsUrl.isEmpty() ||
-            this.launchReadyReported ||
-            this.launchTimeoutReported
-        ) {
-            return;
+        synchronized (this.launchReportLock) {
+            if (
+                this.implementation == null ||
+                this.implementation.statsUrl == null ||
+                this.implementation.statsUrl.isEmpty() ||
+                this.launchReadyReported ||
+                this.launchTimeoutReported
+            ) {
+                return;
+            }
+            this.launchTimeoutReported = true;
         }
-
-        this.launchTimeoutReported = true;
         final Map<String, String> metadata = new HashMap<>();
         metadata.put("duration_ms", Long.toString(Math.max(0, System.currentTimeMillis() - this.launchStartedAtMs)));
         metadata.put("launch_started_at", Long.toString(this.launchStartedAtMs));

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapacitorUpdaterPlugin.java
@@ -4753,8 +4753,8 @@ public class CapacitorUpdaterPlugin extends Plugin {
         final String messageUpdate = initialDirectUpdateAllowed
             ? "Update will occur now."
             : this.shouldAutoSetNextBundle()
-              ? "Update will occur next time app moves to background."
-              : "Update will be downloaded and made available.";
+                ? "Update will occur next time app moves to background."
+                : "Update will be downloaded and made available.";
         Thread newTask = startNewThread(() -> {
             // Wait for cleanup to complete before starting download
             waitForCleanupIfNeeded();

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -2958,18 +2958,39 @@ public class CapgoUpdater {
 
     private static void writeFileAtomically(final File file, final byte[] bytes) throws IOException {
         final File tmp = new File(file.getAbsolutePath() + ".tmp");
-        try (FileOutputStream out = new FileOutputStream(tmp)) {
-            out.write(bytes);
-            out.flush();
-        }
-        if (tmp.renameTo(file)) {
-            return;
-        }
-        if (file.exists() && !file.delete()) {
-            throw new IOException("Failed to replace " + file.getAbsolutePath());
-        }
-        if (!tmp.renameTo(file)) {
+        File backup = null;
+        try {
+            try (FileOutputStream out = new FileOutputStream(tmp)) {
+                out.write(bytes);
+                out.flush();
+            }
+            if (tmp.renameTo(file)) {
+                return;
+            }
+            if (file.exists()) {
+                backup = new File(file.getAbsolutePath() + ".bak");
+                if (backup.exists() && !backup.delete()) {
+                    throw new IOException("Failed to replace " + file.getAbsolutePath());
+                }
+                if (!file.renameTo(backup)) {
+                    throw new IOException("Failed to replace " + file.getAbsolutePath());
+                }
+            }
+            if (tmp.renameTo(file)) {
+                if (backup != null && backup.exists() && !backup.delete()) {
+                    backup.deleteOnExit();
+                }
+                backup = null;
+                return;
+            }
             throw new IOException("Failed to persist " + file.getAbsolutePath());
+        } finally {
+            if (backup != null && !file.exists()) {
+                backup.renameTo(file);
+            }
+            if (tmp.exists() && !tmp.delete()) {
+                tmp.deleteOnExit();
+            }
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CapgoUpdater.java
@@ -2854,7 +2854,17 @@ public class CapgoUpdater {
 
     public void restorePendingStats() {
         File file = pendingStatsFile();
-        if (file == null || !file.exists()) {
+        if (file == null) {
+            return;
+        }
+        File backup = new File(file.getAbsolutePath() + ".bak");
+        if (!file.exists() && backup.exists() && !backup.renameTo(file)) {
+            if (logger != null) {
+                logger.error("Failed to restore stats backup");
+            }
+            return;
+        }
+        if (!file.exists()) {
             return;
         }
         try {

--- a/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/CryptoCipher.java
@@ -169,7 +169,11 @@ public class CryptoCipher {
         }
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key.getEncoded(), "AES"), new IvParameterSpec(iv));
-        File tempFile = File.createTempFile("capgo-aes-", ".tmp", file.getParentFile());
+        File parent = file.getAbsoluteFile().getParentFile();
+        if (parent == null) {
+            throw new IOException("Cannot create temp file for " + file.getAbsolutePath());
+        }
+        File tempFile = File.createTempFile("capgo-aes-", ".tmp", parent);
         try {
             byte[] inBuf = new byte[ioBufferBytes()];
             // Reuse one output buffer. cipher.update(in) allocates a new byte[] per chunk.
@@ -186,6 +190,9 @@ public class CryptoCipher {
                 if (last > 0) {
                     fos.write(outBuf, 0, last);
                 }
+            }
+            if (tempFile.length() == 0) {
+                throw new IOException("Empty decrypted data");
             }
             replaceFile(tempFile, file);
             tempFile = null;

--- a/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/DownloadService.java
@@ -76,8 +76,10 @@ public class DownloadService extends Worker {
     public static final String DEFAULT_CHANNEL = "default_channel";
     public static final String IS_PROD = "is_prod";
     public static final String IS_EMULATOR = "is_emulator";
-    // HTTP + decode share one pool. Cap by CPU: 8 on 4 cores, 16 on 8 cores, 64 max.
+    // HTTP + decode share one pool. Cap per host by CPU: 8 on 4 cores, 16 on 8 cores.
+    // Keep the global cap at 64 so API calls on another host are not starved by manifest downloads.
     private static final int MANIFEST_MAX_CONCURRENT_FILES = manifestMaxConcurrentFiles();
+    private static final int SHARED_MAX_REQUESTS = 64;
     private static final String UPDATE_FILE = "update.dat";
 
     // Shared OkHttpClient to prevent resource leaks
@@ -89,7 +91,7 @@ public class DownloadService extends Worker {
     // Initialize shared client with User-Agent interceptor
     static {
         Dispatcher dispatcher = new Dispatcher();
-        dispatcher.setMaxRequests(MANIFEST_MAX_CONCURRENT_FILES);
+        dispatcher.setMaxRequests(SHARED_MAX_REQUESTS);
         dispatcher.setMaxRequestsPerHost(MANIFEST_MAX_CONCURRENT_FILES);
         sharedClient = new OkHttpClient.Builder()
             .dispatcher(dispatcher)
@@ -905,12 +907,9 @@ public class DownloadService extends Worker {
             } catch (IOException e) {
                 String msg = e.getMessage();
                 if (msg != null && msg.contains("Checksum verification failed")) {
-                    if (finalTargetFile.exists() && !finalTargetFile.delete()) {
-                        logger.debug("Failed to delete dest after checksum mismatch");
-                    }
                     sendStatsAsync("download_manifest_checksum_fail", getInputData().getString(VERSION) + ":" + finalTargetFile.getName());
                     keepPartial = false;
-                } else if (isBrotli) {
+                } else if (isBrotli && msg != null && msg.toLowerCase(java.util.Locale.US).contains("brotli")) {
                     sendStatsAsync("download_manifest_brotli_fail", getInputData().getString(VERSION) + ":" + finalTargetFile.getName());
                     keepPartial = false;
                 }
@@ -947,7 +946,8 @@ public class DownloadService extends Worker {
         if (CapgoUpdater.isSafeCacheHash(hash) && hash.length() == 64) {
             return new File(cacheDir, "partial_" + hash + "_" + token + ".tmp");
         }
-        return new File(cacheDir, "temp_" + UUID.randomUUID() + "_" + token + ".tmp");
+        String digest = CryptoCipher.shortPathKey((hash == null ? "" : hash) + "\0" + (fileName == null ? "" : fileName));
+        return new File(cacheDir, "partial_" + digest + "_" + token + ".tmp");
     }
 
     static boolean shouldAppendHttpBody(int statusCode, long existingBytes) {
@@ -1062,7 +1062,7 @@ public class DownloadService extends Worker {
                 }
             }
             logger.error("Error: Raw data (" + fileName + "): " + hexDump);
-            throw e;
+            throw new IOException("Brotli process failed for " + fileName + ": " + e.getMessage(), e);
         }
     }
 

--- a/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
@@ -766,10 +766,10 @@ public class ShakeMenu implements ShakeDetector.Listener, ThreeFingerPinchDetect
                                     latestMessage != null && !latestMessage.isEmpty()
                                         ? latestMessage
                                         : latestError != null && !latestError.isEmpty()
-                                          ? latestError
-                                          : latestKind != null && !latestKind.isEmpty()
-                                            ? latestKind
-                                            : "server did not provide a message";
+                                            ? latestError
+                                            : latestKind != null && !latestKind.isEmpty()
+                                                ? latestKind
+                                                : "server did not provide a message";
 
                                 // Handle update errors first (before "no new version" check)
                                 if (

--- a/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
+++ b/android/src/main/java/ee/forgr/capacitor_updater/ShakeMenu.java
@@ -238,6 +238,9 @@ public class ShakeMenu implements ShakeDetector.Listener, ThreeFingerPinchDetect
 
     private void setPreviewMenuButtonsEnabled(List<Button> buttons, boolean enabled) {
         for (Button button : buttons) {
+            if (!enabled && "Close menu".equals(button.getText().toString())) {
+                continue;
+            }
             button.setEnabled(enabled);
         }
     }
@@ -763,10 +766,10 @@ public class ShakeMenu implements ShakeDetector.Listener, ThreeFingerPinchDetect
                                     latestMessage != null && !latestMessage.isEmpty()
                                         ? latestMessage
                                         : latestError != null && !latestError.isEmpty()
-                                            ? latestError
-                                            : latestKind != null && !latestKind.isEmpty()
-                                                ? latestKind
-                                                : "server did not provide a message";
+                                          ? latestError
+                                          : latestKind != null && !latestKind.isEmpty()
+                                            ? latestKind
+                                            : "server did not provide a message";
 
                                 // Handle update errors first (before "no new version" check)
                                 if (

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3778,6 +3778,22 @@ public class CapacitorUpdaterUnitTest {
     }
 
     @Test
+    public void restorePendingStatsRecoversBackupWhenQueueFileMissing() throws Exception {
+        final Path tempDir = Files.createTempDirectory("capgo-pending-stats-bak");
+        final File backup = tempDir.resolve("capgo_pending_stats.json.bak").toFile();
+        Files.write(backup.toPath(), "[{\"action\":\"download_fail\",\"timestamp\":2}]".getBytes(StandardCharsets.UTF_8));
+
+        final CapgoUpdater updater = new CapgoUpdater(mock(Logger.class));
+        updater.documentsDir = tempDir.toFile();
+        updater.restorePendingStats();
+
+        assertEquals(1, updater.pendingStatsCount());
+        assertTrue(tempDir.resolve("capgo_pending_stats.json").toFile().exists());
+        assertFalse(backup.exists());
+        updater.shutdown();
+    }
+
+    @Test
     public void ioBuffersAre256KiBForChecksumAndCopy() {
         assertEquals(256 * 1024, CryptoCipher.ioBufferBytes());
         assertEquals(256 * 1024, CryptoCipher.checksumBufferBytes());

--- a/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/CapacitorUpdaterUnitTest.java
@@ -3849,6 +3849,20 @@ public class CapacitorUpdaterUnitTest {
             assertTrue(e.getMessage().contains("Checksum verification failed"));
             assertFalse(bad.exists());
         }
+
+        File existing = dir.resolve("existing.bin").toFile();
+        Files.write(existing.toPath(), "keep-me".getBytes(StandardCharsets.UTF_8));
+        try {
+            DownloadService.writeFileAtomic(
+                existing,
+                new ByteArrayInputStream(payload),
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            );
+            fail("expected checksum mismatch");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Checksum verification failed"));
+            assertEquals("keep-me", new String(Files.readAllBytes(existing.toPath()), StandardCharsets.UTF_8));
+        }
     }
 
     @Test
@@ -3892,7 +3906,8 @@ public class CapacitorUpdaterUnitTest {
         assertTrue(nested.getName().length() < 255);
         assertTrue(nested.getName().endsWith(".tmp"));
         File unsafe = DownloadService.manifestPartialFile(dir.toFile(), "../evil", "app.js");
-        assertTrue(unsafe.getName().startsWith("temp_"));
+        assertTrue(unsafe.getName().startsWith("partial_"));
+        assertEquals(unsafe.getName(), DownloadService.manifestPartialFile(dir.toFile(), "../evil", "app.js").getName());
     }
 
     @Test
@@ -3915,6 +3930,18 @@ public class CapacitorUpdaterUnitTest {
         Files.write(file.toPath(), enc.doFinal(plain));
         CryptoCipher.decryptAesFile(file, key, iv);
         assertArrayEquals(plain, Files.readAllBytes(file.toPath()));
+
+        File emptyPlain = dir.resolve("empty-plain.bin").toFile();
+        enc.init(javax.crypto.Cipher.ENCRYPT_MODE, key, new javax.crypto.spec.IvParameterSpec(iv));
+        Files.write(emptyPlain.toPath(), enc.doFinal(new byte[0]));
+        byte[] emptyCipher = Files.readAllBytes(emptyPlain.toPath());
+        try {
+            CryptoCipher.decryptAesFile(emptyPlain, key, iv);
+            fail("expected empty plaintext to be rejected");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Empty decrypted data"));
+            assertArrayEquals(emptyCipher, Files.readAllBytes(emptyPlain.toPath()));
+        }
     }
 
     private static byte[] hexToBytes(String hex) {

--- a/android/src/test/java/ee/forgr/capacitor_updater/RsaContractTest.java
+++ b/android/src/test/java/ee/forgr/capacitor_updater/RsaContractTest.java
@@ -124,6 +124,8 @@ public class RsaContractTest {
                 } catch (IOException ignored) {
                     // expected
                 }
+            } else {
+                CryptoCipher.decryptChecksum(checksumHex, publicKeyPem);
             }
         }
     }

--- a/ios/Sources/CapacitorUpdaterPlugin/AES.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/AES.swift
@@ -180,6 +180,11 @@ public struct AES128Key {
         }
         try output.close()
 
+        let decryptedSize = (try fileManager.attributesOfItem(atPath: tempURL.path)[.size] as? NSNumber)?.uint64Value ?? 0
+        if decryptedSize == 0 {
+            throw NSError(domain: "Empty decrypted data", code: 7, userInfo: nil)
+        }
+
         do {
             _ = try fileManager.replaceItemAt(destination, withItemAt: tempURL)
         } catch {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1131,7 +1131,11 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         logger.info("Waiting for cleanup to complete before starting download...")
-        cleanupGroup.wait()
+        let result = cleanupGroup.wait(timeout: .now() + .seconds(60))
+        if result == .timedOut {
+            logger.warn("Cleanup wait timed out after 60s, proceeding with download")
+            return
+        }
         logger.info("Cleanup finished, proceeding with download")
     }
 
@@ -2749,7 +2753,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             guard self.previewSessionEnabled else {
                 return
             }
-            if let topVC = UIApplication.topViewController(),
+            if let topVC = UIApplication.topViewController(self.bridge?.viewController),
                topVC.isKind(of: UIAlertController.self) {
                 self.previewSessionAlertPending = true
                 UserDefaults.standard.set(true, forKey: self.previewSessionAlertPendingDefaultsKey)
@@ -2763,7 +2767,7 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: "Got it", style: .default))
-            if let topVC = UIApplication.topViewController() {
+            if let topVC = UIApplication.topViewController(self.bridge?.viewController) {
                 topVC.present(alert, animated: true)
             } else {
                 self.previewSessionAlertPending = true

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1096,6 +1096,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
                 let res = self.implementation.list()
                 for version in res {
+                    if Thread.current.isCancelled {
+                        return
+                    }
                     self.logger.info("Deleting obsolete bundle: \(version.getId())")
                     let deleted = self.implementation.delete(id: version.getId())
                     if !deleted {
@@ -1103,17 +1106,25 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
                     }
                     Thread.sleep(forTimeInterval: 0.075)
                 }
-                self.implementation.cleanupDeltaCache()
+                self.implementation.cleanupDeltaCache(threadToCheck: Thread.current)
+            }
+
+            if Thread.current.isCancelled {
+                return
             }
 
             // Resume any DELETING leftovers from prior kills, one-by-one.
             self.implementation.drainPendingDeletes()
 
+            if Thread.current.isCancelled {
+                return
+            }
+
             // Always sweep orphan directories so incomplete prior cleanups (or failed deletes)
             // cannot leave hundreds of MB behind across launches.
             let allowedIds = self.implementation.allowedBundleIdsForCleanup()
-            self.implementation.cleanupDownloadDirectories(allowedIds: allowedIds)
-            self.implementation.cleanupOrphanedTempFolders(threadToCheck: nil)
+            self.implementation.cleanupDownloadDirectories(allowedIds: allowedIds, threadToCheck: Thread.current)
+            self.implementation.cleanupOrphanedTempFolders(threadToCheck: Thread.current)
 
             if self.defaultChannelCleanupMustRetry {
                 self.logger.warn("Keeping the previous native build version so default channel cleanup retries")
@@ -1133,7 +1144,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         logger.info("Waiting for cleanup to complete before starting download...")
         let result = cleanupGroup.wait(timeout: .now() + .seconds(60))
         if result == .timedOut {
-            logger.warn("Cleanup wait timed out after 60s, proceeding with download")
+            logger.warn("Cleanup wait timed out after 60s, cancelling leftover cleanup")
+            cleanupThread?.cancel()
+            _ = cleanupGroup.wait(timeout: .now() + .seconds(60))
             return
         }
         logger.info("Cleanup finished, proceeding with download")

--- a/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapacitorUpdaterPlugin.swift
@@ -1124,6 +1124,9 @@ public class CapacitorUpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
             // cannot leave hundreds of MB behind across launches.
             let allowedIds = self.implementation.allowedBundleIdsForCleanup()
             self.implementation.cleanupDownloadDirectories(allowedIds: allowedIds, threadToCheck: Thread.current)
+            if Thread.current.isCancelled {
+                return
+            }
             self.implementation.cleanupOrphanedTempFolders(threadToCheck: Thread.current)
 
             if self.defaultChannelCleanupMustRetry {

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -318,7 +318,8 @@ import UIKit
         if isSafeCacheHash(hash) && hash.count == 64 {
             return cacheFolder.appendingPathComponent("partial_\(hash)_\(token).tmp")
         }
-        return cacheFolder.appendingPathComponent("temp_\(UUID().uuidString)_\(token).tmp")
+        let digest = CryptoCipher.shortPathKey("\(hash)|\(fileName)")
+        return cacheFolder.appendingPathComponent("partial_\(digest)_\(token).tmp")
     }
 
     private func cleanupOldManifestPartials() {
@@ -2254,6 +2255,7 @@ import UIKit
         if !hadRegistry && !hadFolder {
             logger.error("Cannot delete unknown bundle")
             logger.debug("Bundle ID: \(id)")
+            self.dequeuePendingDelete(id: id)
             return false
         }
 

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -2315,6 +2315,10 @@ import UIKit
         var pendingIds = Set(self.list(raw: true).filter { $0.isDeleting() }.map { $0.getId() }.filter { !$0.isEmpty })
         pendingIds.formUnion(self.getPendingDeleteIds())
         for id in pendingIds {
+            if Thread.current.isCancelled {
+                logger.warn("drainPendingDeletes was cancelled")
+                return
+            }
             logger.info("Resuming pending delete for bundle: \(id)")
             if self.delete(id: id, removeInfo: true) {
                 self.dequeuePendingDelete(id: id)

--- a/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
+++ b/ios/Sources/CapacitorUpdaterPlugin/CapgoUpdater.swift
@@ -2505,11 +2505,16 @@ import UIKit
             logger.debug("Error: \(error.localizedDescription)")
         }
 
+        if let thread = threadToCheck, thread.isCancelled {
+            logger.warn("cleanupOrphanedTempFolders was cancelled")
+            return
+        }
+
         // Also cleanup old download temp files (package_*.tmp and update_*.dat)
-        cleanupOldDownloadTempFiles()
+        cleanupOldDownloadTempFiles(threadToCheck: threadToCheck)
     }
 
-    private func cleanupOldDownloadTempFiles() {
+    private func cleanupOldDownloadTempFiles(threadToCheck: Thread? = nil) {
         let fileManager = FileManager.default
         guard let documentsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return
@@ -2520,6 +2525,10 @@ import UIKit
             let oneHourAgo = Date().addingTimeInterval(-3600)
 
             for url in contents {
+                if let thread = threadToCheck, thread.isCancelled {
+                    logger.warn("cleanupOldDownloadTempFiles was cancelled")
+                    return
+                }
                 let fileName = url.lastPathComponent
                 // Only cleanup package_*.tmp and update_*.dat files
                 let isDownloadTemp = (fileName.hasPrefix("package_") && fileName.hasSuffix(".tmp")) ||

--- a/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/PopulateDeltaCacheTests.swift
@@ -410,6 +410,9 @@ final class StreamDecodeTests: XCTestCase {
         XCTAssertTrue(nested.lastPathComponent.hasPrefix("partial_\(hash)_"))
         XCTAssertLessThan(nested.lastPathComponent.count, 255)
         XCTAssertTrue(nested.lastPathComponent.hasSuffix(".tmp"))
+        let unsafe = CapgoUpdater.manifestPartialURL(cacheFolder: cache, hash: "../evil", fileName: "app.js")
+        XCTAssertTrue(unsafe.lastPathComponent.hasPrefix("partial_"))
+        XCTAssertEqual(unsafe.lastPathComponent, CapgoUpdater.manifestPartialURL(cacheFolder: cache, hash: "../evil", fileName: "app.js").lastPathComponent)
     }
 
     func testStoreDownloadedFileReplacesOn200AndAppendsOn206() throws {

--- a/ios/Tests/CapacitorUpdaterPluginTests/RsaContractTests.swift
+++ b/ios/Tests/CapacitorUpdaterPluginTests/RsaContractTests.swift
@@ -160,6 +160,11 @@ final class RsaContractTests: XCTestCase {
                     try CryptoCipher.decryptChecksum(checksum: checksumHex, publicKey: publicKey),
                     id
                 )
+            } else {
+                XCTAssertNoThrow(
+                    try CryptoCipher.decryptChecksum(checksum: checksumHex, publicKey: publicKey),
+                    id
+                )
             }
         }
     }

--- a/scripts/generate-ai-changelog.mjs
+++ b/scripts/generate-ai-changelog.mjs
@@ -39,10 +39,16 @@ function resolveTags({ fromTag, toTag }) {
   const major = currentTag.match(/^v?(\d+)/)?.[1];
   const describeArgs = ['describe', '--tags', '--abbrev=0'];
   if (major) {
-    describeArgs.push(`--match=${major}.*`);
+    try {
+      return {
+        previousTag: git([...describeArgs, `--match=${major}.*`, `--match=v${major}.*`, `${currentTag}^`]),
+        currentTag,
+      };
+    } catch {
+      // First release of a new major has no same-major predecessor.
+    }
   }
-  describeArgs.push(`${currentTag}^`);
-  return { previousTag: git(describeArgs), currentTag };
+  return { previousTag: git([...describeArgs, `${currentTag}^`]), currentTag };
 }
 
 function buildPrompt(previousTag, currentTag) {
@@ -91,7 +97,10 @@ async function generateChangelog(prompt, model) {
     throw new Error('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required.');
   }
 
-  const timeoutMs = Math.min(600000, Math.max(1000, Number(process.env.CHANGELOG_AI_TIMEOUT_MS || 60000)));
+  const configuredTimeoutMs = Number(process.env.CHANGELOG_AI_TIMEOUT_MS || 60000);
+  const timeoutMs = Number.isFinite(configuredTimeoutMs)
+    ? Math.min(600000, Math.max(1000, Math.trunc(configuredTimeoutMs)))
+    : 60000;
   const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`;
   const response = await fetch(url, {
     method: 'POST',

--- a/scripts/generate-ai-changelog.mjs
+++ b/scripts/generate-ai-changelog.mjs
@@ -26,16 +26,23 @@ function git(args) {
 function resolveTags({ fromTag, toTag }) {
   const currentTag =
     toTag ??
-    (process.env.GITHUB_REF?.startsWith('refs/tags/')
-      ? process.env.GITHUB_REF.replace('refs/tags/', '')
-      : null);
+    (process.env.GITHUB_REF?.startsWith('refs/tags/') ? process.env.GITHUB_REF.replace('refs/tags/', '') : null);
 
   if (!currentTag) {
     throw new Error('Missing target tag. Set GITHUB_REF to refs/tags/<tag> or pass --to-tag.');
   }
 
-  const previousTag = fromTag ?? git(['describe', '--tags', '--abbrev=0', `${currentTag}^`]);
-  return { previousTag, currentTag };
+  if (fromTag) {
+    return { previousTag: fromTag, currentTag };
+  }
+
+  const major = currentTag.match(/^v?(\d+)/)?.[1];
+  const describeArgs = ['describe', '--tags', '--abbrev=0'];
+  if (major) {
+    describeArgs.push(`--match=${major}.*`);
+  }
+  describeArgs.push(`${currentTag}^`);
+  return { previousTag: git(describeArgs), currentTag };
 }
 
 function buildPrompt(previousTag, currentTag) {
@@ -84,6 +91,7 @@ async function generateChangelog(prompt, model) {
     throw new Error('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required.');
   }
 
+  const timeoutMs = Math.min(600000, Math.max(1000, Number(process.env.CHANGELOG_AI_TIMEOUT_MS || 60000)));
   const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`;
   const response = await fetch(url, {
     method: 'POST',
@@ -94,6 +102,7 @@ async function generateChangelog(prompt, model) {
     body: JSON.stringify({
       messages: [{ role: 'user', content: prompt }],
     }),
+    signal: AbortSignal.timeout(timeoutMs),
   });
 
   const payload = await response.json();
@@ -113,10 +122,16 @@ function writeGithubOutput({ result, fromTag, toTag }) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (!outputFile) return;
 
-  const delimiter = `changelog_${Date.now()}`;
-  appendFileSync(outputFile, `result<<${delimiter}\n${result}\n${delimiter}\n`);
-  appendFileSync(outputFile, `from_tag=${fromTag}\n`);
-  appendFileSync(outputFile, `to_tag=${toTag}\n`);
+  if (fromTag) {
+    appendFileSync(outputFile, `from_tag=${fromTag}\n`);
+  }
+  if (toTag) {
+    appendFileSync(outputFile, `to_tag=${toTag}\n`);
+  }
+  if (result) {
+    const delimiter = `changelog_${Date.now()}`;
+    appendFileSync(outputFile, `result<<${delimiter}\n${result}\n${delimiter}\n`);
+  }
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -126,10 +141,11 @@ const prompt = buildPrompt(previousTag, currentTag);
 
 console.error(`Generating changelog with ${model}`);
 console.error(`Range: ${previousTag}..${currentTag}`);
+writeGithubOutput({ fromTag: previousTag, toTag: currentTag });
 
 try {
   const result = await generateChangelog(prompt, model);
-  writeGithubOutput({ result, fromTag: previousTag, toTag: currentTag });
+  writeGithubOutput({ result });
 } catch (error) {
   const message = error instanceof Error ? error.message : 'Unknown error';
   console.error(`Changelog generation failed: ${message}`);

--- a/scripts/generate-rsa-contract-fixtures.mjs
+++ b/scripts/generate-rsa-contract-fixtures.mjs
@@ -12,40 +12,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const outputPath = path.join(root, 'native-contract-tests', 'crypto-rsa.json');
 
-// Test-only RSA key so regenerate:rsa-contract is reproducible. Not used in production.
-const privateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEpQIBAAKCAQEAsv0A3reP1v+pBU0ZD/ZlXAGckXJ6LFzXQuXzOkN8vDptsPiB
-kJBdORet953EtayZpx8lzAH7BhU+eByN2PCfzFUTpiD/jFh3lv1S3JUP/JUGAixT
-MF4D6J2rtxUOKyWjRPa/A0fM/M8IbPqeSfOtEEZaWjyBVajAIYIXO9XeaxfV5U9t
-D6g/mbH0SArDvbgwOOXUARW3UQ30u9qB5cC08dVC4DZywRdn885AyPSjefQ8t7if
-qUtcOZ4iUmrhrOPBh0UH1OcOCC+M9Gso7wTKRt7E03ZKhY+4SKuTxCsINgOd3YSi
-JPYlrUEpSpdjYfxnbsGe1hI8oPHAgJMihZX+AwIDAQABAoIBAFL6pl+afC3xortZ
-begPlBgeiyaHCwrsE8Po9WUqinZ9JANqgi6yLvXb+4QTeXG8ThPDhfNZa7X7PVXT
-7xMHIx5Ixu462B6JmQ+/651l4d54fCufvwVqYKeECWq8cTAhp9q+BfoQXIFLvh0/
-5whj1vT3mMXCzTcYH9KpC/pqgU3mHWKp8Kb5i5olZFunrfSx8lpO5nW5N5QqWWpd
-yDMgw/aqyQhzalXUh1JE1xgrG6PA1emTtRG+WuksQvhyYccT+5vbHAYxzFk7xaTz
-7+DQy3Z/MGwyWylGNQ6B5n5cEVhhmtEn1hTjnv3W1mxq88IXNafnk1Y1YG8K4XpJ
-7Gp3fHECgYEA3cD1pp0Be32MUwYP0waFDOJEpUtrH0aSd85rZ9e2s6rdck+cmpXz
-MIKSlq3DkWwqpfan20CzydW2C9tA0BrY94zGDdVYE62XqiLgJNFp38/C4xJL505M
-FFIHC4p5gDp+JL/Sh143XyF2aWdmeDvHskzm0GaeQnMGxNN8xRq3qakCgYEAzqFP
-eerX4iaAlxiKwShO28A+k+OupOdjwZMXXjHbd/4aqGOJQ6mQEtE1p2J2qRhkOKkB
-NTNSIS1fo8ScaazA+18nDgHEfmtGejCQXAPq8QJ3LyIug18oOGK8uPUyGjdeuKpG
-KyZhUWg+wNZheYkvAWSTjlv3dt5klFDbBlV57csCgYEAiGJr8xwvVDckPc/FncEt
-xX3IQG1BJgwuexbuggBu8tOMvQhvxbehyV0VMS0P0fnXxRkNpdCGgwU4oNQpaZSJ
-ir7+9HUZZYjndZFbj+loF2ndb/DJ1CoYqorEoHl7Pr065flAT1dH8O9Qt4ULxbjm
-mien8dabUT0TlayI2WUUPnkCgYEAvQiuYOcMIYT/1ztIlXV+z2OM3FdLiul1Rb5/
-flk2YwxA7xRAm3ogqFZlM4DM9d2usndK95S/6kJMYNKaFcNJua5PWG0dilox289a
-AhRDd8G9r40h6GXBsfQCm2MWNw24xlBgaVFvbr5jyp9WBY4PRsLwiyhvuHu0oEto
-VN8V8QkCgYEAoXVod6XM+kc9tbqx4CcuGBSXiqB32NLllv9X1HZGxyLxSKBbA7zM
-DeRpsaHpS11Mdxh8Rqx/gFbfvlT0C0i45CJU7rZtFdlvN7xhIEJMCb2ymdxmX7qo
-yWP9MBFaiO4ZfWNJ0QIqBNnUUCEUBz4XLBrk6Vp4vdpxjjL1YOxPeQU=
------END RSA PRIVATE KEY-----
-`;
-
-const publicKey = crypto.createPublicKey(privateKey).export({ type: 'pkcs1', format: 'pem' });
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+});
 
 function privateEncrypt(plaintext) {
-  return crypto.privateEncrypt({ key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING }, plaintext);
+  return crypto.privateEncrypt(
+    { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
+    plaintext,
+  );
 }
 
 function toHex(buffer) {
@@ -53,7 +30,10 @@ function toHex(buffer) {
 }
 
 const sessionKeyPlaintext = Buffer.alloc(16, 0xab);
-const checksumPlaintext = Buffer.from('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', 'hex');
+const checksumPlaintext = Buffer.from(
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  'hex',
+);
 
 const sessionKeyCiphertext = privateEncrypt(sessionKeyPlaintext);
 const checksumCiphertext = privateEncrypt(checksumPlaintext);

--- a/scripts/generate-rsa-contract-fixtures.mjs
+++ b/scripts/generate-rsa-contract-fixtures.mjs
@@ -12,17 +12,40 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const outputPath = path.join(root, 'native-contract-tests', 'crypto-rsa.json');
 
-const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
-  modulusLength: 2048,
-  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
-  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
-});
+// Test-only RSA key so regenerate:rsa-contract is reproducible. Not used in production.
+const privateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAsv0A3reP1v+pBU0ZD/ZlXAGckXJ6LFzXQuXzOkN8vDptsPiB
+kJBdORet953EtayZpx8lzAH7BhU+eByN2PCfzFUTpiD/jFh3lv1S3JUP/JUGAixT
+MF4D6J2rtxUOKyWjRPa/A0fM/M8IbPqeSfOtEEZaWjyBVajAIYIXO9XeaxfV5U9t
+D6g/mbH0SArDvbgwOOXUARW3UQ30u9qB5cC08dVC4DZywRdn885AyPSjefQ8t7if
+qUtcOZ4iUmrhrOPBh0UH1OcOCC+M9Gso7wTKRt7E03ZKhY+4SKuTxCsINgOd3YSi
+JPYlrUEpSpdjYfxnbsGe1hI8oPHAgJMihZX+AwIDAQABAoIBAFL6pl+afC3xortZ
+begPlBgeiyaHCwrsE8Po9WUqinZ9JANqgi6yLvXb+4QTeXG8ThPDhfNZa7X7PVXT
+7xMHIx5Ixu462B6JmQ+/651l4d54fCufvwVqYKeECWq8cTAhp9q+BfoQXIFLvh0/
+5whj1vT3mMXCzTcYH9KpC/pqgU3mHWKp8Kb5i5olZFunrfSx8lpO5nW5N5QqWWpd
+yDMgw/aqyQhzalXUh1JE1xgrG6PA1emTtRG+WuksQvhyYccT+5vbHAYxzFk7xaTz
+7+DQy3Z/MGwyWylGNQ6B5n5cEVhhmtEn1hTjnv3W1mxq88IXNafnk1Y1YG8K4XpJ
+7Gp3fHECgYEA3cD1pp0Be32MUwYP0waFDOJEpUtrH0aSd85rZ9e2s6rdck+cmpXz
+MIKSlq3DkWwqpfan20CzydW2C9tA0BrY94zGDdVYE62XqiLgJNFp38/C4xJL505M
+FFIHC4p5gDp+JL/Sh143XyF2aWdmeDvHskzm0GaeQnMGxNN8xRq3qakCgYEAzqFP
+eerX4iaAlxiKwShO28A+k+OupOdjwZMXXjHbd/4aqGOJQ6mQEtE1p2J2qRhkOKkB
+NTNSIS1fo8ScaazA+18nDgHEfmtGejCQXAPq8QJ3LyIug18oOGK8uPUyGjdeuKpG
+KyZhUWg+wNZheYkvAWSTjlv3dt5klFDbBlV57csCgYEAiGJr8xwvVDckPc/FncEt
+xX3IQG1BJgwuexbuggBu8tOMvQhvxbehyV0VMS0P0fnXxRkNpdCGgwU4oNQpaZSJ
+ir7+9HUZZYjndZFbj+loF2ndb/DJ1CoYqorEoHl7Pr065flAT1dH8O9Qt4ULxbjm
+mien8dabUT0TlayI2WUUPnkCgYEAvQiuYOcMIYT/1ztIlXV+z2OM3FdLiul1Rb5/
+flk2YwxA7xRAm3ogqFZlM4DM9d2usndK95S/6kJMYNKaFcNJua5PWG0dilox289a
+AhRDd8G9r40h6GXBsfQCm2MWNw24xlBgaVFvbr5jyp9WBY4PRsLwiyhvuHu0oEto
+VN8V8QkCgYEAoXVod6XM+kc9tbqx4CcuGBSXiqB32NLllv9X1HZGxyLxSKBbA7zM
+DeRpsaHpS11Mdxh8Rqx/gFbfvlT0C0i45CJU7rZtFdlvN7xhIEJMCb2ymdxmX7qo
+yWP9MBFaiO4ZfWNJ0QIqBNnUUCEUBz4XLBrk6Vp4vdpxjjL1YOxPeQU=
+-----END RSA PRIVATE KEY-----
+`;
+
+const publicKey = crypto.createPublicKey(privateKey).export({ type: 'pkcs1', format: 'pem' });
 
 function privateEncrypt(plaintext) {
-  return crypto.privateEncrypt(
-    { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
-    plaintext,
-  );
+  return crypto.privateEncrypt({ key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING }, plaintext);
 }
 
 function toHex(buffer) {
@@ -30,10 +53,7 @@ function toHex(buffer) {
 }
 
 const sessionKeyPlaintext = Buffer.alloc(16, 0xab);
-const checksumPlaintext = Buffer.from(
-  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-  'hex',
-);
+const checksumPlaintext = Buffer.from('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', 'hex');
 
 const sessionKeyCiphertext = privateEncrypt(sessionKeyPlaintext);
 const checksumCiphertext = privateEncrypt(checksumPlaintext);


### PR DESCRIPTION
## What
- Stop deleting an existing manifest dest file when a new download fails checksum
- Keep a valid resumable partial when dest I/O fails; drop it only on checksum or Brotli decode failure
- Reject empty AES plaintext before replacing the dest file
- Bound cleanup wait, changelog AI fetch, and pin `capacitor-plugin-standard-version`

## Why
Cubic review on the v7 backport ([#861](https://github.com/Cap-go/capacitor-updater/pull/861)) flagged holes that already exist on `main`. Those bugs should be fixed on Capacitor 8 first.

## How
- Manifest dest stays untouched on checksum mismatch (`writeFileAtomic` already writes to a temp file)
- Shared OkHttp client keeps a global 64 request cap and only CPU-caps per host, so API calls are not starved
- Unsafe-hash partial names are a stable digest under `partial_*.tmp` so retries resume
- iOS pending-delete ids are dequeued when the bundle is already gone
- Android `app_launch_timeout` reports the timeout actually used and fires once
- Stats persist uses backup-and-restore instead of delete-then-rename
- Changelog writes `from_tag` before the AI call, aborts hung fetches, and matches previous tags by major
- Invalid-checksum RSA tests assert the `throws: false` branch

Not changed: HTTP-date `Retry-After`. Capgo backend sends delay-seconds only.

## Testing
- `cd android && ./gradlew testDebugUnitTest --tests ee.forgr.capacitor_updater.CapacitorUpdaterUnitTest --tests ee.forgr.capacitor_updater.RsaContractTest`
- Linux container `bun run prettier -- --check` after nested-ternary indent match

## Not Tested
- iOS tests locally (`simctl` missing in this environment); CI will run them
- Live changelog AI / npm bump workflows
- Cache re-checksum on hit (kept as the existing perf tradeoff)
- Maestro step vs script timeout mismatch
- Wall-clock `sendReadyToJs` test rewrite